### PR TITLE
set destination path for miniconda

### DIFF
--- a/scripts/travis/travis_install.sh
+++ b/scripts/travis/travis_install.sh
@@ -62,7 +62,7 @@ rm -f $LMDB_FILE
 # than using pip for everything).
 wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
 chmod +x miniconda.sh
-./miniconda.sh -b
+./miniconda.sh -b -p /home/travis/miniconda
 export PATH=/home/travis/miniconda/bin:$PATH
 conda update --yes conda
 conda install --yes numpy scipy matplotlib scikit-image pip


### PR DESCRIPTION
Change where miniconda gets installed. It seems the default from the miniconda installer has changed from miniconda to miniconda2.
