### PR TITLE
Turn off cuDNN in TravisCI script

### DIFF
--- a/scripts/travis/travis_setup_makefile_config.sh
+++ b/scripts/travis/travis_setup_makefile_config.sh
@@ -20,4 +20,5 @@ PYTHON_LIB := $(ANACONDA_HOME)/lib
 INCLUDE_DIRS := $(PYTHON_INCLUDE) /usr/local/include
 LIBRARY_DIRS := $(PYTHON_LIB) /usr/local/lib /usr/lib
 WITH_PYTHON_LAYER := 1
+USE_CUDNN := 0
 EOF


### PR DESCRIPTION
I broke CI for this fork in 18a3ff4e12c3431d5124c8e997944b75407ff442 by turning on USE_CUDNN in `Makefile.config.example`.

This change re-enables TravisCI builds.