### PR TITLE
Fixed build failure on power arch by replacing pause instruction with…

### DIFF
--- a/3rdparty/cub/host/mutex.cuh
+++ b/3rdparty/cub/host/mutex.cuh
@@ -121,9 +121,13 @@ struct Mutex
          */
         __forceinline__ void YieldProcessor()
         {
-        #ifndef __arm__
-                asm volatile("pause\n": : :"memory");
-        #endif  // __arm__
+            #if defined(__powerpc64__) || defined(__powerpc__)
+                asm volatile("or 27,27,27\n": : :"memory");
+            #else
+                #ifndef __arm__
+                    asm volatile("pause\n": : :"memory");
+                #endif  //__arm__
+            #endif //__powerpc64__
         }
 
     #endif  // defined(_MSC_VER)


### PR DESCRIPTION
… or 27,27,27
