### PR TITLE
Fix Python installation with CMake install target

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -22,13 +22,19 @@ if(UNIX OR APPLE)
 endif()
 
 # ---[ Install
-file(GLOB files1 *.py requirements.txt)
-install(FILES ${files1} DESTINATION python)
+# scripts
+file(GLOB python_files *.py requirements.txt)
+install(FILES ${python_files} DESTINATION python)
 
-file(GLOB files2 caffe/*.py)
-install(FILES  ${files2} DESTINATION python/caffe)
+# module
+install(DIRECTORY caffe
+    DESTINATION python
+    FILES_MATCHING
+    PATTERN "*.py"
+    PATTERN "ilsvrc_2012_mean.npy"
+    PATTERN "test" EXCLUDE
+    )
+
+# _caffe.so
 install(TARGETS pycaffe  DESTINATION python/caffe)
-install(DIRECTORY caffe/imagenet caffe/proto caffe/test DESTINATION python/caffe)
-
-
 


### PR DESCRIPTION
- Stop installing the `test` directory
- Stop installing `*.pyc` files
- Install Python layers from https://github.com/NVIDIA/caffe/pull/144

Before:

```
install/python/
├── caffe/
│   ├── _caffe.so
│   ├── classifier.py
│   ├── coord_map.py
│   ├── detector.py
│   ├── draw.py
│   ├── imagenet/
│   │   └── ilsvrc_2012_mean.npy
│   ├── __init__.py
│   ├── io.py
│   ├── net_spec.py
│   ├── proto/
│   │   ├── caffe_pb2.py
│   │   └── __init__.py
│   ├── pycaffe.py
│   └── test/
│       ├── test_coord_map.py
│       ├── test_coord_map.pyc
│       ├── test_io.py
│       ├── test_io.pyc
│       ├── test_layer_type_list.py
│       ├── test_layer_type_list.pyc
│       ├── test_net.py
│       ├── test_net.pyc
│       ├── test_net_spec.py
│       ├── test_net_spec.pyc
│       ├── test_python_layer.py
│       ├── test_python_layer.pyc
│       ├── test_python_layer_with_param_str.py
│       ├── test_python_layer_with_param_str.pyc
│       ├── test_solver.py
│       └── test_solver.pyc
├── classify.py
├── detect.py
├── draw_net.py
└── requirements.txt
```

After:

```
install/python/
├── caffe/
│   ├── _caffe.so
│   ├── classifier.py
│   ├── coord_map.py
│   ├── detector.py
│   ├── draw.py
│   ├── imagenet/
│   │   └── ilsvrc_2012_mean.npy
│   ├── __init__.py
│   ├── io.py
│   ├── layers/
│   │   ├── detectnet/
│   │   │   ├── clustering.py
│   │   │   ├── __init__.py
│   │   │   └── mean_ap.py
│   │   └── __init__.py
│   ├── net_spec.py
│   ├── proto/
│   │   ├── caffe_pb2.py
│   │   └── __init__.py
│   └── pycaffe.py
├── classify.py
├── detect.py
├── draw_net.py
└── requirements.txt
```
