### PR TITLE
Setting maximum roundable bin size to 4M

### DIFF
--- a/src/caffe/util/gpu_memory.cpp
+++ b/src/caffe/util/gpu_memory.cpp
@@ -142,7 +142,7 @@ void GPUMemoryManager::InitMemory(const std::vector<int>& gpus, PoolMode m) {
     try {
       // Just in case someone installed 'no cleanup' arena before
       delete cub_allocator;
-      cub_allocator = new cub::CachingDeviceAllocator(2, 6, 31, (size_t) -1,
+      cub_allocator = new cub::CachingDeviceAllocator(2, 6, 22, (size_t) -1,
           false, debug_);
     } catch (...) {
     }


### PR DESCRIPTION
CUB rounds allocation size up to next power of 2 to increase cache hit probability. This overhead becomes a problem when we make allocations of, let say, 2.5G. We do 4G instead which is a waste. This fix goes from 2^31 down to 2^22 (4MB).
