### PR TITLE
IoU threshold and MAX_BOXES in the .prototxt

### DIFF
--- a/python/caffe/layers/detectnet/mean_ap.py
+++ b/python/caffe/layers/detectnet/mean_ap.py
@@ -2,8 +2,6 @@ import numpy as np
 
 import caffe
 
-MAX_BOXES = 50
-
 
 class ScoreDetections(caffe.Layer):
     """
@@ -46,8 +44,9 @@ class ScoreDetections(caffe.Layer):
 
     def reshape(self, bottom, top):
         n_images = bottom[0].data.shape[0]
-        # Assuming that max booxes per image are MAX_BOXES
-        top[0].reshape(n_images, MAX_BOXES, 5)
+        max_boxes = bottom[0].data.shape[1]
+        # Assuming that max boxes per image are MAX_BOXES
+        top[0].reshape(n_images, max_boxes, 5)
         assert(bottom[0].data.shape[0] == bottom[1].data.shape[0]), "# of images not matching!"
 
     def forward(self, bottom, top):
@@ -125,6 +124,7 @@ def divide_zero_is_zero(a, b):
 
 
 def score_det(gt_bbox_list, det_bbox_list, threshold):
+    MAX_BOXES = gt_bbox_list.shape[1]
     matched_bbox = np.zeros([gt_bbox_list.shape[0], MAX_BOXES, 5])
 
     for k in range(gt_bbox_list.shape[0]):

--- a/python/caffe/layers/detectnet/mean_ap.py
+++ b/python/caffe/layers/detectnet/mean_ap.py
@@ -28,13 +28,21 @@ class ScoreDetections(caffe.Layer):
         python_param {
             module: 'caffe.layers.detectnet.mean_ap'
             layer: 'ScoreDetections'
+            # parameter - IoU threshold (optional - default: 0.7)
+            param_str: '0.7'
         }
         include: { phase: TEST }
     }
     """
+    
 
     def setup(self, bottom, top):
-        pass
+        # Default IoU threshold
+        self.iou_threshold = 0.7 
+        try:
+            self.iou_threshold = float(self.param_str)
+        except:
+            pass
 
     def reshape(self, bottom, top):
         n_images = bottom[0].data.shape[0]
@@ -43,7 +51,7 @@ class ScoreDetections(caffe.Layer):
         assert(bottom[0].data.shape[0] == bottom[1].data.shape[0]), "# of images not matching!"
 
     def forward(self, bottom, top):
-        bbox_list = score_det(bottom[0].data, bottom[1].data)
+        bbox_list = score_det(bottom[0].data, bottom[1].data, self.iou_threshold)
         top[0].data[...] = bbox_list
 
     def backward(self, top, propagate_down, bottom):
@@ -71,8 +79,6 @@ class mAP(caffe.Layer):
         python_param {
             module: 'caffe.layers.detectnet.mean_ap'
             layer: 'mAP'
-            # parameters - img_size_x, img_size_y, stride
-            param_str : '1248,352,16'
         }
         include: { phase: TEST }
     }
@@ -118,8 +124,7 @@ def divide_zero_is_zero(a, b):
     return float(a)/float(b) if b != 0 else 0
 
 
-def score_det(gt_bbox_list, det_bbox_list):
-    threshold = 0.7
+def score_det(gt_bbox_list, det_bbox_list, threshold):
     matched_bbox = np.zeros([gt_bbox_list.shape[0], MAX_BOXES, 5])
 
     for k in range(gt_bbox_list.shape[0]):


### PR DESCRIPTION
This PR aims to:
- Add IoU threshold to the `.prototxt`
- Add MAX_BOXES to the `.prototxt`

The default value of the IoU threshold on the DetectNet is 0.7. This PR allows users to set it on the `.prototxt`. For instance, in the [German Traffic Sign Detection Benchmark](http://ieeexplore.ieee.org/stamp/stamp.jsp?arnumber=6706807) the threshold is 0.6. Also, users might want to change the MAX_BOXES (#228). This PR also allows them to set it on the `.prototxt`.

In both cases, the parameters are optional and their default remains 0.7 (IoU threshold) and 50 (MAX_BOXES) respectively. Which means, it doesn't break previous setups (backward compatibility). Docstrings were also updated.
