### PR TITLE
Inform that CMake is downloading CUB headers

### DIFF
--- a/3rdparty/getCUB.sh
+++ b/3rdparty/getCUB.sh
@@ -4,6 +4,7 @@ GITHUBURL="https://raw.githubusercontent.com/NVlabs/cub"
 TARGETDIR=3rdparty
 mkdir -p $TARGETDIR/cub
 mkdir -p $TARGETDIR/cub/host
+echo -n "-- Downloading CUB headers... "
 for CUH in \
   cub/util_allocator.cuh \
   cub/util_arch.cuh \
@@ -13,5 +14,6 @@ for CUH in \
 do
   wget -q -N -O $TARGETDIR/$CUH $GITHUBURL/$VERSION/$CUH || exit 1
 done
+echo "done!"
 exit 0
 


### PR DESCRIPTION
I was wanting to test DetectNet (using DIGITS 4.1 + Caffe-NV 0.15.7, I had Caffe-NV 0.14) and CMake was just hanging on:

```
-- ...
-- Install:
--   Install path      :   {caffe-nv-home}/build/install
-- 
```

And nothing happened. Firstly, I thought it could be something wrong I was doing, but after reading the commit history (and many many other checks, such as cuDNN version, CUDA version, other dependencies, etc.), I noticed something: a download was added from to `0.15.1` (d02894534b5763c7dc749e2c4fa654f421363fa2). This PR (very small change) is just to inform users that a download is in progress. This could have saved me some hours, and I think there is no loss adding it. The output would be:

```
-- ...
-- Install:
--   Install path      :   {caffe-nv-home}/build/install
-- 
-- Downloading CUB headers... done!
```

---

Additional info:
At my university, we can only access internet using based on individual authentication. Therefore, shared resources (such as a machine that I use with a Tesla K40), usually, are not connected to the internet and need to be authenticated beforehand by the user that wants this access. That said, this PR comes to inform the user that the CMake is attempting to downloading something, because otherwise it just hangs.
