### PR TITLE
Fix cmake versioning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,8 @@ cmake_minimum_required(VERSION 2.8.7)
 project(Caffe C CXX)
 
 # ---[ Caffe version
-set(CAFFE_TARGET_VERSION "0")
-set(CAFFE_TARGET_SOVERSION "0")
+set(CAFFE_TARGET_VERSION "0.13")
+set(CAFFE_TARGET_SOVERSION "0.13.2")
 
 # ---[ Using cmake scripts and modules
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/Modules)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,10 @@ cmake_minimum_required(VERSION 2.8.7)
 # ---[ Caffe project
 project(Caffe C CXX)
 
+# ---[ Caffe version
+set(CAFFE_TARGET_VERSION "0")
+set(CAFFE_TARGET_SOVERSION "0")
+
 # ---[ Using cmake scripts and modules
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/Modules)
 

--- a/cmake/Targets.cmake
+++ b/cmake/Targets.cmake
@@ -106,8 +106,6 @@ endfunction()
 #   caffe_default_properties(<target>)
 function(caffe_default_properties target)
   set_target_properties(${target} PROPERTIES
-    OUTPUT_NAME caffe-nv
-    SOVERSION 0.13.2
     DEBUG_POSTFIX ${Caffe_DEBUG_POSTFIX}
     ARCHIVE_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/lib"
     LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/lib"

--- a/cmake/Targets.cmake
+++ b/cmake/Targets.cmake
@@ -109,7 +109,10 @@ function(caffe_default_properties target)
     DEBUG_POSTFIX ${Caffe_DEBUG_POSTFIX}
     ARCHIVE_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/lib"
     LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/lib"
-    RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/bin")
+    RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/bin"
+    VERSION   ${CAFFE_TARGET_VERSION}
+    SOVERSION ${CAFFE_TARGET_SOVERSION}
+  )
 endfunction()
 
 ################################################################################################

--- a/src/caffe/CMakeLists.txt
+++ b/src/caffe/CMakeLists.txt
@@ -20,6 +20,7 @@ endif()
 add_library(caffe ${srcs})
 target_link_libraries(caffe proto ${Caffe_LINKER_LIBS})
 caffe_default_properties(caffe)
+set_target_properties(${target} PROPERTIES OUTPUT_NAME "caffe-nv")
 
 # ---[ Tests
  add_subdirectory(test)


### PR DESCRIPTION
Reverts hacky implementation at https://github.com/NVIDIA/caffe/pull/6 to use quality implementation from @CDLuminate at https://github.com/BVLC/caffe/pull/3015 instead.

The other tools like `compute_image_mean` weren't being built at all because every target was building to `caffe-nv`.