### PR TITLE
fix multi-gpu hang when restore from a snapshot

### DIFF
--- a/include/caffe/common.hpp
+++ b/include/caffe/common.hpp
@@ -384,8 +384,8 @@ class Caffe {
   static void set_solver_count(int val) { Get().solver_count_ = val; }
   static bool root_solver() { return Get().root_solver_; }
   static void set_root_solver(bool val) { Get().root_solver_ = val; }
-  static int restored_iter() { return restored_iter_; }
-  static void set_restored_iter(int val) { restored_iter_ = val; }
+  static int restored_iter() { return Get().restored_iter_; }
+  static void set_restored_iter(int val) { Get().restored_iter_ = val; }
 
   static void set_gpus(const std::vector<int>& gpus) {
     Properties::instance().gpus_ = gpus;

--- a/include/caffe/common.hpp
+++ b/include/caffe/common.hpp
@@ -384,6 +384,8 @@ class Caffe {
   static void set_solver_count(int val) { Get().solver_count_ = val; }
   static bool root_solver() { return Get().root_solver_; }
   static void set_root_solver(bool val) { Get().root_solver_ = val; }
+  static int restored_iter() { return restored_iter_; }
+  static void set_restored_iter(int val) { restored_iter_ = val; }
 
   static void set_gpus(const std::vector<int>& gpus) {
     Properties::instance().gpus_ = gpus;
@@ -474,6 +476,7 @@ class Caffe {
   Brew mode_;
   int solver_count_;
   bool root_solver_;
+  static int restored_iter_;
 
   // Default device chosen by a user and associated with the main thread.
   // For example, if user runs `caffe train -gpu=1,0,3` then it has to be set to 1.

--- a/include/caffe/common.hpp
+++ b/include/caffe/common.hpp
@@ -384,8 +384,8 @@ class Caffe {
   static void set_solver_count(int val) { Get().solver_count_ = val; }
   static bool root_solver() { return Get().root_solver_; }
   static void set_root_solver(bool val) { Get().root_solver_ = val; }
-  static int restored_iter() { return Get().restored_iter_; }
-  static void set_restored_iter(int val) { Get().restored_iter_ = val; }
+  static int restored_iter() { return restored_iter_; }
+  static void set_restored_iter(int val) { restored_iter_ = val; }
 
   static void set_gpus(const std::vector<int>& gpus) {
     Properties::instance().gpus_ = gpus;

--- a/include/caffe/data_reader.hpp
+++ b/include/caffe/data_reader.hpp
@@ -32,10 +32,11 @@ class DataReader : public InternalThread {
     const size_t parser_threads_, parser_thread_id_;
     const size_t rank_cycle_, full_cycle_;
     size_t rec_id_, rec_end_;
+    size_t num_skips_;
 
    public:
     CursorManager(shared_ptr<db::DB> db, size_t solver_count, size_t solver_rank,
-        size_t parser_threads, size_t parser_thread_id, size_t batch_size_);
+        size_t parser_threads, size_t parser_thread_id, size_t batch_size_, size_t num_skips_);
     ~CursorManager();
     void next(Datum* datum);
     void fetch(Datum* datum);
@@ -102,6 +103,7 @@ class DataReader : public InternalThread {
   string db_source_;
   const size_t solver_count_, solver_rank_;
   size_t batch_size_;
+  size_t num_skips_;
   const bool skip_one_batch_;
   DataParameter_DB backend_;
 

--- a/include/caffe/layers/cudnn_conv_layer.hpp
+++ b/include/caffe/layers/cudnn_conv_layer.hpp
@@ -50,8 +50,6 @@ class CuDNNConvolutionLayer : public ConvolutionLayer<Ftype, Btype> {
   // because they hurt performance.
   static thread_local GPUMemory::Workspace workspace_;
   static thread_local GPUMemory::Workspace tmp_weights_;
-  // Stop alloc/dealloc
-  static thread_local bool was_reduced_;
 
  public:
   explicit CuDNNConvolutionLayer(const LayerParameter& param)
@@ -160,9 +158,6 @@ thread_local size_t CuDNNConvolutionLayer<Ftype, Btype>::mem_size_estimated_;
 
 template<typename Ftype, typename Btype>
 thread_local size_t CuDNNConvolutionLayer<Ftype, Btype>::mem_req_all_grps_;
-
-template<typename Ftype, typename Btype>
-thread_local bool CuDNNConvolutionLayer<Ftype, Btype>::was_reduced_ = false;
 
 #endif
 

--- a/src/caffe/common.cpp
+++ b/src/caffe/common.cpp
@@ -21,7 +21,7 @@ int Caffe::thread_count_ = 0;
 shared_mutex Caffe::caffe_mutex_;
 std::mutex Caffe::mutex_;
 std::mutex Caffe::mutex2_;
-int Caffe::restored_iter_;
+int Caffe::restored_iter_ = -1;
 
 
 #ifndef CPU_ONLY

--- a/src/caffe/common.cpp
+++ b/src/caffe/common.cpp
@@ -21,6 +21,7 @@ int Caffe::thread_count_ = 0;
 shared_mutex Caffe::caffe_mutex_;
 std::mutex Caffe::mutex_;
 std::mutex Caffe::mutex2_;
+int Caffe::restored_iter_;
 
 
 #ifndef CPU_ONLY

--- a/src/caffe/data_reader.cpp
+++ b/src/caffe/data_reader.cpp
@@ -45,6 +45,11 @@ DataReader::DataReader(const LayerParameter& param,
     }
   }
   db_source_ = param.data_param().source();
+  if (param.data_param().shuffle()) {
+  	num_skips_ = std::min(int(batch_size_)-1, 6);
+  } else {
+	num_skips_ = batch_size_;
+  }
   init_ = make_shared<BlockingQueue<shared_ptr<Datum>>>();
   StartInternalThread();
 }
@@ -60,7 +65,7 @@ void DataReader::InternalThreadEntry() {
 void DataReader::InternalThreadEntryN(size_t thread_id) {
   shared_ptr<db::DB> db(db::GetDB(backend_));
   db->Open(db_source_, db::READ);
-  CursorManager cm(db, solver_count_, solver_rank_, parser_threads_num_, thread_id, batch_size_);
+  CursorManager cm(db, solver_count_, solver_rank_, parser_threads_num_, thread_id, batch_size_, num_skips_);
   shared_ptr<Datum> init_datum = make_shared<Datum>();
   cm.fetch(init_datum.get());
   init_->push(init_datum);
@@ -102,11 +107,11 @@ void DataReader::InternalThreadEntryN(size_t thread_id) {
 }
 
 DataReader::CursorManager::CursorManager(shared_ptr<db::DB> db, size_t solver_count,
-    size_t solver_rank, size_t parser_threads, size_t parser_thread_id, size_t batch_size)
+    size_t solver_rank, size_t parser_threads, size_t parser_thread_id, size_t batch_size, size_t num_skips)
     : db_(db), cursor_(db->NewCursor()), solver_count_(solver_count), solver_rank_(solver_rank),
       batch_size_(batch_size), parser_threads_(parser_threads), parser_thread_id_(parser_thread_id),
       rank_cycle_(parser_threads_ * batch_size_), full_cycle_(rank_cycle_ * solver_count_),
-      rec_id_(0UL), rec_end_(0UL) {}
+      rec_id_(0UL), rec_end_(0UL),num_skips_(num_skips) {}
 
 DataReader::CursorManager::~CursorManager() {
   cursor_.reset();
@@ -123,7 +128,14 @@ void DataReader::CursorManager::next(Datum* datum) {
     rec_end_ += full_cycle_;
   }
   for (size_t i = old_id; i < rec_id_; ++i) {
-    cursor_->Next();
+    if (num_skips_ != batch_size_) {
+      unsigned int skip = caffe_rng_rand() % num_skips_;
+      while(cursor_->valid() && skip-- >0 ) {
+	    cursor_->Next();
+      }
+    } else {
+       cursor_->Next();
+    }
     if (!cursor_->valid()) {
       LOG_IF(INFO, solver_rank_ == 0 && parser_thread_id_ == 0)
           << "Restarting data pre-fetching";

--- a/src/caffe/data_reader.cpp
+++ b/src/caffe/data_reader.cpp
@@ -46,7 +46,7 @@ DataReader::DataReader(const LayerParameter& param,
   }
   db_source_ = param.data_param().source();
   if (param.data_param().shuffle()) {
-  	num_skips_ = std::min(int(batch_size_)-1, 6);
+  	num_skips_ = std::min(int(batch_size_)-1, 3);
   } else {
 	num_skips_ = batch_size_;
   }

--- a/src/caffe/layers/cudnn_conv_layer.cpp
+++ b/src/caffe/layers/cudnn_conv_layer.cpp
@@ -18,11 +18,6 @@ namespace caffe {
 #endif
 
 template <typename Dtype>
-float gb_round2(Dtype val) {
-  return std::round(val * 1.e-7) * 0.01F;
-}
-
-template <typename Dtype>
 void createFilterDesc(cudnnFilterDescriptor_t* desc, int n, int c, int h, int w) {
   CUDNN_CHECK(cudnnCreateFilterDescriptor(desc));
   CUDNN_CHECK(cudnnSetFilter4dDescriptor(*desc, cudnn::dataType<Dtype>::type,
@@ -210,12 +205,8 @@ void CuDNNConvolutionLayer<Ftype, Btype>::LayerSetUp(
 
 template <typename Ftype, typename Btype>
 size_t CuDNNConvolutionLayer<Ftype, Btype>::ComputeFindExWorkspaceSize() {
-  if (was_reduced_) {
-    return workspace_.size();
-  }
   if (this->phase_ == TEST) {
-    workspace_.safe_reserve(INITIAL_WORKSPACE_SIZE * groups());
-    return workspace_.size();
+    return INITIAL_WORKSPACE_SIZE * groups();
   }
   size_t workspace_limit_bytes, total_memory, workspace_bytes = 0UL;
   GPUMemory::GetInfo(&workspace_limit_bytes, &total_memory, true);
@@ -224,8 +215,9 @@ size_t CuDNNConvolutionLayer<Ftype, Btype>::ComputeFindExWorkspaceSize() {
   }
   // Try to use the amount estimated for all groups
   workspace_bytes = align_down<7>(
-      std::min(static_cast<size_t>(total_memory / 2UL),
-          static_cast<size_t>(mem_size_estimated_) * groups()));
+      std::min(static_cast<size_t>(total_memory - PAGE_SIZE),
+          static_cast<size_t>(mem_size_estimated_)));
+  workspace_bytes *= groups();
   if (workspace_bytes <= workspace_.size()) {
     return workspace_.size();  // job is done by previous layer on this GPU
   }
@@ -233,8 +225,8 @@ size_t CuDNNConvolutionLayer<Ftype, Btype>::ComputeFindExWorkspaceSize() {
       workspace_limit_bytes - PAGE_SIZE : 0UL;
   if (workspace_bytes > workspace_limit_bytes) {
     LOG(WARNING) << "[" << Caffe::current_device()
-        << "] Current workspace (" << gb_round2(workspace_.size()) << "G)"
-        << " Estimated requirement (" << gb_round2(workspace_bytes) << "G)";
+        << "] Current workspace (" << std::round(workspace_.size() * 1.e-7) * 0.01F << "G)"
+        << " Estimated requirement (" << std::round(workspace_bytes * 1.e-7) * 0.01F << "G)";
     workspace_bytes = align_down<7>(workspace_limit_bytes);
   }
   int attempts = ATTEMPTS_TO_RESERVE_WS;
@@ -272,20 +264,6 @@ void CuDNNConvolutionLayer<Ftype, Btype>::Reshape(
     // If cached descriptors are not initialized yet, need to
     // do reshape which also initializes cached descriptors.
     use_reshape_ = true;
-  }
-  if ((this->iter() == 3 || (this->iter() > 3 && use_reshape_))
-      && this->phase_ == TRAIN
-      && mem_req_all_grps_ > 0UL
-      && workspace_.size() > mem_req_all_grps_ * 2UL) {
-    // Winner needs less than half of initial estimate - saving the rest
-    // Half because we want to reduce the number of allocs/deallocs
-    LOG(INFO) << "[" << Caffe::current_device() << "]"
-              << " Layer '" << this->name() << "' reallocating workspace: "
-              << gb_round2(workspace_.size()) << "G -> "
-              << gb_round2(mem_req_all_grps_ * 2UL) << "G";
-    workspace_.release();
-    workspace_.reserve(mem_req_all_grps_ * 2UL);
-    was_reduced_ = true;
   }
   if (!use_reshape_) {
     return;
@@ -371,7 +349,7 @@ void CuDNNConvolutionLayer<Ftype, Btype>::Reshape(
 
   // Ask cuDNN to find the best algorithm
   // When batch is small and every image is different we don't want to call Find* over and over
-  if (use_algo_seeker_ && this->iter() <= 2) {
+  if (use_algo_seeker_ && this->iter() <= 3) {
     // FindEx: A workspace of size workspace_bytes is allocated for FindEx.
     //         Besides, workspace, a buffer is allocated for the output of
     //         FindEx-backward-filter. The size of buffer is as big as weights.
@@ -385,10 +363,6 @@ void CuDNNConvolutionLayer<Ftype, Btype>::Reshape(
     } else {
       // Make sure it's all allocated before we take the rest
       this->blobs_[0]->allocate_data();
-      this->blobs_[0]->allocate_diff();
-      if (this->bias_term_) {
-        this->blobs_[1]->allocate_data();
-      }
       for (int i = 0; i < bottom.size(); ++i) {
         top[i]->allocate_data();
         top[i]->allocate_diff();
@@ -453,7 +427,7 @@ void CuDNNConvolutionLayer<Ftype, Btype>::Reshape(
   CUDA_CHECK(cudaStreamSynchronize(Caffe::thread_stream()));
 
   UpdateWorkspaceDemand(bottom.size());
-  workspace_.safe_reserve(mem_req_all_grps_);
+  workspace_.safe_reserve(align_up<7>(mem_req_all_grps_));
 
   // Tensor descriptor for bias.
   if (this->bias_term_) {
@@ -469,8 +443,6 @@ void CuDNNConvolutionLayer<Ftype, Btype>::EstimateMaxWorkspaceSize(const vector<
   size_t size;
   size_t available_memory, total_memory;
   GPUMemory::GetInfo(&available_memory, &total_memory, true);
-  // As per our experiments, it's not healthy to take more than 50% of total
-  available_memory = std::min(available_memory, total_memory / 2);
   std::list<int> algos_to_test;
   for (int i = 0; i < bottom.size(); ++i) {
     if (user_algos_override_[0] < 0) {
@@ -638,9 +610,8 @@ void CuDNNConvolutionLayer<Ftype, Btype>::FindExConvAlgo(
   bool bwd_filter_pseudo = false;
   bool bwd_data_pseudo = false;
 
-  const size_t ngroups = groups();
-  const size_t gsize = workspace_.size() / ngroups;
-  CHECK(is_even(gsize)) << workspace_.size() << " / " << ngroups << " -> " << gsize;
+  const size_t gsize = workspace_.size() / groups();
+  CHECK(is_even(gsize)) << workspace_.size() << " / " << groups() << " -> " << gsize;
 
   // Allocate temporary buffer for weights used for backward filter FindEx
   if (this->phase_ == TRAIN) {
@@ -699,8 +670,6 @@ void CuDNNConvolutionLayer<Ftype, Btype>::FindExConvAlgo(
             }
             fwd_algo_[i] = fwd_results[k].algo;
             workspace_fwd_sizes_[i] = fwd_results[k].memory;
-            mem_req_all_grps_ = std::max(mem_req_all_grps_,
-                align_up<7>(workspace_fwd_sizes_[i] * ngroups));
             fwd_pseudo = is_precise(forward_math_) && !is_precise(tp<Ftype>());
             break;
           }
@@ -760,8 +729,6 @@ void CuDNNConvolutionLayer<Ftype, Btype>::FindExConvAlgo(
               }
               bwd_filter_algo_[i] = bwd_filter_results[k].algo;
               workspace_bwd_filter_sizes_[i] = bwd_filter_results[k].memory;
-              mem_req_all_grps_ = std::max(mem_req_all_grps_,
-                  align_up<7>(workspace_bwd_filter_sizes_[i] * ngroups));
               bwd_filter_pseudo = is_precise(backward_filter_math_) && !is_precise(tp<Btype>());
               break;
             }
@@ -819,8 +786,6 @@ void CuDNNConvolutionLayer<Ftype, Btype>::FindExConvAlgo(
               }
               bwd_data_algo_[i] = bwd_data_results[k].algo;
               workspace_bwd_data_sizes_[i] = bwd_data_results[k].memory;
-              mem_req_all_grps_ = std::max(mem_req_all_grps_,
-                  align_up<7>(workspace_bwd_data_sizes_[i] * ngroups));
               bwd_data_pseudo = is_precise(backward_data_math_) && !is_precise(tp<Btype>());
               break;
             }
@@ -833,7 +798,7 @@ void CuDNNConvolutionLayer<Ftype, Btype>::FindExConvAlgo(
 
       LOG(INFO)<< "[" << Caffe::current_device() << "]"
           << " Conv Algos (F,BD,BF): '" << this->name() << "' with space "
-          << gb_round2(workspace_.size()) << "G/" << groups()
+          << std::round(workspace_.size() * 1.e-7) * 0.01F << "G/" << groups()
 #ifdef DEBUG
           << " -> [" << workspace_fwd_sizes_[i]
           << " " << workspace_bwd_data_sizes_[i]
@@ -845,8 +810,7 @@ void CuDNNConvolutionLayer<Ftype, Btype>::FindExConvAlgo(
       << (user_algos_override_[1] >= 0 ? "u " : (bwd_data_pseudo ? "p " : " "))
       << bwd_filter_algo_[i]
       << (user_algos_override_[2] >= 0 ? "u " : (bwd_filter_pseudo ? "p " : " "))
-      << " (limit " << gb_round2(workspace_limit_bytes) << "G, req "
-      << gb_round2(mem_req_all_grps_) << "G)";
+      << " (limit " << std::round(workspace_limit_bytes * 1.e-7) * 0.01F << "G)";
     }
   }
 }
@@ -956,21 +920,17 @@ bool CuDNNConvolutionLayer<Ftype, Btype>::data_algo_fallback(int i, int pad_h,
 
 template <typename Ftype, typename Btype>
 void CuDNNConvolutionLayer<Ftype, Btype>::UpdateWorkspaceDemand(int size) {
-  // Updating maximum mem_size_required_
-  const size_t ngroups = groups();
-  size_t req;
+  // Updating maximum mem_size_required_ and max_groups_
+  size_t pgroups = groups();
   for (int i = 0; i < size; ++i) {
-    req = align_up<7>(workspace_fwd_sizes_[i] * ngroups);
-    if (mem_req_all_grps_ < req) {
-      mem_req_all_grps_ = req;
+    if (align_up<7>(workspace_fwd_sizes_[i]) * pgroups > mem_req_all_grps_) {
+      mem_req_all_grps_ = align_up<7>(workspace_fwd_sizes_[i]) * pgroups;
     }
-    req = align_up<7>(workspace_bwd_data_sizes_[i] * ngroups);
-    if (mem_req_all_grps_ < req) {
-      mem_req_all_grps_ = req;
+    if (align_up<7>(workspace_bwd_data_sizes_[i]) * pgroups > mem_req_all_grps_) {
+      mem_req_all_grps_ = align_up<7>(workspace_bwd_data_sizes_[i]) * pgroups;
     }
-    req = align_up<7>(workspace_bwd_filter_sizes_[i] * ngroups);
-    if (mem_req_all_grps_ < req) {
-      mem_req_all_grps_ = req;
+    if (align_up<7>(workspace_bwd_filter_sizes_[i]) * pgroups > mem_req_all_grps_) {
+      mem_req_all_grps_ = align_up<7>(workspace_bwd_filter_sizes_[i]) * pgroups;
     }
   }
 }

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -827,6 +827,7 @@ message DataParameter {
   // Takes effect only when used together with 'threads' setting.
   // Ignored and always set to 1 for test nets.
   optional uint32 parser_threads  = 12 [default = 0];
+  optional bool shuffle = 13 [default = false];
 }
 
 message DropoutParameter {

--- a/src/caffe/solver.cpp
+++ b/src/caffe/solver.cpp
@@ -375,7 +375,6 @@ void Solver::Reduce(int device, Caffe::Brew mode, int rand_seed,
 }
 
 bool Solver::Solve(const char* resume_file) {
-
   callback_soft_barrier();
   LOG(INFO) << "Solving " << net_->name();
   LOG(INFO) << "Learning Rate Policy: " << param_.lr_policy();
@@ -389,7 +388,7 @@ bool Solver::Solve(const char* resume_file) {
 
   callback_soft_barrier();
   
-  if(Caffe::restored_iter() != -1) {
+  if (Caffe::restored_iter() != -1) {
     //set correct state for Rank > 0
     iter_ = Caffe::restored_iter();
     iterations_last_ = -1;

--- a/src/caffe/solver.cpp
+++ b/src/caffe/solver.cpp
@@ -387,7 +387,6 @@ bool Solver::Solve(const char* resume_file) {
   }
 
   callback_soft_barrier();
-  
   if (Caffe::restored_iter() != -1) {
     //set correct state for Rank > 0
     iter_ = Caffe::restored_iter();

--- a/src/caffe/solver.cpp
+++ b/src/caffe/solver.cpp
@@ -376,8 +376,6 @@ void Solver::Reduce(int device, Caffe::Brew mode, int rand_seed,
 
 bool Solver::Solve(const char* resume_file) {
 
-  Caffe::set_restored_iter(-1);
-
   callback_soft_barrier();
   LOG(INFO) << "Solving " << net_->name();
   LOG(INFO) << "Learning Rate Policy: " << param_.lr_policy();
@@ -390,6 +388,7 @@ bool Solver::Solve(const char* resume_file) {
   }
 
   callback_soft_barrier();
+  
   if(Caffe::restored_iter() != -1) {
     //set correct state for Rank > 0
     iter_ = Caffe::restored_iter();

--- a/src/caffe/solver.cpp
+++ b/src/caffe/solver.cpp
@@ -375,6 +375,9 @@ void Solver::Reduce(int device, Caffe::Brew mode, int rand_seed,
 }
 
 bool Solver::Solve(const char* resume_file) {
+
+  Caffe::set_restored_iter(-1);
+
   callback_soft_barrier();
   LOG(INFO) << "Solving " << net_->name();
   LOG(INFO) << "Learning Rate Policy: " << param_.lr_policy();
@@ -384,6 +387,13 @@ bool Solver::Solve(const char* resume_file) {
   if (resume_file) {
     LOG(INFO) << "Restoring previous solver status from " << resume_file;
     Restore(resume_file);
+  }
+
+  callback_soft_barrier();
+  if(Caffe::restored_iter() != -1) {
+    //set correct state for Rank > 0
+    iter_ = Caffe::restored_iter();
+    iterations_last_ = -1;
   }
 
   // For a network that is trained by the solver, no bottom or top vecs

--- a/src/caffe/solvers/sgd_solver.cpp
+++ b/src/caffe/solvers/sgd_solver.cpp
@@ -286,6 +286,8 @@ void SGDSolver<Dtype>::RestoreSolverStateFromBinaryProto(const string& state_fil
   SolverState state;
   ReadProtoFromBinaryFile(state_file, &state);
   this->iter_ = state.iter();
+  LOG(INFO) << "restore iter is " << this->iter_;
+  Caffe::set_restored_iter(state.iter());
   this->iterations_restored_ = this->iter_;
   this->iterations_last_ = -1;  // for correct benchmarking
   if (state.has_learned_net()) {


### PR DESCRIPTION
Deadlock is caused by un-synced restore states(iter_ and last_iter_) between root solver and non-root solvers.
Fix: Add a global variable to share the iteration id parsed by root solver and broadcast to non-root solvers. 
follow result is dumped from Solver::Step do the test,
Root solver entering into the path of restored. 
Nono-root solver entering into justed started path.  
Happily, deadlock 100%. 

    // Just started or restored?
    const bool first_loop = iter_ == 0 || iterations_last_ < 0;
    if (first_loop) {
      if (TestAll(1, use_multi_gpu_testing)) {
        break;
      }
      callback_soft_barrier();
      LOG_IF(INFO, Caffe::root_solver()) << mgpu_str << "Initial Test completed";
    } else if (param_.test_interval() && iter_ % param_.test_interval() == 0) {
      test_timer_.Start();
      if (TestAll(0, use_multi_gpu_testing)) {
        break;
      }
      callback_soft_barrier();

I0608 06:26:48.129050 27937 solver.cpp:247] Andy is first_loopfalse0
I0608 06:26:48.129050 27938 solver.cpp:247] Andy is first_loopfalse0
I0608 06:26:48.129050 27941 solver.cpp:247] Andy is first_loopfalse0
I0608 06:26:48.129076 27935 solver.cpp:247] Andy is first_loopfalse0
I0608 06:26:48.129132 27940 solver.cpp:247] Andy is first_loopfalse0
I0608 06:26:48.129163 27934 solver.cpp:247] Andy is first_looptrue-1 <= root_solver's state is correct, all the left are wrong.  
I0608 06:26:48.129165 27936 solver.cpp:247] Andy is first_loopfalse0
I0608 06:26:48.129161 27939 solver.cpp:247] Andy is first_loopfalse0

Reported and fixed in 0.15 #254. But not got merged.   
Please kindly fixed it.
