### PR TITLE
Thread the data reader code

### DIFF
--- a/include/caffe/data_transformer.hpp
+++ b/include/caffe/data_transformer.hpp
@@ -6,6 +6,7 @@
 #include "caffe/blob.hpp"
 #include "caffe/common.hpp"
 #include "caffe/proto/caffe.pb.h"
+#include "caffe/util/blocking_queue.hpp"
 
 namespace caffe {
 
@@ -26,6 +27,16 @@ class DataTransformer {
   void InitRand();
 
   /**
+   * @brief Generates a random integer from Uniform({0, 1, ..., n-1}).
+   *
+   * @param n
+   *    The upperbound (exclusive) value of the random number.
+   * @return
+   *    A uniformly random integer value from ({0, 1, ..., n-1}).
+   */
+  virtual int Rand(int n);
+
+  /**
    * @brief Applies the transformation defined in the data layer's
    * transform_param block to the data.
    *
@@ -36,6 +47,26 @@ class DataTransformer {
    *    set_cpu_data() is used. See data_layer.cpp for an example.
    */
   void Transform(const Datum& datum, Blob<Dtype>* transformed_blob);
+
+  /**
+   * @brief Applies the transformation defined in the data layer's
+   * transform_param block to the data.
+   *
+   * @param datum
+   *    Datum containing the data to be transformed.
+   * @param rand1
+   *    Random value (0,RAND_MAX+1]
+   * @param rand2
+   *    Random value (0,RAND_MAX+1]
+   * @param rand3
+   *    Random value (0,RAND_MAX+1]
+   * @param transformed_blob
+   *    This is destination blob. It can be part of top blob's data if
+   *    set_cpu_data() is used. See data_layer.cpp for an example.
+   */
+    void TransformPtrEntry(Datum* datum, Dtype* transformed_ptr,
+                           int rand1, int rand2, int rand3,
+                           BlockingQueue<Datum*>* free);
 
   /**
    * @brief Applies the transformation defined in the data layer's
@@ -75,6 +106,25 @@ class DataTransformer {
    *    set_cpu_data() is used. See image_data_layer.cpp for an example.
    */
   void Transform(const cv::Mat& cv_img, Blob<Dtype>* transformed_blob);
+
+  /**
+   * @brief Applies the transformation defined in the data layer's
+   * transform_param block to a cv::Mat
+   *
+   * @param cv_img
+   *    cv::Mat containing the data to be transformed.
+   * @param transformed_blob
+   *    This is destination blob. It can be part of top blob's data if
+   *    set_cpu_data() is used. See image_data_layer.cpp for an example.
+   * @param rand1
+   *    Random value (0,RAND_MAX+1]
+   * @param rand2
+   *    Random value (0,RAND_MAX+1]
+   * @param rand3
+   *    Random value (0,RAND_MAX+1]
+   */
+  void TransformPtr(const cv::Mat& cv_img, Dtype* transformed_ptr,
+                    int rand1, int rand2, int rand3);
 #endif  // USE_OPENCV
 
   /**
@@ -128,20 +178,12 @@ class DataTransformer {
 #endif  // USE_OPENCV
 
  protected:
-   /**
-   * @brief Generates a random integer from Uniform({0, 1, ..., n-1}).
-   *
-   * @param n
-   *    The upperbound (exclusive) value of the random number.
-   * @return
-   *    A uniformly random integer value from ({0, 1, ..., n-1}).
-   */
-  virtual int Rand(int n);
-
   void Transform(const Datum& datum, Dtype* transformed_data);
   // Tranformation parameters
   TransformationParameter param_;
-
+  void TransformPtrInt(Datum* datum, Dtype* transformed_data,
+                       int rand1, int rand2, int rand3,
+                       BlockingQueue<Datum*>* free);
 
   shared_ptr<Caffe::RNG> rng_;
   Phase phase_;

--- a/include/caffe/layers/data_layer.hpp
+++ b/include/caffe/layers/data_layer.hpp
@@ -11,6 +11,7 @@
 #include "caffe/layers/base_data_layer.hpp"
 #include "caffe/proto/caffe.pb.h"
 #include "caffe/util/db.hpp"
+#include "caffe/util/thread_pool.hpp"
 
 namespace caffe {
 
@@ -32,6 +33,7 @@ class DataLayer : public BasePrefetchingDataLayer<Dtype> {
   virtual void load_batch(Batch<Dtype>* batch);
 
   DataReader reader_;
+  ThreadPool pool_;
 };
 
 }  // namespace caffe

--- a/include/caffe/util/thread_pool.hpp
+++ b/include/caffe/util/thread_pool.hpp
@@ -1,0 +1,114 @@
+#ifndef THREAD_POOL_H
+#define THREAD_POOL_H
+
+#include <boost/bind.hpp>
+#include <boost/thread.hpp>
+#include <queue>
+
+class ThreadPool{
+ private:
+    std::queue< boost::function< void() > > tasks_;
+    boost::thread_group threads_;
+    boost::mutex mutex_;
+    boost::condition_variable condition_;
+    boost::condition_variable completed_;
+    bool running_;
+    bool complete_;
+    std::size_t available_;
+    std::size_t total_;
+
+ public:
+    /// @brief Constructor.
+    explicit ThreadPool(std::size_t pool_size)
+        :  running_(true), complete_(true),
+           available_(pool_size), total_(pool_size) {
+        for ( std::size_t i = 0; i < pool_size; ++i ) {
+            threads_.create_thread(
+                boost::bind(&ThreadPool::main_loop, this));
+        }
+    }
+
+    /// @brief Destructor.
+    ~ThreadPool() {
+        // Set running flag to false then notify all threads.
+        {
+            boost::unique_lock< boost::mutex > lock(mutex_);
+            running_ = false;
+            condition_.notify_all();
+        }
+
+        try {
+            threads_.join_all();
+        }
+        // Suppress all exceptions.
+        catch (const std::exception&) {}
+    }
+
+    /// @brief Add task to the thread pool if a thread is currently available.
+    template <typename Task>
+    void runTask(Task task) {
+        boost::unique_lock<boost::mutex> lock(mutex_);
+
+        // Set task and signal condition variable so that a worker thread will
+        // wake up and use the task.
+        tasks_.push(boost::function<void()>(task));
+        complete_ = false;
+        condition_.notify_one();
+    }
+
+    /// @brief Wait for queue to be empty
+    void waitWorkComplete() {
+        boost::unique_lock<boost::mutex> lock(mutex_);
+        if (!complete_)
+            completed_.wait(lock);
+    }
+
+ private:
+    /// @brief Entry point for pool threads.
+    void main_loop() {
+        while (running_) {
+            // Wait on condition variable while the task is empty and
+            // the pool is still running.
+            boost::unique_lock<boost::mutex> lock(mutex_);
+            while (tasks_.empty() && running_) {
+                condition_.wait(lock);
+            }
+            // If pool is no longer running, break out of loop.
+            if (!running_) break;
+
+            // Copy task locally and remove from the queue.  This is
+            // done within its own scope so that the task object is
+            // destructed immediately after running the task.  This is
+            // useful in the event that the function contains
+            // shared_ptr arguments bound via bind.
+            {
+                boost::function< void() > task = tasks_.front();
+                tasks_.pop();
+                // Decrement count, indicating thread is no longer available.
+                --available_;
+
+                lock.unlock();
+
+                // Run the task.
+                try {
+                    task();
+                }
+                // Suppress all exceptions.
+                catch ( const std::exception& ) {}
+
+                // Update status of empty, maybe
+                // Need to recover the lock first
+                lock.lock();
+
+                // Increment count, indicating thread is available.
+                ++available_;
+                if (tasks_.empty() && available_ == total_) {
+                    complete_ = true;
+                    completed_.notify_one();
+                }
+            }
+        }  // while running_
+    }
+};
+
+#endif


### PR DESCRIPTION
Initial patch set for parallel read.

TODO:
- [x] Debug CPU mode deadlock when reading DB in DataLayerTest/0.TestReadLMDB
- [ ] Come up with a way to define the pool size at runtime to something that makes sense.  e.g. number of CPU cores divided by number of GPUs?  
- [ ] Add support for overridding above in the prototxt
- [ ] Move parsing datum into the threads, google's code is incredibly slow here.
- [ ] Reorder some of the transform loops for better CPU performance.  We don't walk linearly in the current code inherited from BVLC.
