### PR TITLE
Fix potential CNMEM_NOT_INITIALIZED errors

### DIFF
--- a/include/caffe/common.hpp
+++ b/include/caffe/common.hpp
@@ -229,6 +229,11 @@ class MemoryHandlerActivator {
       using_pool_ = true;
       MemoryHandler::usePool();
       MemoryHandler::setGPUs(gpus);
+#ifndef CPU_ONLY
+      void* temp;
+      MemoryHandler::mallocGPU(&temp, 4);
+      MemoryHandler::freeGPU(temp);
+#endif
     }
   }
   ~MemoryHandlerActivator() {


### PR DESCRIPTION
dummy alloc / free in MemoryHandlerActivator to ensure that
the memory pool has been set up before any potential operations