### PR TITLE
Multi-GPU support for the GPUMemory::Workspace

### DIFF
--- a/include/caffe/layers/cudnn_conv_layer.hpp
+++ b/include/caffe/layers/cudnn_conv_layer.hpp
@@ -46,7 +46,7 @@ class CuDNNConvolutionLayer : public ConvolutionLayer<Dtype> {
   // This is the workspace used by all Convolution layers one after another.
   // We carry it global to prevent unnecessary allocations/deallocations
   // because they hurt performance.
-  static GPUMemory::Workspace WORKSPACE;
+  static GPUMemory::MultiWorkspace WORKSPACE;
 
  public:
   explicit CuDNNConvolutionLayer(const LayerParameter& param)
@@ -114,7 +114,7 @@ const size_t CuDNNConvolutionLayer<Dtype>::INITIAL_WORKSPACE_SIZE =
     4*1024*1024;
 
 template<typename Dtype>
-GPUMemory::Workspace CuDNNConvolutionLayer<Dtype>::WORKSPACE;
+GPUMemory::MultiWorkspace CuDNNConvolutionLayer<Dtype>::WORKSPACE;
 
 template<typename Dtype>
 const float CuDNNConvolutionLayer<Dtype>::MAX_WORKSPACE_RATIO = 0.95F;

--- a/src/caffe/layers/cudnn_conv_layer.cpp
+++ b/src/caffe/layers/cudnn_conv_layer.cpp
@@ -90,8 +90,6 @@ void CuDNNConvolutionLayer<Dtype>::LayerSetUp(
   use_reshape_ = true;
   // When true, cached bottom and conv descriptors need to be set.
   initialized_cached_descs_ = false;
-  // In case of reusing it
-  WORKSPACE.release();
 }
 
 template <typename Dtype>


### PR DESCRIPTION
For performance reasons, we recently introduced global workspace used by CuDNNConvolutionLayer. It boosted performance well, now we need to add multi-GPU support. GPUMenory::MultiWorkspace class added.
