### PR TITLE
Fix restoring global Caffe state after running CommonTest

### DIFF
--- a/src/caffe/test/test_common.cpp
+++ b/src/caffe/test/test_common.cpp
@@ -21,10 +21,12 @@ TEST_F(CommonTest, TestCublasHandlerGPU) {
 #endif
 
 TEST_F(CommonTest, TestBrewMode) {
+  Caffe::Brew current_mode = Caffe::mode();
   Caffe::set_mode(Caffe::CPU);
   EXPECT_EQ(Caffe::mode(), Caffe::CPU);
   Caffe::set_mode(Caffe::GPU);
   EXPECT_EQ(Caffe::mode(), Caffe::GPU);
+  Caffe::set_mode(current_mode);
 }
 
 TEST_F(CommonTest, TestRandSeedCPU) {


### PR DESCRIPTION
Removed: https://travis-ci.org/NVIDIA/caffe/jobs/141243108
