### PR TITLE
cuDNN and pooling fixes

### DIFF
--- a/src/caffe/layer_factory.cpp
+++ b/src/caffe/layer_factory.cpp
@@ -78,7 +78,14 @@ shared_ptr<Layer<Dtype> > GetPoolingLayer(const LayerParameter& param) {
 #ifdef USE_CUDNN
   } else if (engine == PoolingParameter_Engine_CUDNN) {
     PoolingParameter p_param = param.pooling_param();
+
+// FIXME We assume that precision issue will be fixed in cuDNN v5.0
+#if CUDNN_VERSION >= 5000
     return shared_ptr<Layer<Dtype> >(new CuDNNPoolingLayer<Dtype>(param));
+#else
+    return shared_ptr<Layer<Dtype> >(new PoolingLayer<Dtype>(param));
+#endif
+
 #endif
   } else {
     LOG(FATAL) << "Layer " << param.name() << " has unknown engine.";

--- a/src/caffe/layers/cudnn_batch_norm_layer.cu
+++ b/src/caffe/layers/cudnn_batch_norm_layer.cu
@@ -85,6 +85,10 @@ void CuDNNBatchNormLayer<Dtype>::Backward_gpu(
       mode_,
       cudnn::dataType<Dtype>::one,
       cudnn::dataType<Dtype>::zero,
+#if CUDNN_VERSION >= 4005
+      cudnn::dataType<Dtype>::one,
+      cudnn::dataType<Dtype>::zero,
+#endif
       bottom_desc_,
       bottom_data,
       bottom_desc_,


### PR DESCRIPTION
Replaced CuDNNPoolingLayer by PoolingLayer for now and also made cudnnBatchNormalizationBackward call compilable again.