### PR TITLE
DetectNet: rename image crop parameter

### DIFF
--- a/examples/kitti/detectnet_network.prototxt
+++ b/examples/kitti/detectnet_network.prototxt
@@ -76,8 +76,8 @@ layer {
     coverage_type: RECTANGULAR
     min_cvg_len: 20
     obj_norm: true
-    image_size_x: 1248
-    image_size_y: 384
+    crop_size_x: 1248
+    crop_size_y: 384
     crop_bboxes: true
     object_class: { src: 1 dst: 0} # obj class 1 -> cvg index 0
   }
@@ -115,8 +115,8 @@ layer {
     coverage_type: RECTANGULAR
     min_cvg_len: 20
     obj_norm: true
-    image_size_x: 1248
-    image_size_y: 384
+    crop_size_x: 1248
+    crop_size_y: 384
     crop_bboxes: false
     object_class: { src: 1 dst: 0} # obj class 1 -> cvg index 0
   }

--- a/src/caffe/layers/detectnet_transform_layer.cpp
+++ b/src/caffe/layers/detectnet_transform_layer.cpp
@@ -126,8 +126,8 @@ void DetectNetTransformationLayer<Dtype>::Reshape(
   top[0]->Reshape(
       bottom[0]->num(),
       bottom[0]->channels(),
-      g_param_.image_size_y(),
-      g_param_.image_size_x());
+      g_param_.crop_size_y(),
+      g_param_.crop_size_x());
   // resize tensor output layer: (never changes /wrt input blobs)
   Vec3i tensorDimensions = coverage_->dimensions();
   top[1]->Reshape(
@@ -337,8 +337,8 @@ void DetectNetTransformationLayer<Dtype>::transform(
     Mat3v* img_aug,
     Dtype* transformed_label
 ) {
-  uint32_t image_x = g_param_.image_size_x();
-  uint32_t image_y = g_param_.image_size_y();
+  uint32_t image_x = g_param_.crop_size_x();
+  uint32_t image_y = g_param_.crop_size_y();
 
   // Perform mean subtraction on un-augmented image:
   Mat3v img_temp = img.clone();  // size determined by scale
@@ -469,7 +469,7 @@ Point DetectNetTransformationLayer<Dtype>::augmentation_crop(
     vector<BboxLabel >* bboxList_aug
 ) {
   bool doCrop = randDouble() <= a_param_.crop_prob();
-  Size2i crop(g_param_.image_size_x(), g_param_.image_size_y());
+  Size2i crop(g_param_.crop_size_x(), g_param_.crop_size_y());
   Size2i shift(a_param_.shift_x(), a_param_.shift_y());
   Size2i imgSize(img_src.cols, img_src.rows);
   Point2i offset, inner, outer;

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -466,8 +466,8 @@ message DetectNetGroundTruthParameter {
   optional CoverageType coverage_type = 7 [default = RECTANGULAR];
   // Size that incoming images are cropped / scaled to during training / test
   //  time. The network will only see images of this size.
-  optional uint32 image_size_x = 8 [default = 1248];
-  optional uint32 image_size_y = 9 [default = 384];
+  optional uint32 crop_size_x = 8 [default = 1248];
+  optional uint32 crop_size_y = 9 [default = 384];
   // coverage proportional to the size of the gridbox region overlapping the
   // normalize object coverage by the size of the object
   optional bool obj_norm = 11 [default = false];

--- a/src/caffe/util/detectnet_coverage_rectangular.cpp
+++ b/src/caffe/util/detectnet_coverage_rectangular.cpp
@@ -42,7 +42,7 @@ template<typename Dtype>
 CoverageGenerator<Dtype>::CoverageGenerator(
     const DetectNetGroundTruthParameter& param
 ) : param_(param),
-    imageROI_(0, 0, (Dtype) param.image_size_x(), (Dtype) param.image_size_y()),
+    imageROI_(0, 0, (Dtype) param.crop_size_x(), (Dtype) param.crop_size_y()),
     gridROI_(
       imageROI_.tl()   * (Dtype)(1.0 / param.stride()),
       imageROI_.size() * (Dtype)(1.0 / param.stride())),


### PR DESCRIPTION
Rename parameter from image_size_[x|y] to crop_size_[x|y]
