### PR TITLE
Updated requirement to force max numpy verson to 1.11

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,5 +1,5 @@
 Cython>=0.19.2
-numpy>=1.7.1
+numpy>=1.7.1,<=1.11.0
 scipy>=0.13.2
 scikit-image>=0.9.3
 matplotlib>=1.3.1


### PR DESCRIPTION
This is because of existing bugs that exists in 1.13 and since numpy is unbounded, it picks up 1.13 during build from source. This is as per Cliff Woolley's suggestions to keep it at 1.11 for standardization