### PR TITLE
Added new GaussianStatic dummy layer

### DIFF
--- a/include/caffe/filler.hpp
+++ b/include/caffe/filler.hpp
@@ -355,7 +355,6 @@ class XavierStaticFiller : public Filler<Dtype> {
          << "Sparsity not supported by this Filler.";
   }
 
-
  private:
   std::vector<Dtype> xavier_static_filler_data_;
   bool xavier_static_filler_flag_;

--- a/include/caffe/filler.hpp
+++ b/include/caffe/filler.hpp
@@ -6,6 +6,7 @@
 #define CAFFE_FILLER_HPP
 
 #include <string>
+#include <vector>
 
 #include "caffe/blob.hpp"
 #include "caffe/proto/caffe.pb.h"
@@ -60,6 +61,40 @@ class UniformFiller : public Filler<Dtype> {
   }
 };
 
+/// @brief Fills a Blob with uniformly distributed values @f$ x\sim U(a, b) @f$.
+//         RNG is only called once, and its output is stored in
+//         UniformStaticFillerdata. Followup calls to the Filler function
+//         will bypass RNG.
+template <typename Dtype>
+class UniformStaticFiller : public Filler<Dtype> {
+ public:
+  explicit UniformStaticFiller(const FillerParameter& param)
+      : Filler<Dtype>(param) {
+        uniform_static_filler_flag_ = false;
+      }
+  virtual void Fill(Blob<Dtype>* blob) {
+    Dtype* data = blob->mutable_cpu_data();
+    const int blob_count = blob->count();
+    CHECK(blob_count);
+
+    if (uniform_static_filler_flag_ == false) {
+      uniform_static_filler_data_.resize(blob_count);
+      caffe_rng_uniform(blob_count, Dtype(this->filler_param_.min()),
+          Dtype(this->filler_param_.max()),
+          &uniform_static_filler_data_.front());
+      uniform_static_filler_flag_ = true;
+    }
+    CHECK_EQ(this->filler_param_.sparse(), -1)
+        << "Sparsity not supported by this Filler.";
+    caffe_copy(blob_count, &uniform_static_filler_data_.front(), data);
+  }
+
+ private:
+  std::vector<Dtype> uniform_static_filler_data_;
+  bool uniform_static_filler_flag_;
+};
+
+
 /// @brief Fills a Blob with Gaussian-distributed values @f$ x = a @f$.
 template <typename Dtype>
 class GaussianFiller : public Filler<Dtype> {
@@ -94,6 +129,58 @@ class GaussianFiller : public Filler<Dtype> {
   shared_ptr<SyncedMemory> rand_vec_;
 };
 
+
+/// @brief Fills a Blob with Gaussian-distributed values @f$ x = a @f$.
+//         RNG is only called once, and its output is stored in
+//         GaussianStaticFillerdata. Followup calls to the Filler function
+//         will bypass RNG.
+template <typename Dtype>
+class GaussianStaticFiller : public Filler<Dtype> {
+ public:
+  explicit GaussianStaticFiller(const FillerParameter& param)
+      : Filler<Dtype>(param) {
+    gaussian_static_filler_flag_ = false;
+  }
+  virtual void Fill(Blob<Dtype>* blob) {
+    Dtype* data = blob->mutable_cpu_data();
+    const int blob_count = blob->count();
+    CHECK(blob_count);
+
+    if (gaussian_static_filler_flag_ == false) {
+      gaussian_static_filler_data_.resize(blob_count);
+      caffe_rng_gaussian(blob_count, Dtype(this->filler_param_.mean()),
+        Dtype(this->filler_param_.std()),
+        &gaussian_static_filler_data_.front());
+      gaussian_static_filler_flag_ = true;
+    }
+    caffe_copy(blob_count, &gaussian_static_filler_data_.front(), data);
+    int sparse = this->filler_param_.sparse();
+    CHECK_GE(sparse, -1);
+    if (sparse >= 0) {
+      // Sparse initialization is implemented for "weight" blobs; i.e. matrices.
+      // These have num == channels == 1; width is number of inputs; height is
+      // number of outputs.  The 'sparse' variable specifies the mean number
+      // of non-zero input weights for a given output.
+      CHECK_GE(blob->num_axes(), 1);
+      const int num_outputs = blob->shape(0);
+      Dtype non_zero_probability = Dtype(sparse) / Dtype(num_outputs);
+      rand_vec_.resize(blob_count * sizeof(int));
+      int* mask = reinterpret_cast<int*>(&rand_vec_.front());
+      caffe_rng_bernoulli(blob_count, non_zero_probability, mask);
+      for (int i = 0; i < blob_count; ++i) {
+        data[i] *= mask[i];
+      }
+    }
+  }
+
+ protected:
+  std::vector<int> rand_vec_;
+
+ private:
+  std::vector<Dtype> gaussian_static_filler_data_;
+  bool gaussian_static_filler_flag_;
+};
+
 /** @brief Fills a Blob with values @f$ x \in [0, 1] @f$
  *         such that @f$ \forall i \sum_j x_{ij} = 1 @f$.
  */
@@ -123,6 +210,54 @@ class PositiveUnitballFiller : public Filler<Dtype> {
          << "Sparsity not supported by this Filler.";
   }
 };
+
+/** @brief Fills a Blob with values @f$ x \in [0, 1] @f$
+ *         such that @f$ \forall i \sum_j x_{ij} = 1 @f$.
+ *         RNG is only called once, and its output is stored in
+ *         PositiveUnitballStaticFillerdata. Followup calls to the Filler function
+ *         will bypass RNG.
+ */
+template <typename Dtype>
+class PositiveUnitballStaticFiller : public Filler<Dtype> {
+ public:
+  explicit PositiveUnitballStaticFiller(const FillerParameter& param)
+      : Filler<Dtype>(param) {
+    positive_unitball_static_filler_flag_ = false;
+  }
+  virtual void Fill(Blob<Dtype>* blob) {
+    Dtype* data = blob->mutable_cpu_data();
+    const int blob_count = blob->count();
+    CHECK(blob_count);
+    if (positive_unitball_static_filler_flag_ == false) {
+      positive_unitball_static_filler_data_.resize(blob_count);
+      caffe_rng_uniform(blob_count, Dtype(0.), Dtype(1.),
+          &positive_unitball_static_filler_data_.front());
+
+      int dim = blob_count / blob->num();
+      CHECK(dim);
+      for (int i = 0; i < blob->num(); ++i) {
+        Dtype sum = 0;
+        for (int j = 0; j < dim; ++j) {
+          sum += positive_unitball_static_filler_data_[i * dim + j];
+        }
+        for (int j = 0; j < dim; ++j) {
+          positive_unitball_static_filler_data_[i * dim + j] /= sum;
+        }
+      }
+      positive_unitball_static_filler_flag_ = true;
+    }
+    CHECK_EQ(this->filler_param_.sparse(), -1)
+         << "Sparsity not supported by this Filler.";
+    caffe_copy(blob_count,
+        &positive_unitball_static_filler_data_.front(), data);
+  }
+
+
+ private:
+  std::vector<Dtype> positive_unitball_static_filler_data_;
+  bool positive_unitball_static_filler_flag_;
+};
+
 
 /**
  * @brief Fills a Blob with values @f$ x \sim U(-a, +a) @f$ where @f$ a @f$ is
@@ -165,6 +300,68 @@ class XavierFiller : public Filler<Dtype> {
   }
 };
 
+
+/**
+ * @brief Fills a Blob with values @f$ x \sim U(-a, +a) @f$ where @f$ a @f$ is
+ *        set inversely proportional to number of incoming nodes, outgoing
+ *        nodes, or their average.
+ *
+ * A Filler based on the paper [Bengio and Glorot 2010]: Understanding
+ * the difficulty of training deep feedforward neuralnetworks.
+ *
+ * It fills the incoming matrix by randomly sampling uniform data from [-scale,
+ * scale] where scale = sqrt(3 / n) where n is the fan_in, fan_out, or their
+ * average, depending on the variance_norm option. You should make sure the
+ * input blob has shape (num, a, b, c) where a * b * c = fan_in and num * b * c
+ * = fan_out. Note that this is currently not the case for inner product layers.
+ *
+ * RNG is only called once, and its output is stored in
+ * XavierStaticFillerdata. Followup calls to the Filler function
+ * will bypass RNG.
+ *
+ * TODO(dox): make notation in above comment consistent with rest & use LaTeX.
+ */
+template <typename Dtype>
+class XavierStaticFiller : public Filler<Dtype> {
+ public:
+  explicit XavierStaticFiller(const FillerParameter& param)
+      : Filler<Dtype>(param) {
+    xavier_static_filler_flag_ = false;
+  }
+  virtual void Fill(Blob<Dtype>* blob) {
+    Dtype* data = blob->mutable_cpu_data();
+    const int blob_count = blob->count();
+    CHECK(blob_count);
+
+    if (xavier_static_filler_flag_ == false) {
+      xavier_static_filler_data_.resize(blob_count);
+      int fan_in = blob_count / blob->num();
+      int fan_out = blob_count / blob->channels();
+      Dtype n = fan_in;  // default to fan_in
+      if (this->filler_param_.variance_norm() ==
+         FillerParameter_VarianceNorm_AVERAGE) {
+        n = (fan_in + fan_out) / Dtype(2);
+      } else if (this->filler_param_.variance_norm() ==
+          FillerParameter_VarianceNorm_FAN_OUT) {
+        n = fan_out;
+      }
+      Dtype scale = sqrt(Dtype(3) / n);
+      caffe_rng_uniform(blob_count, Dtype(-scale), Dtype(scale),
+          &xavier_static_filler_data_.front());
+      xavier_static_filler_flag_ = true;
+    }
+    caffe_copy(blob_count, &xavier_static_filler_data_.front(), data);
+    CHECK_EQ(this->filler_param_.sparse(), -1)
+         << "Sparsity not supported by this Filler.";
+  }
+
+
+ private:
+  std::vector<Dtype> xavier_static_filler_data_;
+  bool xavier_static_filler_flag_;
+};
+
+
 /**
  * @brief Fills a Blob with values @f$ x \sim N(0, \sigma^2) @f$ where
  *        @f$ \sigma^2 @f$ is set inversely proportional to number of incoming
@@ -205,6 +402,67 @@ class MSRAFiller : public Filler<Dtype> {
     CHECK_EQ(this->filler_param_.sparse(), -1)
          << "Sparsity not supported by this Filler.";
   }
+};
+
+
+/**
+ * @brief Fills a Blob with values @f$ x \sim N(0, \sigma^2) @f$ where
+ *        @f$ \sigma^2 @f$ is set inversely proportional to number of incoming
+ *        nodes, outgoing nodes, or their average.
+ *
+ * A Filler based on the paper [He, Zhang, Ren and Sun 2015]: Specifically
+ * accounts for ReLU nonlinearities.
+ *
+ * Aside: for another perspective on the scaling factor, see the derivation of
+ * [Saxe, McClelland, and Ganguli 2013 (v3)].
+ *
+ * It fills the incoming matrix by randomly sampling Gaussian data with std =
+ * sqrt(2 / n) where n is the fan_in, fan_out, or their average, depending on
+ * the variance_norm option. You should make sure the input blob has shape (num,
+ * a, b, c) where a * b * c = fan_in and num * b * c = fan_out. Note that this
+ * is currently not the case for inner product layers.
+ *
+ * RNG is only called once, and its output is stored in
+ * MSRAStaticFillerdata. Followup calls to the Filler function
+ * will bypass RNG.
+ */
+template <typename Dtype>
+class MSRAStaticFiller : public Filler<Dtype> {
+ public:
+  explicit MSRAStaticFiller(const FillerParameter& param)
+      : Filler<Dtype>(param) {
+    msra_static_filler_flag_ = false;
+  }
+  virtual void Fill(Blob<Dtype>* blob) {
+    Dtype* data = blob->mutable_cpu_data();
+    const int blob_count = blob->count();
+    CHECK(blob_count);
+
+    if (msra_static_filler_flag_ == false) {
+      msra_static_filler_data_.resize(blob_count);
+      int fan_in = blob_count / blob->num();
+      int fan_out = blob_count / blob->channels();
+      Dtype n = fan_in;  // default to fan_in
+      if (this->filler_param_.variance_norm() ==
+          FillerParameter_VarianceNorm_AVERAGE) {
+        n = (fan_in + fan_out) / Dtype(2);
+      } else if (this->filler_param_.variance_norm() ==
+          FillerParameter_VarianceNorm_FAN_OUT) {
+        n = fan_out;
+      }
+      Dtype std = sqrt(Dtype(2) / n);
+      caffe_rng_gaussian(blob_count, Dtype(0), std,
+          &msra_static_filler_data_.front());
+      msra_static_filler_flag_ = true;
+    }
+    caffe_copy(blob_count, &msra_static_filler_data_.front(), data);
+    CHECK_EQ(this->filler_param_.sparse(), -1)
+         << "Sparsity not supported by this Filler.";
+  }
+
+ private:
+  std::vector<Dtype> msra_static_filler_data_;
+  bool msra_static_filler_flag_;
 };
 
 /*!
@@ -261,6 +519,81 @@ class BilinearFiller : public Filler<Dtype> {
   }
 };
 
+/*!
+@brief Fills a Blob with coefficients for bilinear interpolation.
+
+A common use case is with the DeconvolutionLayer acting as upsampling.
+You can upsample a feature map with shape of (B, C, H, W) by any integer factor
+using the following proto.
+\code
+layer {
+  name: "upsample", type: "Deconvolution"
+  bottom: "{{bottom_name}}" top: "{{top_name}}"
+  convolution_param {
+    kernel_size: {{2 * factor - factor % 2}} stride: {{factor}}
+    num_output: {{C}} group: {{C}}
+    pad: {{ceil((factor - 1) / 2.)}}
+    weight_filler: { type: "bilinear" } bias_term: false
+  }
+  param { lr_mult: 0 decay_mult: 0 }
+}
+\endcode
+Please use this by replacing `{{}}` with your values. By specifying
+`num_output: {{C}} group: {{C}}`, it behaves as
+channel-wise convolution. The filter shape of this deconvolution layer will be
+(C, 1, K, K) where K is `kernel_size`, and this filler will set a (K, K)
+interpolation kernel for every channel of the filter identically. The resulting
+shape of the top feature map will be (B, C, factor * H, factor * W).
+Note that the learning rate and the
+weight decay are set to 0 in order to keep coefficient values of bilinear
+interpolation unchanged during training. If you apply this to an image, this
+operation is equivalent to the following call in Python with Scikit.Image.
+\code{.py}
+out = skimage.transform.rescale(img, factor, mode='constant', cval=0)
+\endcode
+
+ * RNG is only called once, and its output is stored in
+ * BilinearStaticFillerdata. Followup calls to the Filler function
+ * will bypass RNG.
+ */
+template <typename Dtype>
+class BilinearStaticFiller : public Filler<Dtype> {
+ public:
+  explicit BilinearStaticFiller(const FillerParameter& param)
+      : Filler<Dtype>(param) {
+    bilinear_static_filler_flag_ = false;
+  }
+  virtual void Fill(Blob<Dtype>* blob) {
+    Dtype* data = blob->mutable_cpu_data();
+    const int blob_count = blob->count();
+    const int blob_width = blob->width();
+    const int blob_height = blob->height();
+
+    CHECK_EQ(blob->num_axes(), 4) << "Blob must be 4 dim.";
+    CHECK_EQ(blob_width, blob_height) << "Filter must be square";
+    if (bilinear_static_filler_flag_ == false) {
+      bilinear_static_filler_data_.resize(blob_count);
+      int f = ceil(blob_width / 2.);
+      float c = (2 * f - 1 - f % 2) / (2. * f);
+      for (int i = 0; i < blob_count; ++i) {
+        float x = i % blob_width;
+        float y = (i / blob_width) % blob_height;
+        bilinear_static_filler_data_[i] =
+          (1 - fabs(x / f - c)) * (1 - fabs(y / f - c));
+      }
+      bilinear_static_filler_flag_ = true;
+    }
+    caffe_copy(blob_count, &bilinear_static_filler_data_.front(), data);
+    CHECK_EQ(this->filler_param_.sparse(), -1)
+         << "Sparsity not supported by this Filler.";
+  }
+
+
+ private:
+  std::vector<Dtype> bilinear_static_filler_data_;
+  bool bilinear_static_filler_flag_;
+};
+
 /**
  * @brief Get a specific filler from the specification given in FillerParameter.
  *
@@ -284,6 +617,18 @@ Filler<Dtype>* GetFiller(const FillerParameter& param) {
     return new MSRAFiller<Dtype>(param);
   } else if (type == "bilinear") {
     return new BilinearFiller<Dtype>(param);
+  } else if (type == "gaussianstatic") {
+    return new GaussianStaticFiller<Dtype>(param);
+  } else if (type == "positive_unitballstatic") {
+    return new PositiveUnitballStaticFiller<Dtype>(param);
+  } else if (type == "uniformstatic") {
+    return new UniformStaticFiller<Dtype>(param);
+  } else if (type == "xavierstatic") {
+    return new XavierStaticFiller<Dtype>(param);
+  } else if (type == "msrastatic") {
+    return new MSRAStaticFiller<Dtype>(param);
+  } else if (type == "bilinearstatic") {
+    return new BilinearStaticFiller<Dtype>(param);
   } else {
     CHECK(false) << "Unknown filler name: " << param.type();
   }

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -41,7 +41,16 @@ message Datum {
 }
 
 message FillerParameter {
-  // The filler type.
+  // The filler type. Can be one of the following:
+  // constant, gaussian, positive_unitball, uniform, xavier,
+  // msra, bilinear, or their static versions:
+  // gaussianstatic, positive_unitballstatic, uniformstatic, 
+  // xavierstatic, msrastatic, bilinearstatic
+  // In the static version the random number generator is only
+  // called once, and subsequent calls to fill blob, will write
+  // the same random numbers as in the first call. This is done
+  // to save time in cases where having same random numbers does
+  // not make a difference.
   optional string type = 1 [default = 'constant'];
   optional float value = 2 [default = 0]; // the value in constant filler
   optional float min = 3 [default = 0]; // the min value in uniform filler

--- a/src/caffe/test/test_filler.cpp
+++ b/src/caffe/test/test_filler.cpp
@@ -1,3 +1,5 @@
+#include <vector>
+
 #include "gtest/gtest.h"
 
 #include "caffe/filler.hpp"
@@ -33,7 +35,6 @@ TYPED_TEST(ConstantFillerTest, TestFill) {
   }
 }
 
-
 template <typename Dtype>
 class UniformFillerTest : public ::testing::Test {
  protected:
@@ -60,6 +61,51 @@ TYPED_TEST(UniformFillerTest, TestFill) {
   for (int i = 0; i < count; ++i) {
     EXPECT_GE(data[i], this->filler_param_.min());
     EXPECT_LE(data[i], this->filler_param_.max());
+  }
+}
+
+template <typename Dtype>
+class UniformStaticFillerTest : public ::testing::Test {
+ protected:
+  UniformStaticFillerTest()
+      : blob_(new Blob<Dtype>(2, 3, 4, 5)),
+        filler_param_() {
+    filler_param_.set_min(1.);
+    filler_param_.set_max(2.);
+    filler_.reset(new UniformStaticFiller<Dtype>(filler_param_));
+    filler_->Fill(blob_);
+  }
+  virtual ~UniformStaticFillerTest() { delete blob_; }
+  Blob<Dtype>* const blob_;
+  FillerParameter filler_param_;
+  shared_ptr<UniformStaticFiller<Dtype> > filler_;
+};
+
+TYPED_TEST_CASE(UniformStaticFillerTest, TestDtypes);
+
+TYPED_TEST(UniformStaticFillerTest, TestFill) {
+  EXPECT_TRUE(this->blob_);
+  const int count = this->blob_->count();
+  const TypeParam* data = this->blob_->cpu_data();
+  // We want to check that repeated calls to the static filler returns the same
+  // values. So we copy the first filler call to data_0 and the second one to
+  // data_1 and then check whether they are equal.
+  std::vector<TypeParam> data_0, data_1;
+  data_0.resize(count);
+  data_1.resize(count);
+  caffe_copy(count, data, &data_0.front());
+
+  for (int i = 0; i < count; ++i) {
+    EXPECT_GE(data[i], this->filler_param_.min());
+    EXPECT_LE(data[i], this->filler_param_.max());
+  }
+
+  this->filler_->Fill(this->blob_);
+  caffe_copy(count, data, &data_1.front());
+  for (int i = 0; i < count; ++i) {
+    // We do not use EXPECT_FLOAT_EQ because the data must match
+    // bit by bit
+    EXPECT_EQ(data_0[i], data_1[i]);
   }
 }
 
@@ -101,6 +147,58 @@ TYPED_TEST(PositiveUnitballFillerTest, TestFill) {
 }
 
 template <typename Dtype>
+class PositiveUnitballStaticFillerTest : public ::testing::Test {
+ protected:
+  PositiveUnitballStaticFillerTest()
+      : blob_(new Blob<Dtype>(2, 3, 4, 5)),
+        filler_param_() {
+    filler_.reset(new PositiveUnitballStaticFiller<Dtype>(filler_param_));
+    filler_->Fill(blob_);
+  }
+  virtual ~PositiveUnitballStaticFillerTest() { delete blob_; }
+  Blob<Dtype>* const blob_;
+  FillerParameter filler_param_;
+  shared_ptr<PositiveUnitballStaticFiller<Dtype> > filler_;
+};
+
+TYPED_TEST_CASE(PositiveUnitballStaticFillerTest, TestDtypes);
+
+TYPED_TEST(PositiveUnitballStaticFillerTest, TestFill) {
+  EXPECT_TRUE(this->blob_);
+  const int num = this->blob_->num();
+  const int count = this->blob_->count();
+  const int dim = count / num;
+  const TypeParam* data = this->blob_->cpu_data();
+  for (int i = 0; i < count; ++i) {
+    EXPECT_GE(data[i], 0);
+    EXPECT_LE(data[i], 1);
+  }
+  for (int i = 0; i < num; ++i) {
+    TypeParam sum = 0;
+    for (int j = 0; j < dim; ++j) {
+      sum += data[i * dim + j];
+    }
+    EXPECT_GE(sum, 0.999);
+    EXPECT_LE(sum, 1.001);
+  }
+  // We want to check that repeated calls to the static filler returns the same
+  // values. So we copy the first filler call to data_0 and the second one to
+  // data_1 and then check whether they are equal.
+  std::vector<TypeParam> data_0, data_1;
+  data_0.resize(count);
+  data_1.resize(count);
+  caffe_copy(count, data, &data_0.front());
+
+  this->filler_->Fill(this->blob_);
+  caffe_copy(count, data, &data_1.front());
+  for (int i = 0; i < count; ++i) {
+    // We do not use EXPECT_FLOAT_EQ because the data must match
+    // bit by bit
+    EXPECT_EQ(data_0[i], data_1[i]);
+  }
+}
+
+template <typename Dtype>
 class GaussianFillerTest : public ::testing::Test {
  protected:
   GaussianFillerTest()
@@ -138,6 +236,63 @@ TYPED_TEST(GaussianFillerTest, TestFill) {
   TypeParam target_var = this->filler_param_.std() * this->filler_param_.std();
   EXPECT_GE(var, target_var / 5.);
   EXPECT_LE(var, target_var * 5.);
+}
+
+
+template <typename Dtype>
+class GaussianStaticFillerTest : public ::testing::Test {
+ protected:
+  GaussianStaticFillerTest()
+      : blob_(new Blob<Dtype>(2, 3, 4, 5)),
+        filler_param_() {
+    filler_param_.set_mean(10.);
+    filler_param_.set_std(0.1);
+    filler_.reset(new GaussianStaticFiller<Dtype>(filler_param_));
+    filler_->Fill(blob_);
+  }
+  virtual ~GaussianStaticFillerTest() { delete blob_; }
+  Blob<Dtype>* const blob_;
+  FillerParameter filler_param_;
+  shared_ptr<GaussianStaticFiller<Dtype> > filler_;
+};
+
+TYPED_TEST_CASE(GaussianStaticFillerTest, TestDtypes);
+
+TYPED_TEST(GaussianStaticFillerTest, TestFill) {
+  EXPECT_TRUE(this->blob_);
+  const int count = this->blob_->count();
+  const TypeParam* data = this->blob_->cpu_data();
+  TypeParam mean = 0.;
+  TypeParam var = 0.;
+  for (int i = 0; i < count; ++i) {
+    mean += data[i];
+    var += (data[i] - this->filler_param_.mean()) *
+        (data[i] - this->filler_param_.mean());
+  }
+  mean /= count;
+  var /= count;
+  // Very loose test.
+  EXPECT_GE(mean, this->filler_param_.mean() - this->filler_param_.std() * 5);
+  EXPECT_LE(mean, this->filler_param_.mean() + this->filler_param_.std() * 5);
+  TypeParam target_var = this->filler_param_.std() * this->filler_param_.std();
+  EXPECT_GE(var, target_var / 5.);
+  EXPECT_LE(var, target_var * 5.);
+
+  // We want to check that repeated calls to the static filler returns the same
+  // values. So we copy the first filler call to data_0 and the second one to
+  // data_1 and then check whether they are equal.
+  std::vector<TypeParam> data_0, data_1;
+  data_0.resize(count);
+  data_1.resize(count);
+  caffe_copy(count, data, &data_0.front());
+
+  this->filler_->Fill(this->blob_);
+  caffe_copy(count, data, &data_1.front());
+  for (int i = 0; i < count; ++i) {
+    // We do not use EXPECT_FLOAT_EQ because the data must match
+    // bit by bit
+    EXPECT_EQ(data_0[i], data_1[i]);
+  }
 }
 
 template <typename Dtype>
@@ -190,6 +345,72 @@ TYPED_TEST(XavierFillerTest, TestFillAverage) {
 }
 
 template <typename Dtype>
+class XavierStaticFillerTest : public ::testing::Test {
+ protected:
+  XavierStaticFillerTest()
+      : blob_(new Blob<Dtype>(1000, 2, 4, 5)),
+        filler_param_() {
+  }
+  virtual void test_params(FillerParameter_VarianceNorm variance_norm,
+      Dtype n) {
+    this->filler_param_.set_variance_norm(variance_norm);
+    this->filler_.reset(new XavierStaticFiller<Dtype>(this->filler_param_));
+    this->filler_->Fill(blob_);
+    EXPECT_TRUE(this->blob_);
+    const int count = this->blob_->count();
+    const Dtype* data = this->blob_->cpu_data();
+    Dtype mean = 0.;
+    Dtype ex2 = 0.;
+    for (int i = 0; i < count; ++i) {
+      mean += data[i];
+      ex2 += data[i] * data[i];
+    }
+    mean /= count;
+    ex2 /= count;
+    Dtype std = sqrt(ex2 - mean*mean);
+    Dtype target_std = sqrt(2.0 / n);
+    EXPECT_NEAR(mean, 0.0, 0.1);
+    EXPECT_NEAR(std, target_std, 0.1);
+
+    // We want to check that repeated calls to the static
+    // filler returns the same values. So we copy the first
+    // filler call to data_0 and the second one to
+    // data_1 and then check whether they are equal.
+    std::vector<Dtype> data_0, data_1;
+    data_0.resize(count);
+    data_1.resize(count);
+    caffe_copy(count, data, &data_0.front());
+
+    this->filler_->Fill(this->blob_);
+    caffe_copy(count, data, &data_1.front());
+    for (int i = 0; i < count; ++i) {
+      // We do not use EXPECT_FLOAT_EQ because the data must match
+      // bit by bit
+      EXPECT_EQ(data_0[i], data_1[i]);
+    }
+  }
+  virtual ~XavierStaticFillerTest() { delete blob_; }
+  Blob<Dtype>* const blob_;
+  FillerParameter filler_param_;
+  shared_ptr<XavierStaticFiller<Dtype> > filler_;
+};
+
+TYPED_TEST_CASE(XavierStaticFillerTest, TestDtypes);
+
+TYPED_TEST(XavierStaticFillerTest, TestFillFanIn) {
+  TypeParam n = 2*4*5;
+  this->test_params(FillerParameter_VarianceNorm_FAN_IN, n);
+}
+TYPED_TEST(XavierStaticFillerTest, TestFillFanOut) {
+  TypeParam n = 1000*4*5;
+  this->test_params(FillerParameter_VarianceNorm_FAN_OUT, n);
+}
+TYPED_TEST(XavierStaticFillerTest, TestFillAverage) {
+  TypeParam n = (2*4*5 + 1000*4*5) / 2.0;
+  this->test_params(FillerParameter_VarianceNorm_AVERAGE, n);
+}
+
+template <typename Dtype>
 class MSRAFillerTest : public ::testing::Test {
  protected:
   MSRAFillerTest()
@@ -234,6 +455,72 @@ TYPED_TEST(MSRAFillerTest, TestFillFanOut) {
   this->test_params(FillerParameter_VarianceNorm_FAN_OUT, n);
 }
 TYPED_TEST(MSRAFillerTest, TestFillAverage) {
+  TypeParam n = (2*4*5 + 1000*4*5) / 2.0;
+  this->test_params(FillerParameter_VarianceNorm_AVERAGE, n);
+}
+
+template <typename Dtype>
+class MSRAStaticFillerTest : public ::testing::Test {
+ protected:
+  MSRAStaticFillerTest()
+      : blob_(new Blob<Dtype>(1000, 2, 4, 5)),
+        filler_param_() {
+  }
+  virtual void test_params(FillerParameter_VarianceNorm variance_norm,
+      Dtype n) {
+    this->filler_param_.set_variance_norm(variance_norm);
+    this->filler_.reset(new MSRAStaticFiller<Dtype>(this->filler_param_));
+    this->filler_->Fill(blob_);
+    EXPECT_TRUE(this->blob_);
+    const int count = this->blob_->count();
+    const Dtype* data = this->blob_->cpu_data();
+    Dtype mean = 0.;
+    Dtype ex2 = 0.;
+    for (int i = 0; i < count; ++i) {
+      mean += data[i];
+      ex2 += data[i] * data[i];
+    }
+    mean /= count;
+    ex2 /= count;
+    Dtype std = sqrt(ex2 - mean*mean);
+    Dtype target_std = sqrt(2.0 / n);
+    EXPECT_NEAR(mean, 0.0, 0.1);
+    EXPECT_NEAR(std, target_std, 0.1);
+
+    // We want to check that repeated calls to the static
+    // filler returns the same values. So we copy the first
+    // filler call to data_0 and the second one to
+    // data_1 and then check whether they are equal.
+    std::vector<Dtype> data_0, data_1;
+    data_0.resize(count);
+    data_1.resize(count);
+    caffe_copy(count, data, &data_0.front());
+
+    this->filler_->Fill(this->blob_);
+    caffe_copy(count, data, &data_1.front());
+    for (int i = 0; i < count; ++i) {
+      // We do not use EXPECT_FLOAT_EQ because the data must match
+      // bit by bit
+      EXPECT_EQ(data_0[i], data_1[i]);
+    }
+  }
+  virtual ~MSRAStaticFillerTest() { delete blob_; }
+  Blob<Dtype>* const blob_;
+  FillerParameter filler_param_;
+  shared_ptr<MSRAStaticFiller<Dtype> > filler_;
+};
+
+TYPED_TEST_CASE(MSRAStaticFillerTest, TestDtypes);
+
+TYPED_TEST(MSRAStaticFillerTest, TestFillFanIn) {
+  TypeParam n = 2*4*5;
+  this->test_params(FillerParameter_VarianceNorm_FAN_IN, n);
+}
+TYPED_TEST(MSRAStaticFillerTest, TestFillFanOut) {
+  TypeParam n = 1000*4*5;
+  this->test_params(FillerParameter_VarianceNorm_FAN_OUT, n);
+}
+TYPED_TEST(MSRAStaticFillerTest, TestFillAverage) {
   TypeParam n = (2*4*5 + 1000*4*5) / 2.0;
   this->test_params(FillerParameter_VarianceNorm_AVERAGE, n);
 }

--- a/src/caffe/test/test_filler.cpp
+++ b/src/caffe/test/test_filler.cpp
@@ -185,8 +185,7 @@ TYPED_TEST(PositiveUnitballStaticFillerTest, TestFill) {
   std::vector<TypeParam> data_0, data_1;
   data_0.resize(count);
   data_1.resize(count);
-  //caffe_copy(count, data, &data_0.front());
-  caffe_gpu_memcpy(count, data, &data_0.front());
+  caffe_copy(count, data, &data_0.front());
 
   this->filler_->Fill(this->blob_.get());
   caffe_copy(count, data, &data_1.front());

--- a/src/caffe/test/test_filler.cpp
+++ b/src/caffe/test/test_filler.cpp
@@ -73,10 +73,9 @@ class UniformStaticFillerTest : public ::testing::Test {
     filler_param_.set_min(1.);
     filler_param_.set_max(2.);
     filler_.reset(new UniformStaticFiller<Dtype>(filler_param_));
-    filler_->Fill(blob_);
+    filler_->Fill(blob_.get());
   }
-  virtual ~UniformStaticFillerTest() { delete blob_; }
-  Blob<Dtype>* const blob_;
+  shared_ptr<Blob<Dtype> > const blob_;
   FillerParameter filler_param_;
   shared_ptr<UniformStaticFiller<Dtype> > filler_;
 };
@@ -100,7 +99,7 @@ TYPED_TEST(UniformStaticFillerTest, TestFill) {
     EXPECT_LE(data[i], this->filler_param_.max());
   }
 
-  this->filler_->Fill(this->blob_);
+  this->filler_->Fill(this->blob_.get());
   caffe_copy(count, data, &data_1.front());
   for (int i = 0; i < count; ++i) {
     // We do not use EXPECT_FLOAT_EQ because the data must match
@@ -153,10 +152,9 @@ class PositiveUnitballStaticFillerTest : public ::testing::Test {
       : blob_(new Blob<Dtype>(2, 3, 4, 5)),
         filler_param_() {
     filler_.reset(new PositiveUnitballStaticFiller<Dtype>(filler_param_));
-    filler_->Fill(blob_);
+    filler_->Fill(blob_.get());
   }
-  virtual ~PositiveUnitballStaticFillerTest() { delete blob_; }
-  Blob<Dtype>* const blob_;
+  shared_ptr<Blob<Dtype> > const blob_;
   FillerParameter filler_param_;
   shared_ptr<PositiveUnitballStaticFiller<Dtype> > filler_;
 };
@@ -187,9 +185,10 @@ TYPED_TEST(PositiveUnitballStaticFillerTest, TestFill) {
   std::vector<TypeParam> data_0, data_1;
   data_0.resize(count);
   data_1.resize(count);
-  caffe_copy(count, data, &data_0.front());
+  //caffe_copy(count, data, &data_0.front());
+  caffe_gpu_memcpy(count, data, &data_0.front());
 
-  this->filler_->Fill(this->blob_);
+  this->filler_->Fill(this->blob_.get());
   caffe_copy(count, data, &data_1.front());
   for (int i = 0; i < count; ++i) {
     // We do not use EXPECT_FLOAT_EQ because the data must match
@@ -248,10 +247,9 @@ class GaussianStaticFillerTest : public ::testing::Test {
     filler_param_.set_mean(10.);
     filler_param_.set_std(0.1);
     filler_.reset(new GaussianStaticFiller<Dtype>(filler_param_));
-    filler_->Fill(blob_);
+    filler_->Fill(blob_.get());
   }
-  virtual ~GaussianStaticFillerTest() { delete blob_; }
-  Blob<Dtype>* const blob_;
+  shared_ptr<Blob<Dtype> > const blob_;
   FillerParameter filler_param_;
   shared_ptr<GaussianStaticFiller<Dtype> > filler_;
 };
@@ -286,7 +284,7 @@ TYPED_TEST(GaussianStaticFillerTest, TestFill) {
   data_1.resize(count);
   caffe_copy(count, data, &data_0.front());
 
-  this->filler_->Fill(this->blob_);
+  this->filler_->Fill(this->blob_.get());
   caffe_copy(count, data, &data_1.front());
   for (int i = 0; i < count; ++i) {
     // We do not use EXPECT_FLOAT_EQ because the data must match
@@ -355,7 +353,7 @@ class XavierStaticFillerTest : public ::testing::Test {
       Dtype n) {
     this->filler_param_.set_variance_norm(variance_norm);
     this->filler_.reset(new XavierStaticFiller<Dtype>(this->filler_param_));
-    this->filler_->Fill(blob_);
+    this->filler_->Fill(blob_.get());
     EXPECT_TRUE(this->blob_);
     const int count = this->blob_->count();
     const Dtype* data = this->blob_->cpu_data();
@@ -381,7 +379,7 @@ class XavierStaticFillerTest : public ::testing::Test {
     data_1.resize(count);
     caffe_copy(count, data, &data_0.front());
 
-    this->filler_->Fill(this->blob_);
+    this->filler_->Fill(this->blob_.get());
     caffe_copy(count, data, &data_1.front());
     for (int i = 0; i < count; ++i) {
       // We do not use EXPECT_FLOAT_EQ because the data must match
@@ -389,8 +387,7 @@ class XavierStaticFillerTest : public ::testing::Test {
       EXPECT_EQ(data_0[i], data_1[i]);
     }
   }
-  virtual ~XavierStaticFillerTest() { delete blob_; }
-  Blob<Dtype>* const blob_;
+  shared_ptr<Blob<Dtype> > const blob_;
   FillerParameter filler_param_;
   shared_ptr<XavierStaticFiller<Dtype> > filler_;
 };
@@ -470,8 +467,8 @@ class MSRAStaticFillerTest : public ::testing::Test {
       Dtype n) {
     this->filler_param_.set_variance_norm(variance_norm);
     this->filler_.reset(new MSRAStaticFiller<Dtype>(this->filler_param_));
-    this->filler_->Fill(blob_);
-    EXPECT_TRUE(this->blob_);
+    this->filler_->Fill(blob_.get());
+    EXPECT_TRUE(this->blob_.get());
     const int count = this->blob_->count();
     const Dtype* data = this->blob_->cpu_data();
     Dtype mean = 0.;
@@ -496,7 +493,7 @@ class MSRAStaticFillerTest : public ::testing::Test {
     data_1.resize(count);
     caffe_copy(count, data, &data_0.front());
 
-    this->filler_->Fill(this->blob_);
+    this->filler_->Fill(this->blob_.get());
     caffe_copy(count, data, &data_1.front());
     for (int i = 0; i < count; ++i) {
       // We do not use EXPECT_FLOAT_EQ because the data must match
@@ -504,8 +501,7 @@ class MSRAStaticFillerTest : public ::testing::Test {
       EXPECT_EQ(data_0[i], data_1[i]);
     }
   }
-  virtual ~MSRAStaticFillerTest() { delete blob_; }
-  Blob<Dtype>* const blob_;
+  shared_ptr<Blob<Dtype> > const blob_;
   FillerParameter filler_param_;
   shared_ptr<MSRAStaticFiller<Dtype> > filler_;
 };


### PR DESCRIPTION
Added a new Gaussian dummy layer class which is 3-4x faster than the current Gaussian dummy layer. The new class is called GaussianStatic which only calls RNG once and stores the results into a private member of the class called GaussianStaticFillerdata. Follow up calls to the Filler function will by pass the RNG part which speeds up the function.
