### PR TITLE
[DetectNetTransform] Build with GPU and w/o OpenCV

### DIFF
--- a/src/caffe/layers/detectnet_transform_layer.cu
+++ b/src/caffe/layers/detectnet_transform_layer.cu
@@ -1,3 +1,5 @@
+#ifdef USE_OPENCV
+
 #include <math.h>
 #include <math_constants.h>
 #include <opencv2/core/core.hpp>
@@ -430,3 +432,5 @@ INSTANTIATE_LAYER_GPU_FUNCS(DetectNetTransformationLayer);
 
 
 }  // namespace caffe
+
+#endif


### PR DESCRIPTION
Fix bug where you can't build with `-DUSE_CUDA=On -DUSE_OPENCV=Off` (which isn't tested with TravisCI).

Thanks to @thatguymike for reporting. Will you verify the fix before merge?
