### PR TITLE
fix comment in pruneBboxes()

### DIFF
--- a/src/caffe/util/detectnet_coverage_rectangular.cpp
+++ b/src/caffe/util/detectnet_coverage_rectangular.cpp
@@ -111,7 +111,7 @@ CoverageGenerator<Dtype>::pruneBboxes(
   foreach_(BboxLabel cLabel, bboxList) {
     // crop bounding boxes to the dimensions of the screen:
     if (this->param_.crop_bboxes()) {
-      // truncated bbox is the union of bounding box and screen rectangle, and
+      // truncated bbox is the intersection between the bounding box and screen rectangle, and
       //  is always smaller than cLabel.bbox:
       Rectv croppedBbox = cLabel.bbox & this->imageROI_;
       // truncation is the area of the intersection over the whole:


### PR DESCRIPTION
croppedBbox is the intersection between the original bounding box and the screen rectangle. the comment falsely say that it is the union.
