### PR TITLE
Cherry-pick gradient accumulation fix for v0.14

### DIFF
--- a/src/caffe/layers/cudnn_conv_layer.cu
+++ b/src/caffe/layers/cudnn_conv_layer.cu
@@ -80,13 +80,11 @@ namespace caffe {
     if (this->param_propagate_down_[0]) {
       weight = this->blobs_[0]->gpu_data();
       weight_diff = this->blobs_[0]->mutable_gpu_diff();
-      caffe_gpu_set(this->blobs_[0]->count(), Dtype(0), weight_diff);
     }
     Dtype* bias_diff = NULL;
 
     if (this->bias_term_ && this->param_propagate_down_[1]) {
       bias_diff = this->blobs_[1]->mutable_gpu_diff();
-      caffe_gpu_set(this->blobs_[1]->count(), Dtype(0), bias_diff);
     }
 
     for (int i = 0; i < top.size(); ++i) {


### PR DESCRIPTION
Cherry-pick 8e455850bf398dd16dffa5e7591480d013b8e573 from https://github.com/BVLC/caffe/pull/3254.

This fix was already added for v0.13 in https://github.com/NVIDIA/caffe/pull/50.