### PR TITLE
Change multi-solver handling by dividing user batch by gpu count

### DIFF
--- a/include/caffe/parallel.hpp
+++ b/include/caffe/parallel.hpp
@@ -97,6 +97,9 @@ class P2PSync : public GPUParams<Dtype>, public Solver<Dtype>::Callback,
 
   void run(const vector<int>& gpus);
 
+  // Divide the batch size by the number of solvers
+  static void divide_batch_size(NetParameter* net);
+
  protected:
   void on_start();
   void on_gradients_ready();

--- a/src/caffe/net.cpp
+++ b/src/caffe/net.cpp
@@ -46,6 +46,9 @@ void Net<Dtype>::Init(const NetParameter& in_param) {
   // the current NetState.
   NetParameter filtered_param;
   FilterNet(in_param, &filtered_param);
+  if (phase_ == TRAIN) {
+    caffe::P2PSync<Dtype>::divide_batch_size(&filtered_param);
+  }
   LOG_IF(INFO, Caffe::root_solver())
       << "Initializing net from parameters: " << std::endl
       << filtered_param.DebugString();

--- a/src/caffe/parallel.cpp
+++ b/src/caffe/parallel.cpp
@@ -447,6 +447,57 @@ void P2PSync<Dtype>::run(const vector<int>& gpus) {
   }
 }
 
+template<typename Dtype>
+void P2PSync<Dtype>::divide_batch_size(NetParameter* net) {
+  int solver_count = Caffe::solver_count();
+  for (int i = 0; i < net->layer_size(); ++i) {
+    string m = "Batch size must be divisible by the number of solvers (GPUs)";
+    if (net->layer(i).has_data_param()) {
+      if (net->layer(i).data_param().has_batch_size()) {
+        uint32_t total = net->layer(i).data_param().batch_size();
+        uint32_t batch = total / solver_count;
+        CHECK(batch * solver_count == total) << m;
+        net->mutable_layer(i)->mutable_data_param()->set_batch_size(batch);
+      }
+    }
+    if (net->layer(i).has_hdf5_data_param()) {
+      if (net->layer(i).hdf5_data_param().has_batch_size()) {
+        uint32_t total = net->layer(i).hdf5_data_param().batch_size();
+        uint32_t batch = total / solver_count;
+        CHECK(batch * solver_count == total) << m;
+        net->mutable_layer(i)->mutable_hdf5_data_param()->set_batch_size(batch);
+      }
+    }
+    if (net->layer(i).has_image_data_param()) {
+      if (net->layer(i).image_data_param().has_batch_size()) {
+        uint32_t total = net->layer(i).image_data_param().batch_size();
+        uint32_t batch = total / solver_count;
+        CHECK(batch * solver_count == total) << m;
+        net->mutable_layer(i)->mutable_image_data_param()->set_batch_size(
+            batch);
+      }
+    }
+    if (net->layer(i).has_memory_data_param()) {
+      if (net->layer(i).memory_data_param().has_batch_size()) {
+        uint32_t total = net->layer(i).memory_data_param().batch_size();
+        uint32_t batch = total / solver_count;
+        CHECK(batch * solver_count == total) << m;
+        net->mutable_layer(i)->mutable_memory_data_param()->set_batch_size(
+            batch);
+      }
+    }
+    if (net->layer(i).has_window_data_param()) {
+      if (net->layer(i).window_data_param().has_batch_size()) {
+        uint32_t total = net->layer(i).window_data_param().batch_size();
+        uint32_t batch = total / solver_count;
+        CHECK(batch * solver_count == total) << m;
+        net->mutable_layer(i)->mutable_window_data_param()->set_batch_size(
+            batch);
+      }
+    }
+  }
+}
+
 INSTANTIATE_CLASS(Params);
 INSTANTIATE_CLASS(GPUParams);
 INSTANTIATE_CLASS(P2PSync);


### PR DESCRIPTION
Change default behavior to strong scale.  e.g. divde the train_val batch size by the number of GPUs, which is the solver count.  NOTE, this is not completely clean because of the way Caffe conflates data layer batch with solver batch.  We are making this change because of the astonishment of training having a different behavior when GPU count changes. 

This change puts back Caffe-0.13 behavior