### PR TITLE
Minor comment fix in pruneBboxes()

### DIFF
--- a/src/caffe/util/detectnet_coverage_rectangular.cpp
+++ b/src/caffe/util/detectnet_coverage_rectangular.cpp
@@ -111,8 +111,8 @@ CoverageGenerator<Dtype>::pruneBboxes(
   foreach_(BboxLabel cLabel, bboxList) {
     // crop bounding boxes to the dimensions of the screen:
     if (this->param_.crop_bboxes()) {
-      // truncated bbox is the union of bounding box and screen rectangle, and
-      //  is always smaller than cLabel.bbox:
+      // truncated bbox is the intersection of bounding box and screen rectangle
+      //  , and is always smaller than cLabel.bbox:
       Rectv croppedBbox = cLabel.bbox & this->imageROI_;
       // truncation is the area of the intersection over the whole:
       Dtype truncation = 1.0 - std::max(cLabel.truncated, (Dtype)0.0);


### PR DESCRIPTION
In pruneBboxes(), croppedBbox is the intersection between the bounding box and the screen rectangle. But the comment stated it is the union.
