### PR TITLE
Explicit class mapping in DetectNet

### DIFF
--- a/examples/kitti/detectnet_network.prototxt
+++ b/examples/kitti/detectnet_network.prototxt
@@ -79,6 +79,7 @@ layer {
     image_size_x: 1248
     image_size_y: 384
     crop_bboxes: true
+    object_class: { src: 1 dst: 0} # obj class 1 -> cvg index 0
   }
    detectnet_augmentation_param: {
     crop_prob: 1
@@ -117,6 +118,7 @@ layer {
     image_size_x: 1248
     image_size_y: 384
     crop_bboxes: false
+    object_class: { src: 1 dst: 0} # obj class 1 -> cvg index 0
   }
   transform_param: {
     mean_value: 127


### PR DESCRIPTION
The hard-coded value in the [code](https://github.com/NVIDIA/caffe/blob/ba120c1a502809a949990c600e101edbda8ec71e/src/caffe/util/detectnet_coverage_rectangular.cpp#L94-L99) feels a bit too magical.
