### PR TITLE
Fix to compile with NCCL.

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -186,7 +186,7 @@ else()
 endif()
 if(NCCL_FOUND)
   add_definitions(-DUSE_NCCL)
-  include_directories(SYSTEM ${NCCL_INCLUDE})
+  include_directories(SYSTEM ${NCCL_INCLUDE_DIR})
   list(APPEND Caffe_LINKER_LIBS ${NCCL_LIBRARY})
 endif()
 


### PR DESCRIPTION
Fix for the nccl.h not found error during compilation.