### PR TITLE
[DetectNetTransformation] Use 0 for background value instead of -0.5

### DIFF
--- a/src/caffe/layers/detectnet_transform_layer.cpp
+++ b/src/caffe/layers/detectnet_transform_layer.cpp
@@ -358,7 +358,7 @@ void DetectNetTransformationLayer<Dtype>::transform(
     // mean subtraction must occur after color augmentations as colorshift
     //  outside of 0..1 invalidates scale
     meanSubtract(&img_temp);
-    // images now bounded from -0.5...0.5
+    // images now bounded from [-1,1] (range is dependent on mean subtraction)
     as.scale = augmentation_scale(img_temp, img_aug, bboxlist, &bboxlist_aug);
     as.degree =
         augmentation_rotate(*img_aug, &img_temp, bboxlist_aug, &bboxlist_aug);
@@ -536,7 +536,7 @@ void DetectNetTransformationLayer<Dtype>::transform_crop(
     // construct a destination matrix:
     *img_dst = Mat3v(dst_size);
     // and fill with black:
-    img_dst->setTo(Scalar(-0.5, -0.5, -0.5));
+    img_dst->setTo(Scalar(0, 0, 0));
 
     // define destinationROI inside of destination mat:
     Mat3v destinationROI = (*img_dst)(dst_rect);
@@ -652,7 +652,7 @@ float DetectNetTransformationLayer<Dtype>::augmentation_rotate(
     // construct a destination matrix large enough to contain the rotated image:
     *img_aug = Mat3v(boundingSize);
     // and fill with black:
-    img_aug->setTo(Scalar(-0.5, -0.5, -0.5));
+    img_aug->setTo(Scalar(0, 0, 0));
     // warp old image into new buffer, maintaining the background:
     warpAffine(
         img_src,


### PR DESCRIPTION
[Data starts in [0,1]](https://github.com/NVIDIA/caffe/blob/v0.15.9/src/caffe/layers/detectnet_transform_layer.cpp#L345-L347). For typical mean values, the range is then transformed into [-0.5, 0.5]. So the background was chosen to be black, or -0.5.

But this doesn't make much sense if you have no mean subtraction at all. Then your image range is [0,1] but the background is outside that range at -0.5. When you display the resulting image, you can see that the background is too negative (that's why the image is washed out):

![before-0-cpu-train](https://cloud.githubusercontent.com/assets/687269/17752796/51fa715a-6482-11e6-9fd9-08d4157a0b55.jpg)

After this pull request, the background is in a valid range for all reasonable mean values. And you can effectively choose your background color based on the mean value chosen.

**mean_value: 0**
image range is [1,0] so 0 is relatively black
![0-cpu-train](https://cloud.githubusercontent.com/assets/687269/17752818/6feaed2a-6482-11e6-9e6a-bf6f2d327c5d.jpg)

**mean_value: 127**
image range is [0.5, -0.5] so 0 is relatively gray (**typical case**)
![127-cpu-train](https://cloud.githubusercontent.com/assets/687269/17752825/79c3af30-6482-11e6-8ac3-6cbaf2b919e1.jpg)

**mean_value: 255**
image range is [0, -1] so 0 is relatively white
![255-cpu-train](https://cloud.githubusercontent.com/assets/687269/17752827/806d4b98-6482-11e6-85e0-17924f9f301e.jpg)
