### PR TITLE
Only print learning rate once for multi-GPU solver

### DIFF
--- a/src/caffe/solvers/sgd_solver.cpp
+++ b/src/caffe/solvers/sgd_solver.cpp
@@ -101,7 +101,8 @@ void SGDSolver<Dtype>::ClipGradients() {
 template <typename Dtype>
 void SGDSolver<Dtype>::ApplyUpdate() {
   Dtype rate = GetLearningRate();
-  if (this->param_.display() && this->iter_ % this->param_.display() == 0) {
+  if (Caffe::root_solver() && this->param_.display() &&
+      this->iter_ % this->param_.display() == 0) {
     LOG(INFO) << "Iteration " << this->iter_ << ", lr = " << rate;
   }
   ClipGradients();


### PR DESCRIPTION
It's getting printed twice per iteration:

```
I0627 13:02:45.109439 26101 solver.cpp:242] Iteration 0 (0 iter/s, 0.805844s/79 iter), loss = 2.72706
I0627 13:02:45.109462 26101 solver.cpp:261]     Train net output #0: loss = 2.72706 (* 1 = 2.72706 loss)
I0627 13:02:45.109465 26141 sgd_solver.cpp:105] Iteration 0, lr = 0.01
I0627 13:02:45.109472 26101 sgd_solver.cpp:105] Iteration 0, lr = 0.01
I0627 13:02:45.362319 26101 solver.cpp:242] Iteration 79 (312.443 iter/s, 0.252846s/79 iter), loss = 0.353703
I0627 13:02:45.362350 26101 solver.cpp:261]     Train net output #0: loss = 0.353703 (* 1 = 0.353703 loss)
I0627 13:02:45.362349 26141 sgd_solver.cpp:105] Iteration 79, lr = 0.01
I0627 13:02:45.362359 26101 sgd_solver.cpp:105] Iteration 79, lr = 0.01
I0627 13:02:45.519508 26101 solver.cpp:242] Iteration 158 (502.707 iter/s, 0.157149s/79 iter), loss = 0.141178
I0627 13:02:45.519534 26141 sgd_solver.cpp:105] Iteration 158, lr = 0.01
I0627 13:02:45.519539 26101 solver.cpp:261]     Train net output #0: loss = 0.141178 (* 1 = 0.141178 loss)
I0627 13:02:45.519577 26101 sgd_solver.cpp:105] Iteration 158, lr = 0.01
```

That's unnecessary, and also breaks DIGITS's [brittle] log parsing.
