### PR TITLE
Move to allreduce model for multi-GPU

### DIFF
--- a/include/caffe/util/coll.h
+++ b/include/caffe/util/coll.h
@@ -1,0 +1,28 @@
+#ifndef INCLUDE_CAFFE_UTIL_COLL_H_
+#define INCLUDE_CAFFE_UTIL_COLL_H_
+
+#ifndef CPU_ONLY
+
+#include <cuda_runtime.h>
+
+#define COLL_NUM_THREADS 1024
+
+template <typename Dtype>
+void multi_gpu_pipeline_bcast(int *my_progress, Dtype* my_data,
+    int *next_progress, Dtype* next_data, const int size, const int grid_dim,
+    cudaStream_t stream);
+
+template <typename Dtype>
+void multi_gpu_pipeline_sum(int *my_progress, Dtype* red_data, Dtype* my_data,
+    int *next_progress, Dtype* next_data, Dtype factor, const int size,
+    const int grid_dim, cudaStream_t stream);
+
+template <typename Dtype>
+void multi_gpu_ring_sum(const int rank, const int nranks, int *my_progress,
+    Dtype* red_data, Dtype* my_data, int *next_progress, Dtype* next_red_data,
+    Dtype* next_data, Dtype factor, const int size, const int grid_dim,
+    cudaStream_t stream);
+
+#endif  // CPU_ONLY
+
+#endif  // INCLUDE_CAFFE_UTIL_COLL_H_

--- a/src/caffe/parallel.cpp
+++ b/src/caffe/parallel.cpp
@@ -1,5 +1,6 @@
 #ifndef CPU_ONLY
 #include <cuda_runtime.h>
+#include "caffe/util/coll.h"
 #endif
 #include <glog/logging.h>
 #include <stdio.h>
@@ -13,11 +14,16 @@
 #include <vector>
 
 #include "boost/thread.hpp"
+#include "boost/thread/latch.hpp"
 #include "caffe/caffe.hpp"
 #include "caffe/parallel.hpp"
 #include "caffe/util/gpu_memory.hpp"
 
+#define GRID_DIM 8
+
 namespace caffe {
+
+boost::barrier *bar;
 
 enum Op {
   copy,
@@ -74,8 +80,8 @@ static size_t total_size(const vector<Blob<Dtype>*>& params) {
 template<typename Dtype>
 Params<Dtype>::Params(shared_ptr<Solver<Dtype> > root_solver)
     : size_(total_size<Dtype>(root_solver->net()->learnable_params())),
-      data_(),
-      diff_() {
+      data_(NULL),
+      diff_(NULL) {
 }
 
 template<typename Dtype>
@@ -112,13 +118,13 @@ template<typename Dtype>
 GPUParams<Dtype>::~GPUParams() {
 #ifndef CPU_ONLY
   int initial_device;
-  cudaGetDevice(&initial_device);
-  cudaSetDevice(buffer_device_);
+  CUDA_CHECK(cudaGetDevice(&initial_device));
+  CUDA_CHECK(cudaSetDevice(buffer_device_));
   gpu_memory::deallocate(data_);
   gpu_memory::deallocate(diff_);
   data_ = NULL;
   diff_ = NULL;
-  cudaSetDevice(initial_device);
+  CUDA_CHECK(cudaSetDevice(initial_device));
 #endif
 }
 
@@ -132,80 +138,9 @@ void GPUParams<Dtype>::configure(Solver<Dtype>* solver) const {
 
 void DevicePair::compute(const vector<int> devices, vector<DevicePair>* pairs) {
 #ifndef CPU_ONLY
-  vector<int> remaining(devices);
-
-  // Depth for reduction tree
-  int remaining_depth = static_cast<int>(ceil(log2(remaining.size())));
-
-  // Group GPUs by board
-  for (int d = 0; d < remaining_depth; ++d) {
-    for (int i = 0; i < remaining.size(); ++i) {
-      for (int j = i + 1; j < remaining.size(); ++j) {
-        cudaDeviceProp a, b;
-        CUDA_CHECK(cudaGetDeviceProperties(&a, remaining[i]));
-        CUDA_CHECK(cudaGetDeviceProperties(&b, remaining[j]));
-        if (a.isMultiGpuBoard && b.isMultiGpuBoard) {
-          if (a.multiGpuBoardGroupID == b.multiGpuBoardGroupID) {
-            pairs->push_back(DevicePair(remaining[i], remaining[j]));
-            DLOG(INFO) << "GPU board: " << remaining[i] << ":" << remaining[j];
-            remaining.erase(remaining.begin() + j);
-            break;
-          }
-        }
-      }
-    }
-  }
-  ostringstream s;
-  for (int i = 0; i < remaining.size(); ++i) {
-    s << (i ? ", " : "") << remaining[i];
-  }
-  DLOG(INFO) << "GPUs paired by boards, remaining: " << s.str();
-
-  // Group by P2P accessibility
-  remaining_depth = ceil(log2(remaining.size()));
-  for (int d = 0; d < remaining_depth; ++d) {
-    for (int i = 0; i < remaining.size(); ++i) {
-      for (int j = i + 1; j < remaining.size(); ++j) {
-        int access;
-        CUDA_CHECK(
-            cudaDeviceCanAccessPeer(&access, remaining[i], remaining[j]));
-        if (access) {
-          pairs->push_back(DevicePair(remaining[i], remaining[j]));
-          DLOG(INFO) << "P2P pair: " << remaining[i] << ":" << remaining[j];
-          remaining.erase(remaining.begin() + j);
-          break;
-        }
-      }
-    }
-  }
-  s.str("");
-  for (int i = 0; i < remaining.size(); ++i) {
-    s << (i ? ", " : "") << remaining[i];
-  }
-  DLOG(INFO) << "GPUs paired by P2P access, remaining: " << s.str();
-
-  // Group remaining
-  remaining_depth = ceil(log2(remaining.size()));
-  for (int d = 0; d < remaining_depth; ++d) {
-    for (int i = 0; i < remaining.size(); ++i) {
-      pairs->push_back(DevicePair(remaining[i], remaining[i + 1]));
-      DLOG(INFO) << "Remaining pair: " << remaining[i] << ":"
-                 << remaining[i + 1];
-      remaining.erase(remaining.begin() + i + 1);
-    }
-  }
-
-  // Should only be the parent node remaining
-  CHECK_EQ(remaining.size(), 1);
-
-  pairs->insert(pairs->begin(), DevicePair(-1, remaining[0]));
-
-  CHECK(pairs->size() == devices.size());
-  for (int i = 0; i < pairs->size(); ++i) {
-    CHECK((*pairs)[i].parent() != (*pairs)[i].device());
-    for (int j = i + 1; j < pairs->size(); ++j) {
-      CHECK((*pairs)[i].device() != (*pairs)[j].device());
-    }
+  pairs->push_back(DevicePair(-1, devices[0]));
+  for (int i = 0; i < devices.size()-1; i++) {
+    pairs->push_back(DevicePair(devices[i], devices[i+1]));
   }
 #else
   NO_GPU;
@@ -216,46 +151,74 @@ void DevicePair::compute(const vector<int> devices, vector<DevicePair>* pairs) {
 
 template<typename Dtype>
 P2PSync<Dtype>::P2PSync(shared_ptr<Solver<Dtype> > root_solver,
-                        P2PSync<Dtype>* parent, const SolverParameter& param)
+                        int rank, int nranks, const SolverParameter& param)
     : GPUParams<Dtype>(root_solver, param.device_id()),
-      parent_(parent),
-      children_(),
+      rank_(rank),
+      nranks_(nranks),
+      parent_(),
+      child_(),
       queue_(),
       initial_iter_(root_solver->iter()),
-      solver_() {
+      solver_(),
+      params_(param) {
 #ifndef CPU_ONLY
   int initial_device;
   CUDA_CHECK(cudaGetDevice(&initial_device));
   const int self = param.device_id();
   CUDA_CHECK(cudaSetDevice(self));
 
-  if (parent == NULL) {
+  if (rank == 0) {
     solver_ = root_solver;
   } else {
     Caffe::set_root_solver(false);
-    solver_.reset(new WorkerSolver<Dtype>(param, root_solver.get()));
+    solver_.reset(GetSolver<Dtype>(param, root_solver.get()));
     Caffe::set_root_solver(true);
   }
   this->configure(solver_.get());
   solver_->add_callback(this);
 
-  if (parent) {
+  CUDA_CHECK(cudaSetDevice(initial_device));
+#else
+  NO_GPU;
+#endif
+}
+
+template<typename Dtype>
+void P2PSync<Dtype>::SetupP2PAccess() {
+#ifndef CPU_ONLY
+  int initial_device;
+  CUDA_CHECK(cudaGetDevice(&initial_device));
+  const int self = solver_->param().device_id();
+  CUDA_CHECK(cudaSetDevice(self));
+
+  cudaStreamCreateWithFlags(&cuda_stream_, cudaStreamNonBlocking);
+
+  gpu_memory::allocate(reinterpret_cast<void **>(&parent_grads_),
+                       size_ * sizeof(Dtype));
+  gpu_memory::allocate(reinterpret_cast<void **>(&offset_),
+                       GRID_DIM*sizeof(int));
+  caffe_gpu_memset(GRID_DIM*sizeof(int), -1, offset_ );
+
+  if (parent_) {
     // Enable p2p access between devices
-    const int peer = parent->solver_->param().device_id();
-    int access;
-    CUDA_CHECK(cudaDeviceCanAccessPeer(&access, self, peer));
-    if (access) {
+    const int peer = parent_->solver_->param().device_id();
+    CUDA_CHECK(cudaDeviceCanAccessPeer(&parent_peer_access_, self, peer));
+    if (parent_peer_access_) {
       CUDA_CHECK(cudaDeviceEnablePeerAccess(peer, 0));
     } else {
       LOG(INFO)<< "GPU " << self << " does not have p2p access to GPU " << peer;
     }
-    // Allocate receiving buffer on parent
-    CUDA_CHECK(cudaSetDevice(peer));
-    gpu_memory::allocate(reinterpret_cast<void **>(&parent_grads_),
-                     size_ * sizeof(Dtype));
-    CUDA_CHECK(cudaSetDevice(self));
   }
 
+  if (child_) {
+    const int peer = child_->solver_->param().device_id();
+    CUDA_CHECK(cudaDeviceCanAccessPeer(&child_peer_access_, self, peer));
+    if (child_peer_access_) {
+      if (child_ != parent_) CUDA_CHECK(cudaDeviceEnablePeerAccess(peer, 0));
+    } else {
+      LOG(INFO)<< "GPU " << self << " does not have p2p access to GPU " << peer;
+    }
+  }
   CUDA_CHECK(cudaSetDevice(initial_device));
 #else
   NO_GPU;
@@ -265,22 +228,30 @@ P2PSync<Dtype>::P2PSync(shared_ptr<Solver<Dtype> > root_solver,
 template<typename Dtype>
 P2PSync<Dtype>::~P2PSync() {
 #ifndef CPU_ONLY
-  if (parent_) {
-    int initial_device;
-    CUDA_CHECK(cudaGetDevice(&initial_device));
-    const int self = solver_->param().device_id();
-    const int peer = parent_->solver_->param().device_id();
-    CUDA_CHECK(cudaSetDevice(peer));
-    gpu_memory::deallocate(parent_grads_);
-    parent_grads_ = NULL;
-    int access;
-    cudaSetDevice(self);
-    CUDA_CHECK(cudaDeviceCanAccessPeer(&access, self, peer));
-    if (access) {
+  int initial_device;
+  CUDA_CHECK(cudaGetDevice(&initial_device));
+  const int self = solver_->param().device_id();
+  CUDA_CHECK(cudaSetDevice(self));
+
+  cudaStreamDestroy(cuda_stream_);
+
+  gpu_memory::deallocate(parent_grads_);
+  gpu_memory::deallocate(offset_);
+
+  if (child_) {
+    const int peer = child_->solver_->param().device_id();
+    if (child_peer_access_) {
       CUDA_CHECK(cudaDeviceDisablePeerAccess(peer));
     }
-    CUDA_CHECK(cudaSetDevice(initial_device));
   }
+  if (parent_) {
+    const int peer = parent_->solver_->param().device_id();
+    if (parent_peer_access_) {
+      if (child_ != parent_) CUDA_CHECK(cudaDeviceDisablePeerAccess(peer));
+    }
+  }
+
+  CUDA_CHECK(cudaSetDevice(initial_device));
 #endif
 }
 
@@ -301,136 +272,90 @@ void P2PSync<Dtype>::InternalThreadEntry() {
 }
 
 template<typename Dtype>
+void P2PSync<Dtype>::soft_barrier() {
+#ifndef CPU_ONLY
+  // CPU barrier to avoid busy-polling on the GPU.
+  CUDA_CHECK(cudaStreamSynchronize(cudaStreamDefault));
+  if (rank_ != nranks_ - 1) queue_.pop();
+  if (rank_) parent_->queue_.push(this);
+  if (rank_) queue_.pop();
+  if (rank_ != nranks_ - 1) child_->queue_.push(this);
+#endif
+}
+
+template<typename Dtype>
 void P2PSync<Dtype>::on_start() {
 #ifndef CPU_ONLY
-#ifdef DEBUG
-  int device;
-  CUDA_CHECK(cudaGetDevice(&device));
-  CHECK(device == solver_->param().device_id());
-#else
-//  CHECK(false);
-#endif
-
-  // Wait for update from parent
-  if (parent_) {
-    P2PSync<Dtype> *parent = queue_.pop();
-    CHECK(parent == parent_);
+  CUDA_CHECK(cudaStreamSynchronize(cudaStreamDefault));
+  multi_gpu_pipeline_bcast(
+    rank_ ? offset_ : NULL,
+    data_,
+    ((rank_ != nranks_ - 1) && child_peer_access_) ? child_->offset_ : NULL,
+    ((rank_ != nranks_ - 1) && child_peer_access_) ? child_->data_ : NULL,
+    size_,
+    GRID_DIM,
+    cuda_stream_);
+  if ((rank_ != nranks_ - 1) && !child_peer_access_) {
+    CUDA_CHECK(cudaMemcpyAsync(child_->data_, data_,
+          size_ * sizeof(Dtype), cudaMemcpyDeviceToDevice, cuda_stream_));
+    for (int i = 0; i< GRID_DIM; i++) {
+      CUDA_CHECK(cudaMemcpyAsync(child_->offset_+i, &size_,
+            sizeof(int), cudaMemcpyHostToDevice, cuda_stream_));
+    }
   }
-
-  // Update children
-  for (int i = children_.size() - 1; i >= 0; i--) {
-    Dtype* src = data_;
-    Dtype* dst = children_[i]->data_;
-
-#ifdef DEBUG
-    cudaPointerAttributes attributes;
-    CUDA_CHECK(cudaPointerGetAttributes(&attributes, src));
-    CHECK(attributes.device == device);
-    CUDA_CHECK(cudaPointerGetAttributes(&attributes, dst));
-    CHECK(attributes.device == children_[i]->solver_->param().device_id());
-#endif
-
-    CUDA_CHECK(cudaMemcpyAsync(dst, src, size_ * sizeof(Dtype),
-        cudaMemcpyDeviceToDevice, cudaStreamDefault));
-    CUDA_CHECK(cudaStreamSynchronize(cudaStreamDefault));
-    children_[i]->queue_.push(this);
-  }
+  CUDA_CHECK(cudaStreamSynchronize(cuda_stream_));
+  caffe_gpu_memset(GRID_DIM*sizeof(int), -1, offset_);
 #endif
 }
 
 template<typename Dtype>
-void P2PSync<Dtype>::on_gradients_ready() {
+void P2PSync<Dtype>::allreduce() {
+  bar->wait();
 #ifndef CPU_ONLY
-#ifdef DEBUG
-  int device;
-  CUDA_CHECK(cudaGetDevice(&device));
-  CHECK(device == solver_->param().device_id());
-#endif
-
-  // Sum children gradients as they appear in the queue
-  for (int i = 0; i < children_.size(); ++i) {
-    P2PSync<Dtype> *child = queue_.pop();
-    Dtype* src = child->parent_grads_;
-    Dtype* dst = diff_;
-
-#ifdef DEBUG
-    bool ok = false;
-    for (int j = 0; j < children_.size(); ++j) {
-      if (child == children_[j]) {
-        ok = true;
-      }
-    }
-    CHECK(ok);
-    cudaPointerAttributes attributes;
-    CUDA_CHECK(cudaPointerGetAttributes(&attributes, src));
-    CHECK(attributes.device == device);
-    CUDA_CHECK(cudaPointerGetAttributes(&attributes, dst));
-    CHECK(attributes.device == device);
-#endif
-
-    caffe_gpu_add(size_, src, dst, dst);
-  }
-
-  // Send gradients to parent
-  if (parent_) {
-    Dtype* src = diff_;
-    Dtype* dst = parent_grads_;
-
-#ifdef DEBUG
-    cudaPointerAttributes attributes;
-    CUDA_CHECK(cudaPointerGetAttributes(&attributes, src));
-    CHECK(attributes.device == device);
-    CUDA_CHECK(cudaPointerGetAttributes(&attributes, dst));
-    CHECK(attributes.device == parent_->solver_->param().device_id());
-#endif
-
-    CUDA_CHECK(cudaMemcpyAsync(dst, src, size_ * sizeof(Dtype),  //
-        cudaMemcpyDeviceToDevice, cudaStreamDefault));
-    CUDA_CHECK(cudaStreamSynchronize(cudaStreamDefault));
-    parent_->queue_.push(this);
-  } else {
-    // Loss functions divide gradients by the batch size, so to compensate
-    // for split batch, the root solver divides by number of solvers.
-    caffe_gpu_scal(size_, Dtype(1.0 / Caffe::solver_count()), diff_);
-  }
+  CUDA_CHECK(cudaStreamSynchronize(cudaStreamDefault));
+  multi_gpu_ring_sum(
+    rank_,
+    nranks_,
+    offset_,
+    diff_,
+    parent_grads_,
+    parent_->offset_,
+    parent_->diff_,
+    parent_->parent_grads_,
+    (Dtype)1.0 / Caffe::solver_count(),  // Mult factor
+    size_,
+    GRID_DIM,
+    cuda_stream_);
+  CUDA_CHECK(cudaStreamSynchronize(cuda_stream_));
 #endif
 }
 
 template<typename Dtype>
-void P2PSync<Dtype>::run(const vector<int>& gpus) {
-  // Pair devices for map-reduce synchronization
-  vector<DevicePair> pairs;
-  DevicePair::compute(gpus, &pairs);
-  ostringstream s;
-  for (int i = 1; i < pairs.size(); ++i) {
-    s << (i == 1 ? "" : ", ") << pairs[i].parent() << ":" << pairs[i].device();
+void P2PSync<Dtype>::run(shared_ptr<Solver<Dtype> > root,
+                         const vector<int>& gpus) {
+  int nranks = gpus.size();
+  bar = new boost::barrier(nranks);
+  SolverParameter param(this->params_);
+  vector<shared_ptr<P2PSync<Dtype> > > syncs(nranks);
+
+  for (int i = 1; i < nranks; i++) {
+    param.set_device_id(gpus[i]);
+    // Set parent_/child_
+    syncs[i].reset(new P2PSync<Dtype>(root, i, nranks, param));
   }
-  LOG(INFO)<< "GPUs pairs " << s.str();
 
-  SolverParameter param(solver_->param());
-  vector<shared_ptr<P2PSync<Dtype> > > syncs(gpus.size());
+  syncs[1].get()->parent_ = this;
+  this->child_ = syncs[1].get();
+  for (int i = 1; i < syncs.size()-1; ++i) {
+    syncs[(i+1)%nranks].get()->parent_ = syncs[i].get();
+    syncs[i].get()->child_ = syncs[(i+1)%nranks].get();
+  }
+  this->parent_ = syncs[syncs.size()-1].get();
+  syncs[syncs.size()-1]->child_ = this;
 
-  // Build the GPU tree by finding the parent for each solver
-  for (int attempts = 0; attempts < pairs.size(); ++attempts) {
-    for (int i = 1; i < pairs.size(); ++i) {
-      if (!syncs[i].get()) {
-        P2PSync<Dtype>* parent = NULL;
-        for (int j = 0; j < syncs.size(); ++j) {
-          P2PSync<Dtype>* sync = j == 0 ? this : syncs[j].get();
-          if (sync) {
-            const SolverParameter& p = sync->solver()->param();
-            if (p.device_id() == pairs[i].parent()) {
-              parent = sync;
-            }
-          }
-        }
-        if (parent) {
-          param.set_device_id(pairs[i].device());
-          syncs[i].reset(new P2PSync<Dtype>(solver_, parent, param));
-          parent->children_.push_back((P2PSync<Dtype>*) syncs[i].get());
-        }
-      }
-    }
+  this->SetupP2PAccess();
+  for (int i = 1; i < syncs.size(); ++i) {
+    syncs[i]->SetupP2PAccess();
   }
 
   LOG(INFO)<< "Starting Optimization";
@@ -440,7 +365,7 @@ void P2PSync<Dtype>::run(const vector<int>& gpus) {
   }
 
   // Run root solver on current thread
-  solver_->Solve();
+  this->solver_->Solve();
 
   for (int i = 1; i < syncs.size(); ++i) {
     syncs[i]->StopInternalThread();

--- a/src/caffe/test/test_gradient_based_solver.cpp
+++ b/src/caffe/test/test_gradient_based_solver.cpp
@@ -36,7 +36,6 @@ class GradientBasedSolverTest : public MultiDeviceTest<TypeParam> {
 
   string snapshot_prefix_;
   shared_ptr<SGDSolver<Dtype> > solver_;
-  shared_ptr<P2PSync<Dtype> > sync_;
   int seed_;
   // Dimensions are determined by generate_sample_data.py
   // TODO this is brittle and the hdf5 file should be checked instead.
@@ -204,9 +203,11 @@ class GradientBasedSolverTest : public MultiDeviceTest<TypeParam> {
           gpus.push_back(i);
       }
       Caffe::set_solver_count(gpus.size());
-      this->sync_.reset(new P2PSync<Dtype>(
-          this->solver_, NULL, this->solver_->param()));
-      this->sync_->run(gpus);
+      SolverParameter param_with_type = this->solver_->param();
+      param_with_type.set_solver_type(solver_type());
+
+      P2PSync<Dtype> sync(this->solver_, 0, gpus.size(), param_with_type);
+      sync.run(this->solver_, gpus);
       Caffe::set_solver_count(1);
     }
     if (snapshot) {

--- a/src/caffe/util/coll.cu
+++ b/src/caffe/util/coll.cu
@@ -1,0 +1,283 @@
+#include <stdlib.h>
+#include "caffe/util/coll.h"
+
+#define SYNC_PERIOD 8
+
+template <typename Dtype>
+__global__ void pipeline_bcast_kernel(int* my_progress, Dtype* my_data,
+  int* next_progress, Dtype* next_data, const int size) {
+  int tid = threadIdx.x;
+
+  if (tid == 0) {
+    if (my_progress != NULL) {
+      my_progress[blockIdx.x] = 0;  // Signal receiver is ready
+    }
+    // Wait for receiver to be ready
+    if (next_progress != NULL) {
+      while (((volatile int*)next_progress)[blockIdx.x] != 0) {}
+    }
+  }
+  __syncthreads();
+
+  // Each block manages its portion of the buffer
+  int block_size = (size+gridDim.x-1)/gridDim.x;
+  int start = block_size*blockIdx.x;
+  int end = block_size*(blockIdx.x+1);
+  if (end > size) end = size;
+  int progress = (my_progress == NULL) ? \
+                 end : ((volatile int*)my_progress)[blockIdx.x];
+  __threadfence_system();
+
+  int sync = SYNC_PERIOD;
+
+  for (int index = start + tid;
+       index < end;
+       index += blockDim.x) {
+    if (progress < index) {
+      while ((progress = ((volatile int*)my_progress)[blockIdx.x]) < index) {}
+      __threadfence_system();
+    }
+    if (next_data != NULL) {
+      next_data[index] = my_data[index];  // Copy data
+    }
+    if (next_progress != NULL) {
+      if (--sync == 0) {
+        __syncthreads();
+        if (tid == 0) {
+          __threadfence_system();
+          next_progress[blockIdx.x] = index + blockDim.x;
+        }
+        sync = SYNC_PERIOD;
+      }
+    }
+  }
+  if (next_progress != NULL) {
+    // Don't forget the last update
+    __syncthreads();
+    if (tid == 0) {
+      __threadfence_system();
+      next_progress[blockIdx.x] = size;
+    }
+  }
+}
+
+template <typename Dtype>
+__global__ void pipeline_sum_kernel(int* my_progress, Dtype* red_data,
+  Dtype* my_data, int* next_progress, Dtype* next_data, Dtype factor,
+  const int size) {
+  int tid = threadIdx.x;
+
+  if (tid == 0) {
+    if (my_progress != NULL) {
+      my_progress[blockIdx.x] = 0;  // Signal receiver is ready
+    }
+    // Wait for receiver to be ready
+    if (next_progress != NULL) {
+      while (((volatile int*)next_progress)[blockIdx.x] != 0) {}
+    }
+  }
+  __syncthreads();
+
+  // Each block manages its portion of the buffer
+  int block_size = (size+gridDim.x-1)/gridDim.x;
+  int start = block_size*blockIdx.x;
+  int end = block_size*(blockIdx.x+1);
+  if (end > size) end = size;
+  int progress = (my_progress == NULL) ? \
+                 end : ((volatile int*)my_progress)[blockIdx.x];
+  __threadfence_system();
+
+  int sync = SYNC_PERIOD;
+
+  for (int index = start + tid;
+       index < end;
+       index += blockDim.x) {
+    if (progress < index) {
+      while ((progress = ((volatile int*)my_progress)[blockIdx.x]) < index) {}
+      __threadfence_system();
+    }
+    if (my_progress != NULL) {
+      // Add it to my data
+      red_data[index] += my_data[index];
+    }
+    if (next_progress != NULL) {
+      next_data[index] = red_data[index];  // Send it to next
+      if (--sync == 0) {
+        __syncthreads();
+        if (tid == 0) {
+          __threadfence_system();
+          next_progress[blockIdx.x] = index + blockDim.x;
+        }
+        sync = SYNC_PERIOD;
+      }
+    } else {
+      red_data[index] *= factor;
+    }
+  }
+  if (next_progress != NULL) {
+    // Don't forget the last update
+    __syncthreads();
+    if (tid == 0) {
+      __threadfence_system();
+      next_progress[blockIdx.x] = size;
+    }
+  }
+}
+
+template <typename Dtype>
+__global__ void ring_sum_kernel(const int rank, const int nranks,
+  int* my_progress, Dtype* red_data, Dtype* my_data, int* next_progress,
+  Dtype* next_red_data, Dtype* next_data, Dtype factor, const int size) {
+  const int tid = threadIdx.x, bid = blockIdx.x;
+
+  // To keep good performance, align a bit. Align block/chunk sizes to a power
+  // of two but not that big that it will break the algorithm.
+  const int max_delta_size = size / (gridDim.x*gridDim.x*nranks*nranks);
+  int align;
+  for (align = 2; align < max_delta_size && align < (nranks*2048); \
+      align <<= 1) {}
+  align >>= 1;
+  const int block_size = ((size+(gridDim.x*align)-1)/(gridDim.x*align)) * \
+                         align;  // upper(size/dim)
+  const int block_start = block_size*bid;
+  const int b_end = block_size*(bid+1);
+  const int block_end = b_end < size ? b_end : size;
+
+  const int chunk_size = (block_size+nranks-1)/nranks;  // upper(b_size/nranks)
+  const int start = block_start + rank * chunk_size;
+  const int boundaries[4] = {
+      // Phase 0 :   1 chunk  : send data to tmp buffer
+      block_start + ((rank+1)%nranks) * chunk_size,
+      // Phase 1 : n-2 chunks : add data + send to tmp buffer
+      block_start + ((rank-1+nranks)%nranks) * chunk_size,
+      // Phase 2 :   1 chunk  : add data + send to final buffer
+      start,  // avoid to recompute block_start + rank * chunk_size
+      // Phase 3 : n-2 chunks : send to final buffer
+      block_start + ((rank-2+nranks)%nranks) * chunk_size
+      // Phase 4 :   1 chunk  : wait data
+  };
+
+  // Do not wait to start sending first chunk : it is initial data
+  int progress = boundaries[0];
+
+  // Sync with receiver
+  if (tid == 0) {
+    while (((volatile int*)next_progress)[bid] != -1) {}
+    __threadfence_system();
+    next_progress[bid] = -2;
+    while (((volatile int*)my_progress)[bid] != -2) {}
+    __threadfence_system();
+    my_progress[bid] = progress;
+    while (((volatile int*)next_progress)[bid] != start) {}
+    __threadfence_system();
+  }
+  __syncthreads();
+
+  int phase = 0;
+  Dtype* dest = next_data;  // first loop uses tmp buffer
+  int chunk_start = start;
+
+  while (phase < 4) {
+    int chunk_end = chunk_start + chunk_size;
+    if (chunk_end > block_end) chunk_end = block_end;
+
+    for (int index = chunk_start + tid;
+        index < chunk_end;
+        index += blockDim.x) {
+      // Do sums in phases 1 and 2
+      if (phase == 1) {
+        red_data[index] += my_data[index];
+      } else if (phase == 2) {
+        red_data[index] = (red_data[index]+my_data[index])*factor;
+      }
+
+      // Copy data to next peer in the ring (rank - 1)
+      dest[index] = red_data[index];
+    }
+
+    chunk_start = chunk_end;
+    if (chunk_start >= block_end) chunk_start = block_start;
+
+    // Update at chunk boundaries
+    __syncthreads();
+    if (tid == 0) {
+        __threadfence_system();
+        next_progress[bid] = chunk_start;
+    }
+
+    // Update phase
+    while (phase < 4 && chunk_start == boundaries[phase]) {
+      phase++;
+      // Phase 2 and 3 work on final buffer
+      if (phase == 2) dest = next_red_data;
+    }
+
+    // Wait for prev to finish next chunk
+    while (progress == chunk_start) {
+      while (progress == ((volatile int*)my_progress)[bid]) {}
+      progress = ((volatile int*)my_progress)[bid];
+      __threadfence_system();
+    }
+  }
+  // Reset progress for next call
+  __syncthreads();
+  if (tid == 0) my_progress[bid] = -1;
+}
+
+template <>
+void multi_gpu_pipeline_bcast<float>(int *my_progress, float* my_data,
+    int *next_progress, float* next_data, const int size, const int grid_dim,
+    cudaStream_t stream) {
+  // NOLINT_NEXT_LINE(whitespace/operators)
+  pipeline_bcast_kernel<float><<<grid_dim, COLL_NUM_THREADS, 0, stream>>>(
+      my_progress, my_data, next_progress, next_data, size);
+}
+
+template <>
+void multi_gpu_pipeline_bcast<double>(int *my_progress, double* my_data,
+    int *next_progress, double* next_data, const int size, const int grid_dim,
+    cudaStream_t stream) {
+  // NOLINT_NEXT_LINE(whitespace/operators)
+  pipeline_bcast_kernel<double><<<grid_dim, COLL_NUM_THREADS, 0, stream>>>(
+      my_progress, my_data, next_progress, next_data, size);
+}
+
+template<>
+void multi_gpu_pipeline_sum<float>(int *my_progress, float* red_data,
+    float* my_data, int *next_progress, float* next_data, float factor,
+    const int size, const int grid_dim, cudaStream_t stream) {
+  // NOLINT_NEXT_LINE(whitespace/operators)
+  pipeline_sum_kernel<float><<<grid_dim, COLL_NUM_THREADS, 0, stream>>>(
+      my_progress, red_data, my_data, next_progress, next_data, factor, size);
+}
+
+template<>
+void multi_gpu_pipeline_sum<double>(int *my_progress, double* red_data,
+    double* my_data, int *next_progress, double* next_data, double factor,
+    const int size, const int grid_dim, cudaStream_t stream) {
+  // NOLINT_NEXT_LINE(whitespace/operators)
+  pipeline_sum_kernel<double><<<grid_dim, COLL_NUM_THREADS, 0, stream>>>(
+      my_progress, red_data, my_data, next_progress, next_data, factor, size);
+}
+
+template<>
+void multi_gpu_ring_sum<float>(const int rank, const int nranks,
+    int *my_progress, float* red_data, float* my_data, int *next_progress,
+    float* next_red_data, float* next_data, float factor, const int size,
+    const int grid_dim, cudaStream_t stream) {
+  // NOLINT_NEXT_LINE(whitespace/operators)
+  ring_sum_kernel<float><<<grid_dim, COLL_NUM_THREADS, 0, stream>>>(
+      rank, nranks, my_progress, red_data, my_data, next_progress,
+      next_red_data, next_data, factor, size);
+}
+
+template<>
+void multi_gpu_ring_sum<double>(const int rank, const int nranks,
+    int *my_progress, double* red_data, double* my_data, int *next_progress,
+    double* next_red_data, double* next_data, double factor, const int size,
+    const int grid_dim, cudaStream_t stream) {
+  // NOLINT_NEXT_LINE(whitespace/operators)
+  ring_sum_kernel<double><<<grid_dim, COLL_NUM_THREADS, 0, stream>>>(
+      rank, nranks, my_progress, red_data, my_data, next_progress,
+      next_red_data, next_data, factor, size);
+}

--- a/tools/caffe.cpp
+++ b/tools/caffe.cpp
@@ -214,8 +214,8 @@ int train() {
   }
 
   if (gpus.size() > 1) {
-    caffe::P2PSync<float> sync(solver, NULL, solver->param());
-    sync.run(gpus);
+    caffe::P2PSync<float> sync(solver, 0, gpus.size(), solver->param());
+    sync.run(solver, gpus);
   } else {
     LOG(INFO) << "Starting Optimization";
     solver->Solve();


### PR DESCRIPTION
Move from the current multi-GPU model to one based on broadcast and allreduce. Initial parameters are broadcast to all solver threads. After each backwards pass is complete, parameter gradients are allreduced and each thread updates its own set of parameters. 

This is a precursor to NCCL integration