### PR TITLE
Solve the bug of dead lock when restore state 

### DIFF
--- a/include/caffe/common.hpp
+++ b/include/caffe/common.hpp
@@ -166,6 +166,8 @@ class Caffe {
   inline static void set_solver_count(int val) { Get().solver_count_ = val; }
   inline static bool root_solver() { return Get().root_solver_; }
   inline static void set_root_solver(bool val) { Get().root_solver_ = val; }
+  inline static int restored_iter() { return restored_iter_; }
+  inline static void set_restored_iter(int val) { restored_iter_ = val; }
 
  protected:
 #ifndef CPU_ONLY
@@ -180,6 +182,7 @@ class Caffe {
   Brew mode_;
   int solver_count_;
   bool root_solver_;
+  static int restored_iter_;
 
  private:
   // The private constructor to avoid duplicate instantiation.

--- a/src/caffe/common.cpp
+++ b/src/caffe/common.cpp
@@ -12,7 +12,7 @@ namespace caffe {
 // Make sure each thread can have different values.
 static boost::thread_specific_ptr<Caffe> thread_instance_;
 int  Caffe::restored_iter_;
-  
+
 Caffe& Caffe::Get() {
   if (!thread_instance_.get()) {
     thread_instance_.reset(new Caffe());

--- a/src/caffe/common.cpp
+++ b/src/caffe/common.cpp
@@ -11,7 +11,8 @@ namespace caffe {
 
 // Make sure each thread can have different values.
 static boost::thread_specific_ptr<Caffe> thread_instance_;
-
+int  Caffe::restored_iter_;
+  
 Caffe& Caffe::Get() {
   if (!thread_instance_.get()) {
     thread_instance_.reset(new Caffe());

--- a/src/caffe/solver.cpp
+++ b/src/caffe/solver.cpp
@@ -192,10 +192,10 @@ void Solver<Dtype>::InitTestNets() {
 
 template <typename Dtype>
 void Solver<Dtype>::Step(int iters) {
-  if(!Caffe::root_solver()) {
-    // fix the start iter_ for slave solver when the 
-    // root solver restore state from binary file 
-    // this will cause deadlock when using NCCL 
+  if (!Caffe::root_solver()) {
+    // fix the start iter_ for slave solver when the
+    // root solver restore state from binary file
+    // this will cause deadlock when using NCCL
     iter_ = Caffe::restored_iter();
   }
   const int start_iter = iter_;

--- a/src/caffe/solver.cpp
+++ b/src/caffe/solver.cpp
@@ -192,6 +192,12 @@ void Solver<Dtype>::InitTestNets() {
 
 template <typename Dtype>
 void Solver<Dtype>::Step(int iters) {
+  if(!Caffe::root_solver()) {
+    // fix the start iter_ for slave solver when the 
+    // root solver restore state from binary file 
+    // this will cause deadlock when using NCCL 
+    iter_ = Caffe::restored_iter();
+  }
   const int start_iter = iter_;
   const int stop_iter = iter_ + iters;
   int average_loss = this->param_.average_loss();

--- a/src/caffe/solvers/sgd_solver.cpp
+++ b/src/caffe/solvers/sgd_solver.cpp
@@ -307,6 +307,7 @@ void SGDSolver<Dtype>::RestoreSolverStateFromBinaryProto(
   SolverState state;
   ReadProtoFromBinaryFile(state_file, &state);
   this->iter_ = state.iter();
+  Caffe::set_restored_iter(state.iter());
   if (state.has_learned_net()) {
     NetParameter net_param;
     ReadNetParamsFromBinaryFileOrDie(state.learned_net().c_str(), &net_param);


### PR DESCRIPTION
Fix the start iter_ for slave solver when the root solver restore state from binary file .
This will cause deadlock when using NCCL 
