### PR TITLE
[Debuild] Add missing python-h5py dependency

### DIFF
--- a/packaging/deb/templates/control
+++ b/packaging/deb/templates/control
@@ -59,6 +59,7 @@ Section: universe/python
 Depends: ${misc:Depends}, ${shlibs:Depends}, libcaffe-nv0 (= ${binary:Version}),
     cython,
     python,
+    python-h5py,
     python-numpy,
     python-opencv,
     python-pil,


### PR DESCRIPTION
*(bug  1856679)*