### PR TITLE
Fixes IoU calculation - off by 1 bug

### DIFF
--- a/python/caffe/layers/detectnet/mean_ap.py
+++ b/python/caffe/layers/detectnet/mean_ap.py
@@ -144,10 +144,10 @@ def score_det(gt_bbox_list, det_bbox_list):
 
         tp = np.asarray([np.append(j, 1) for j in cur_det_bbox[np.where(det_matched == 1)]])
         fp = np.asarray([np.append(j, 2) for j in cur_det_bbox[np.where(det_matched == 0)]])
-        tn = np.asarray([np.append(j, 3) for j in cur_gt_bbox[np.where(gt_matched == 0)]])
+        fn = np.asarray([np.append(j, 3) for j in cur_gt_bbox[np.where(gt_matched == 0)]])
 
         temp = np.append(tp, fp)
-        temp = np.append(temp, tn)
+        temp = np.append(temp, fn)
         temp = temp.reshape([temp.size/5, 5])
         matched_bbox[k, 0:temp.shape[0], :] = temp
 
@@ -157,7 +157,7 @@ def score_det(gt_bbox_list, det_bbox_list):
 def calcmAP(scored_detections, self):
     self.true_positives = np.where(scored_detections[:, :, 4] == 1)[0].size
     self.false_positives = np.where(scored_detections[:, :, 4] == 2)[0].size
-    self.true_negatives = np.where(scored_detections[:, :, 4] == 3)[0].size
+    self.false_negatives = np.where(scored_detections[:, :, 4] == 3)[0].size
     self.precision = divide_zero_is_zero(self.true_positives, self.true_positives+self.false_positives)*100.00
-    self.recall = divide_zero_is_zero(self.true_positives, self.true_positives+self.true_negatives)*100.00
+    self.recall = divide_zero_is_zero(self.true_positives, self.true_positives+self.false_negatives)*100.00
     self.avp = self.precision * self.recall / 100.0

--- a/python/caffe/layers/detectnet/mean_ap.py
+++ b/python/caffe/layers/detectnet/mean_ap.py
@@ -103,13 +103,13 @@ class mAP(caffe.Layer):
 
 
 def iou(det, rhs):
-    x_overlap = max(0, min(det[2], rhs[2]) - max(det[0], rhs[0]))
-    y_overlap = max(0, min(det[3], rhs[3]) - max(det[1], rhs[1]))
+    x_overlap = max(0, min(det[2], rhs[2]) - max(det[0], rhs[0]) + 1)
+    y_overlap = max(0, min(det[3], rhs[3]) - max(det[1], rhs[1]) + 1)
     overlap_area = x_overlap * y_overlap
     if overlap_area == 0:
         return 0
-    det_area = (det[2]-det[0])*(det[3]-det[1])
-    rhs_area = (rhs[2]-rhs[0])*(rhs[3]-rhs[1])
+    det_area = (det[2]-det[0]+1)*(det[3]-det[1]+1)
+    rhs_area = (rhs[2]-rhs[0]+1)*(rhs[3]-rhs[1]+1)
     unionarea = det_area + rhs_area - overlap_area
     return overlap_area/unionarea
 


### PR DESCRIPTION
Fixes IoU calculation - off by 1 bug. There should be +1 when calculating the area of a rectangle from left,top,right,bottom pixel values. Otherwise this seemingly benign lines can result in wrong FP/TP calculation for some edge cases.