### PR TITLE
Reshape Layers before calling Forward / Backward

### DIFF
--- a/src/caffe/net.cpp
+++ b/src/caffe/net.cpp
@@ -553,6 +553,7 @@ Dtype Net<Dtype>::ForwardFromTo(int start, int end) {
   }
   for (int i = start; i <= end; ++i) {
     // LOG(ERROR) << "Forwarding " << layer_names_[i];
+    layers_[i]->Reshape(bottom_vecs_[i], top_vecs_[i]);
     Dtype layer_loss = layers_[i]->Forward(bottom_vecs_[i], top_vecs_[i]);
     loss += layer_loss;
     if (debug_info_) { ForwardDebugInfo(i); }
@@ -617,6 +618,7 @@ void Net<Dtype>::BackwardFromTo(int start, int end) {
   CHECK_LT(start, layers_.size());
   for (int i = start; i >= end; --i) {
     if (layer_need_backward_[i]) {
+      layers_[i]->Reshape(bottom_vecs_[i], top_vecs_[i]);
       layers_[i]->Backward(
           top_vecs_[i], bottom_need_backward_[i], bottom_vecs_[i]);
       if (debug_info_) { BackwardDebugInfo(i); }


### PR DESCRIPTION
Fix issue where cuDNN convolution algorithms were being chosen, then subsequent layer reshapes caused allocations that resulted in not enough memory being available to actually allocate workspace(s) in CuDNNConvolutionLayer->{Forward,Backward}_gpu()