### PR TITLE
Disable FindEx if cuDNN is older than v5

### DIFF
--- a/include/caffe/layers/cudnn_conv_layer.hpp
+++ b/include/caffe/layers/cudnn_conv_layer.hpp
@@ -69,9 +69,11 @@ class CuDNNConvolutionLayer : public ConvolutionLayer<Dtype> {
  private:
   bool use_algo_seeker_;
   bool use_modest_workspace_;
+#if CUDNN_VERSION_MIN(5, 0, 0)
   void FindExConvAlgo(const vector<Blob<Dtype>*>& bottom,
                       const vector<Blob<Dtype>*>& top,
                       const size_t workspace_bytes);
+#endif
   void GetConvAlgo(const vector<Blob<Dtype>*>& bottom,
                    const vector<Blob<Dtype>*>& top,
                    const size_t workspace_bytes);


### PR DESCRIPTION
- cuDNN v5 introduced FindEx.
- cuDNN v4 is supported by Caffe.
- This PR makes sure if Caffe is compiled against cuDNN v4, then it doesn't use FindEx and it only uses Get to set the best convolution algorithms.
