### PR TITLE
weight updates should be done with beta=1

### DIFF
--- a/src/caffe/layers/cudnn_batch_norm_layer.cu
+++ b/src/caffe/layers/cudnn_batch_norm_layer.cu
@@ -87,7 +87,7 @@ void CuDNNBatchNormLayer<Dtype>::Backward_gpu(
       cudnn::dataType<Dtype>::zero,
 #if CUDNN_VERSION >= 4005
       cudnn::dataType<Dtype>::one,
-      cudnn::dataType<Dtype>::zero,
+      cudnn::dataType<Dtype>::one,
 #endif
       bottom_desc_,
       bottom_data,


### PR DESCRIPTION
As per Natalia:
Line 90 of cudnn_batch_norm_layer.cu should be
cudnn::dataType<Dtype>::one
- weight updates should be done with beta=1, similar to how they are done for convolutional layers, so that updates can be potentially accumulated over a few batches. 