### PR TITLE
Fix for broken DataLayerTest/2.TestReshapeLevelDB test

### DIFF
--- a/include/caffe/layers/cudnn_lcn_layer.hpp
+++ b/include/caffe/layers/cudnn_lcn_layer.hpp
@@ -41,7 +41,7 @@ class CuDNNLCNLayer : public LRNLayer<Dtype> {
   Dtype alpha_, beta_, k_;
 
   size_t tempDataSize_;
-  GPUMemory::Workspace temp1_, temp2_;
+  GPUMemory::MultiWorkspace temp1_, temp2_;
 };
 #endif
 

--- a/include/caffe/syncedmem.hpp
+++ b/include/caffe/syncedmem.hpp
@@ -72,7 +72,13 @@ class SyncedMemory {
   size_t size() { return size_; }
 
 #ifndef CPU_ONLY
-  void async_gpu_push(const cudaStream_t& stream);
+  cudaStream_t stream() const {
+    return stream_;
+  }
+  int gpu_device() const {
+    return gpu_device_;
+  }
+  void async_gpu_push();
 #endif
 
  private:

--- a/src/caffe/layers/base_data_layer.cpp
+++ b/src/caffe/layers/base_data_layer.cpp
@@ -74,21 +74,14 @@ void BasePrefetchingDataLayer<Dtype>::LayerSetUp(
 
 template <typename Dtype>
 void BasePrefetchingDataLayer<Dtype>::InternalThreadEntry() {
-#ifndef CPU_ONLY
-  cudaStream_t stream;
-  if (Caffe::mode() == Caffe::GPU) {
-    CUDA_CHECK(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking));
-  }
-#endif
-
   try {
     while (!must_stop()) {
       Batch<Dtype>* batch = prefetch_free_.pop();
       load_batch(batch);
 #ifndef CPU_ONLY
       if (Caffe::mode() == Caffe::GPU) {
-        batch->data_.data().get()->async_gpu_push(stream);
-        CUDA_CHECK(cudaStreamSynchronize(stream));
+        batch->data_.data()->async_gpu_push();
+        CUDA_CHECK(cudaStreamSynchronize(batch->data_.data()->stream()));
       }
 #endif
       prefetch_full_.push(batch);
@@ -96,11 +89,6 @@ void BasePrefetchingDataLayer<Dtype>::InternalThreadEntry() {
   } catch (boost::thread_interrupted&) {
     // Interrupted exception is expected on shutdown
   }
-#ifndef CPU_ONLY
-  if (Caffe::mode() == Caffe::GPU) {
-    CUDA_CHECK(cudaStreamDestroy(stream));
-  }
-#endif
 }
 
 template <typename Dtype>

--- a/src/caffe/layers/cudnn_lcn_layer.cu
+++ b/src/caffe/layers/cudnn_lcn_layer.cu
@@ -10,12 +10,8 @@ void CuDNNLCNLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
     const vector<Blob<Dtype>*>& top) {
   const Dtype* bottom_data = bottom[0]->gpu_data();
   Dtype* top_data = top[0]->mutable_gpu_data();
-
-  int device;
-  CUDA_CHECK(cudaGetDevice(&device));
-  cudaStream_t stream = GPUMemory::device_stream(device);
-  temp1_.reserve(tempDataSize_, device, stream);
-  temp2_.reserve(tempDataSize_, device, stream);
+  temp1_.reserve(tempDataSize_);
+  temp2_.reserve(tempDataSize_);
 
   CUDNN_CHECK(cudnnDivisiveNormalizationForward(
         Caffe::cudnn_handle(), norm_desc_, CUDNN_DIVNORM_PRECOMPUTED_MEANS,
@@ -37,12 +33,8 @@ void CuDNNLCNLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
   const Dtype* top_data = top[0]->gpu_data();
   const Dtype* bottom_data = bottom[0]->gpu_data();
   Dtype* bottom_diff = bottom[0]->mutable_gpu_diff();
-
-  int device;
-  CUDA_CHECK(cudaGetDevice(&device));
-  cudaStream_t stream = GPUMemory::device_stream(device);
-  temp1_.reserve(tempDataSize_, device, stream);
-  temp2_.reserve(tempDataSize_, device, stream);
+  temp1_.reserve(tempDataSize_);
+  temp2_.reserve(tempDataSize_);
 
   CUDNN_CHECK(cudnnDivisiveNormalizationBackward(
         Caffe::cudnn_handle(), norm_desc_,


### PR DESCRIPTION
```
BasePrefetchingDataLayer<Dtype>::InternalThreadEntry()
```

used to destroy the stream it created. The problem is that the same stream was given to CUB via 

```
batch->data_.data().get()->async_gpu_push(stream);
```

call. CUB uses streams for housekeeping. Apparently, dead stream in deallocation flow did make CUB unhappy. This fix was followed by few subsequent clean up changes.
Besides that:
- Single-GPU `Workspace` was replaced by multi-GPU `MultiWorkspace` (one spot was missed in LCN last time).
- `SyncedMemory` now fully encapsulates current device and maintains the stream used for allocation (see changes in `SyncedMemory::async_gpu_push`).
