### PR TITLE
Init workaround to walk the net once before alloc

### DIFF
--- a/include/caffe/vision_layers.hpp
+++ b/include/caffe/vision_layers.hpp
@@ -305,6 +305,8 @@ class CuDNNConvolutionLayer : public ConvolutionLayer<Dtype> {
       const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
 
   bool handles_setup_;
+  bool forward_pass_called;
+  bool backward_pass_called;
 
   // algorithms for forward and backwards convolutions
   cudnnConvolutionFwdAlgo_t *fwd_algo_;

--- a/src/caffe/layers/cudnn_conv_layer.cu
+++ b/src/caffe/layers/cudnn_conv_layer.cu
@@ -29,11 +29,11 @@ namespace caffe {
       Dtype* top_data = top[i]->mutable_gpu_data();
 
       // Test free space and force reshape if allocations have changed
-      size_t workspace_limit_bytes, total_memory;
-      gpu_memory::getInfo(&workspace_limit_bytes, &total_memory);
-      if (workspace_fwd_sizes_[i] > workspace_limit_bytes) {
-          this->Reshape(bottom, top);
-      }
+      // size_t workspace_limit_bytes, total_memory;
+      // gpu_memory::getInfo(&workspace_limit_bytes, &total_memory);
+      // if (workspace_fwd_sizes_[i] > workspace_limit_bytes) {
+      //     this->Reshape(bottom, top);
+      // }
 
       // !!!! Not safe if group_ > 1 !!!!
       workspace.reserve(workspace_fwd_sizes_[i]);
@@ -74,6 +74,7 @@ namespace caffe {
       // NOLINT_NEXT_LINE(whitespace/operators)
       CUDA_CHECK(cudaStreamSynchronize(cudaStreamLegacy));
     }
+    forward_pass_called = true;
   }
 
   template <typename Dtype>
@@ -100,12 +101,12 @@ namespace caffe {
         const Dtype* top_diff = top[i]->gpu_diff();
 
         // Test free space and force reshape if allocations have changed
-        size_t workspace_limit_bytes, total_memory;
-        gpu_memory::getInfo(&workspace_limit_bytes, &total_memory);
-        if (workspace_bwd_filter_sizes_[i] > workspace_limit_bytes ||
-           workspace_bwd_data_sizes_[i] > workspace_limit_bytes) {
-            this->Reshape(bottom, top);
-        }
+        // size_t workspace_limit_bytes, total_memory;
+        // gpu_memory::getInfo(&workspace_limit_bytes, &total_memory);
+        // if (workspace_bwd_filter_sizes_[i] > workspace_limit_bytes ||
+        //    workspace_bwd_data_sizes_[i] > workspace_limit_bytes) {
+        //     this->Reshape(bottom, top);
+        // }
 
         // To remove pressure on allocator, allocate the larger of the
         // workspaces needed for the following steps
@@ -175,6 +176,7 @@ namespace caffe {
         // NOLINT_NEXT_LINE(whitespace/operators)
         CUDA_CHECK(cudaStreamSynchronize(cudaStreamLegacy));
     }
+    backward_pass_called = true;
   }
 
   INSTANTIATE_LAYER_GPU_FUNCS(CuDNNConvolutionLayer);


### PR DESCRIPTION
Need to carefully think about this.  What this is trying to solve is more reliable allocation.  Because Caffe does lazy initialization, we can run into corner cases allocating memory.  This is a hacky workaround to make sure we see a forward and backward pass before we allocate any workspaces.

In theory this should not be needed with Cub's caching allocator.  @drnikolaev has a one liner that may aleviate the need for this PR.  However, even with @drnikolaev change, it will take a full forward and backward for the allocations to stabilize.
