### PR TITLE
Add control over thread pool size for threaded data loader

### DIFF
--- a/include/caffe/layers/data_layer.hpp
+++ b/include/caffe/layers/data_layer.hpp
@@ -33,7 +33,7 @@ class DataLayer : public BasePrefetchingDataLayer<Dtype> {
   virtual void load_batch(Batch<Dtype>* batch);
 
   DataReader reader_;
-  ThreadPool pool_;
+  shared_ptr<ThreadPool> pool_;
 };
 
 }  // namespace caffe

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -742,6 +742,9 @@ message DataParameter {
   // Prefetch queue (Number of batches to prefetch to host memory, increase if
   // data access bandwidth varies).
   optional uint32 prefetch = 10 [default = 4];
+  // Number of processing threads.  0 means use defaults. 1 thread for CPU or
+  // cpu logical cores / number of GPUs
+  optional uint32 threads  = 11 [default = 0];
 }
 
 message DropoutParameter {


### PR DESCRIPTION
Add a dynamic sizer for the thread pool in GPU mode.  It's not perfect, but doing it "right" requires more complex dependencies.

In CPU mode, we don't need the prefetch speed and using the CPU cores to compute, so only have 1 thread.

In GPU mode, take the number of CPU cores and divide by the number of GPUs.

Where this isn't quite right is that we are using a mechanism to get CPU cores that will include hyperthreading.  On the GPU side, CUDA_VISIBLE_DEVICES and hide devices from our ability to count.  We could fix this with NVML usage, but pulls in a dependency.  It is likely a corner case.

Can be overridden in the prototxt in the datalayer by setting "threads" in the params just as batch_size is set now.
