### PR TITLE
Re-evaluating device info when get closer to zero mem

### DIFF
--- a/src/caffe/layers/cudnn_conv_layer.cpp
+++ b/src/caffe/layers/cudnn_conv_layer.cpp
@@ -116,34 +116,18 @@ void CuDNNConvolutionLayer<Dtype>::Reshape(
         filter_desc_, pad_h, pad_w, stride_h, stride_w);
 
     // Have to pass full fwd/bwd cycle before taking the rest of memory
-    if (backward_passed_ctr_ > 1) {
+    if (backward_passed_ctr_ > 0) {
       // choose forward and backward algorithms + workspace(s)
       CUDNN_CHECK(cudnnGetConvolutionForwardAlgorithm(Caffe::cudnn_handle(),
           bottom_descs_[i], filter_desc_, conv_descs_[i], top_descs_[i],
           CUDNN_CONVOLUTION_FWD_SPECIFY_WORKSPACE_LIMIT,
           workspace_limit_bytes, &fwd_algo_[i]));
-    }
-
-    CUDNN_CHECK(cudnnGetConvolutionForwardWorkspaceSize(Caffe::cudnn_handle(),
-        bottom_descs_[i], filter_desc_, conv_descs_[i], top_descs_[i],
-        fwd_algo_[i], &(workspace_fwd_sizes_[i])));
-
-    if (backward_passed_ctr_ > 1) {
       // choose backward algorithm for filter
       CUDNN_CHECK(cudnnGetConvolutionBackwardFilterAlgorithm(
           Caffe::cudnn_handle(),
           bottom_descs_[i], top_descs_[i], conv_descs_[i], filter_desc_,
           CUDNN_CONVOLUTION_BWD_FILTER_SPECIFY_WORKSPACE_LIMIT,
           workspace_limit_bytes, &bwd_filter_algo_[i]));
-    }
-
-    // get workspace for backwards filter algorithm
-    CUDNN_CHECK(cudnnGetConvolutionBackwardFilterWorkspaceSize(
-        Caffe::cudnn_handle(),
-        bottom_descs_[i], top_descs_[i], conv_descs_[i], filter_desc_,
-        bwd_filter_algo_[i], &workspace_bwd_filter_sizes_[i]));
-
-    if (backward_passed_ctr_ > 1) {
       // choose backward algo for data
       CUDNN_CHECK(cudnnGetConvolutionBackwardDataAlgorithm(
           Caffe::cudnn_handle(),
@@ -152,7 +136,16 @@ void CuDNNConvolutionLayer<Dtype>::Reshape(
           workspace_limit_bytes, &bwd_data_algo_[i]));
     }
 
-    // get workspace size
+    // get workspace size for forward algorithm
+    CUDNN_CHECK(cudnnGetConvolutionForwardWorkspaceSize(Caffe::cudnn_handle(),
+        bottom_descs_[i], filter_desc_, conv_descs_[i], top_descs_[i],
+        fwd_algo_[i], &(workspace_fwd_sizes_[i])));
+    // get workspace size for backward filter algorithm
+    CUDNN_CHECK(cudnnGetConvolutionBackwardFilterWorkspaceSize(
+        Caffe::cudnn_handle(),
+        bottom_descs_[i], top_descs_[i], conv_descs_[i], filter_desc_,
+        bwd_filter_algo_[i], &workspace_bwd_filter_sizes_[i]));
+    // get workspace size for backward data algorithm
     CUDNN_CHECK(cudnnGetConvolutionBackwardDataWorkspaceSize(
         Caffe::cudnn_handle(),
         filter_desc_, top_descs_[i], conv_descs_[i], bottom_descs_[i],

--- a/src/caffe/util/gpu_memory.cpp
+++ b/src/caffe/util/gpu_memory.cpp
@@ -56,19 +56,20 @@ void GPUMemoryManager::destroy() {
   mode_ = NO_POOL;
 }
 
-void GPUMemoryManager::allocate(void** ptr, size_t size, cudaStream_t stream) {
+bool GPUMemoryManager::try_allocate(void** ptr, size_t size, cudaStream_t stream) {
   CHECK((ptr) != NULL);
+  cudaError_t status = cudaSuccess, last_err = cudaSuccess;
   switch (mode_) {
   case CUB_POOL:
-    if (cub_allocator->DeviceAllocate(ptr, size, stream) != cudaSuccess) {
+    // Clean Cache & Retry logic is inside now
+    status = cub_allocator->DeviceAllocate(ptr, size, stream);
+    // If there was a retry and it succeeded we get good status here but
+    // we need to clean up last error...
+    last_err = cudaGetLastError();
+    // ...and update the dev info if something was wrong
+    if (status != cudaSuccess || last_err != cudaSuccess) {
       int cur_device;
       CUDA_CHECK(cudaGetDevice(&cur_device));
-      // free all cached memory (for all devices), synchrionize
-      cudaDeviceSynchronize();
-      cudaThreadSynchronize();
-      cub_allocator->FreeAllCached();
-      cudaDeviceSynchronize();
-      cudaThreadSynchronize();
       // Refresh per-device saved values.
       for (int i = 0; i < dev_info_.size(); ++i) {
         // only query devices that were initialized
@@ -80,16 +81,13 @@ void GPUMemoryManager::allocate(void** ptr, size_t size, cudaStream_t stream) {
           }
         }
       }
-      // Retry once
-      CUDA_CHECK(cub_allocator->DeviceAllocate(ptr, size, stream));
     }
-    // If retry succeeds we need to clean up last error
-    cudaGetLastError();
     break;
   default:
-    CUDA_CHECK(cudaMalloc(ptr, size));
+    status = cudaMalloc(ptr, size);
     break;
   }
+  return status == cudaSuccess;
 }
 
 void GPUMemoryManager::deallocate(void* ptr, cudaStream_t stream) {
@@ -172,7 +170,7 @@ void GPUMemoryManager::GetInfo(size_t* free_mem, size_t* total_mem) {
     CUDA_CHECK(cudaGetDevice(&cur_device));
     *total_mem = dev_info_[cur_device].total_;
     // Free memory is initial free memory minus outstanding allocations.
-    // Assuming we only allocate via GPUMemoryManager since its constructon.
+    // Assuming we only allocate via GPUMemoryManager since its construction.
     *free_mem = dev_info_[cur_device].free_ -
         cub_allocator->cached_bytes[cur_device].live;
     break;

--- a/src/caffe/util/gpu_memory.cpp
+++ b/src/caffe/util/gpu_memory.cpp
@@ -56,7 +56,8 @@ void GPUMemoryManager::destroy() {
   mode_ = NO_POOL;
 }
 
-bool GPUMemoryManager::try_allocate(void** ptr, size_t size, cudaStream_t stream) {
+bool GPUMemoryManager::try_allocate(void** ptr, size_t size,
+    cudaStream_t stream) {
   CHECK((ptr) != NULL);
   cudaError_t status = cudaSuccess, last_err = cudaSuccess;
   switch (mode_) {


### PR DESCRIPTION
When GPU memory comes to its end GPUMemoryManager::GetInfo may report for available memory some value like 174MB and cudnnGetConvolutionForwardAlgorithm decides to take about 143MB out of it for better algorithm. Suddenly, cudaMalloc refuses to allocate 143MB out of the "last 174" and Caffe crashes. It has nothing to do with cache - I verified that no single deallocation happen before the OOM appears. So, the cache is empty. After debugging I found that Device Info values we maintain are diverging from reality when we get more and more allocations. Perhaps, due to cudaMalloc alignment or for some other reason. The fix updates the dev_info_ structure when we get allocation failure while calling new allocator try_allocate (as well as try_reserve). We use new try mechanism to ensure that convolution algorithm chooser does the right thing.
