### PR TITLE
PyCaffe memory leak fix, see issue #154 for details

### DIFF
--- a/include/caffe/layers/memory_data_layer.hpp
+++ b/include/caffe/layers/memory_data_layer.hpp
@@ -20,7 +20,8 @@ template <typename Dtype>
 class MemoryDataLayer : public BaseDataLayer<Dtype> {
  public:
   explicit MemoryDataLayer(const LayerParameter& param)
-      : BaseDataLayer<Dtype>(param), has_new_data_(false) {}
+      : BaseDataLayer<Dtype>(param), has_new_data_(false),
+        deep_copy_mode_(false) {}
   virtual void DataLayerSetUp(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top);
 
@@ -38,6 +39,9 @@ class MemoryDataLayer : public BaseDataLayer<Dtype> {
   //  will be given to Blob, which is mutable
   void Reset(Dtype* data, Dtype* label, int n);
   void set_batch_size(int new_size);
+  void set_deep_copy_mode(bool deep_copy_mode) {
+    deep_copy_mode_ = deep_copy_mode;
+  }
 
   int batch_size() { return batch_size_; }
   int channels() { return channels_; }
@@ -56,6 +60,7 @@ class MemoryDataLayer : public BaseDataLayer<Dtype> {
   Blob<Dtype> added_data_;
   Blob<Dtype> added_label_;
   bool has_new_data_;
+  bool deep_copy_mode_;
 };
 
 }  // namespace caffe

--- a/python/caffe/_caffe.cpp
+++ b/python/caffe/_caffe.cpp
@@ -135,8 +135,7 @@ void Net_Save(const Net<Dtype>& net, string filename) {
   WriteProtoToBinaryFile(net_param, filename.c_str());
 }
 
-void Net_SetInputArrays(Net<Dtype>* net, bp::object data_obj,
-    bp::object labels_obj) {
+shared_ptr<MemoryDataLayer<Dtype> > get_md_layer(Net<Dtype>* net) {
   // check that this network has an input MemoryDataLayer
   shared_ptr<MemoryDataLayer<Dtype> > md_layer =
     boost::dynamic_pointer_cast<MemoryDataLayer<Dtype> >(net->layers()[0]);
@@ -144,7 +143,17 @@ void Net_SetInputArrays(Net<Dtype>* net, bp::object data_obj,
     throw std::runtime_error("set_input_arrays may only be called if the"
         " first layer is a MemoryDataLayer");
   }
+  return md_layer;
+}
 
+void Net_SetDeepCopyMode(Net<Dtype>* net, bool deep_copy_mode) {
+  shared_ptr<MemoryDataLayer<Dtype> > md_layer = get_md_layer(net);
+  md_layer->set_deep_copy_mode(deep_copy_mode);
+}
+
+void Net_SetInputArrays(Net<Dtype>* net, bp::object data_obj,
+    bp::object labels_obj) {
+  shared_ptr<MemoryDataLayer<Dtype> > md_layer = get_md_layer(net);
   // check that we were passed appropriately-sized contiguous memory
   PyArrayObject* data_arr =
       reinterpret_cast<PyArrayObject*>(data_obj.ptr());
@@ -288,7 +297,9 @@ BOOST_PYTHON_MODULE(_caffe) {
         bp::return_value_policy<bp::copy_const_reference>()))
     .def("_set_input_arrays", &Net_SetInputArrays,
         bp::with_custodian_and_ward<1, 2, bp::with_custodian_and_ward<1, 3> >())
-    .def("save", &Net_Save);
+    .def("save", &Net_Save)
+    .def("set_deep_copy_mode", &Net_SetDeepCopyMode);
+
   BP_REGISTER_SHARED_PTR_TO_PYTHON(Net<Dtype>);
 
   bp::class_<Blob<Dtype>, shared_ptr<Blob<Dtype> >, boost::noncopyable>(

--- a/src/caffe/layers/memory_data_layer.cpp
+++ b/src/caffe/layers/memory_data_layer.cpp
@@ -110,8 +110,15 @@ void MemoryDataLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
   CHECK(data_) << "MemoryDataLayer needs to be initalized by calling Reset";
   top[0]->Reshape(batch_size_, channels_, height_, width_);
   top[1]->Reshape(batch_size_, 1, 1, 1);
-  top[0]->set_cpu_data(data_ + pos_ * size_);
-  top[1]->set_cpu_data(labels_ + pos_);
+  Dtype* pdata = data_ + pos_ * size_;
+  Dtype* plabel = labels_ + pos_;
+  if (deep_copy_mode_) {
+    caffe_copy(top[0]->count(), pdata, top[0]->mutable_cpu_data());
+    caffe_copy(top[1]->count(), plabel, top[1]->mutable_cpu_data());
+  } else {
+    top[0]->set_cpu_data(pdata);
+    top[1]->set_cpu_data(plabel);
+  }
   pos_ = (pos_ + batch_size_) % n_;
   if (pos_ == 0)
     has_new_data_ = false;


### PR DESCRIPTION
This leak has been reproduced on both BVLC and NVCaffe branches. See issue #154 . Here is the fix: instead of shallow copying from Python (thus keeping refcount>0 forever) we make deep copies and allow Python to garbage collect its arrays properly.
