### PR TITLE
Remove Caffe::all_streams_ since it causes a memory leak when calling Solver::Step(1)

### DIFF
--- a/include/caffe/common.hpp
+++ b/include/caffe/common.hpp
@@ -459,7 +459,6 @@ class Caffe {
 
  protected:
 #ifndef CPU_ONLY
-  static std::list<shared_ptr<CudaStream>> all_streams_;
   vector<vector<shared_ptr<CudaStream>>> device_streams_;  // [device][group]
   vector<vector<shared_ptr<CudaStream>>> device_streams_aux_;  // [device][id]
   vector<vector<cublasHandle_t>> cublas_handles_;  // [device][group]

--- a/include/caffe/util/gpu_memory.hpp
+++ b/include/caffe/util/gpu_memory.hpp
@@ -144,6 +144,10 @@ struct GPUMemory {
     std::string report_dev_info(int device);
     shared_mutex& read_write_mutex() { return mutex_; }
 
+    // keep a reference to which streams have been used, so that we can call
+    // deallocate before the streams themselves have been destroyed
+    std::set<shared_ptr<CudaStream>> used_streams_;
+
     Mode mode_;
     bool debug_;
 

--- a/src/caffe/common.cpp
+++ b/src/caffe/common.cpp
@@ -27,11 +27,6 @@ std::mutex Caffe::pstream_mutex_;
 std::mutex Caffe::cublas_mutex_;
 std::mutex Caffe::seed_mutex_;
 
-#ifndef CPU_ONLY
-// Lifecycle management for CUDA streams
-std::list<shared_ptr<CudaStream>> Caffe::all_streams_;
-#endif
-
 Caffe& Caffe::Get() {
   // Make sure each thread can have different values.
   static thread_local unique_ptr<Caffe> thread_instance_;
@@ -246,7 +241,6 @@ shared_ptr<CudaStream> Caffe::device_pstream(int group) {
   }
   if (!group_streams[group]) {
     group_streams[group] = CudaStream::create();
-    all_streams_.push_back(group_streams[group]);
   }
   return group_streams[group];
 }
@@ -259,7 +253,6 @@ shared_ptr<CudaStream> Caffe::device_pstream_aux(int id) {
   }
   if (!streams[id]) {
     streams[id] = CudaStream::create();
-    all_streams_.push_back(streams[id]);
   }
   return streams[id];
 }

--- a/src/caffe/util/gpu_memory.cpp
+++ b/src/caffe/util/gpu_memory.cpp
@@ -167,6 +167,7 @@ void GPUMemory::Manager::reset() {
     return;
   }
   cub_allocator_.reset();
+  used_streams_.clear();
   mode_ = CUDA_MALLOC;
   initialized_ = false;
 }
@@ -205,6 +206,7 @@ bool GPUMemory::Manager::try_allocate(void** ptr, size_t size, int device, int g
       // wait for "writers" like NCCL and potentially others
       shared_lock<shared_mutex> lock(GPUMemory::read_write_mutex());
       shared_ptr<CudaStream> pstream = Caffe::thread_pstream(group);
+      used_streams_.insert(pstream); // mark this stream as used
       size_t size_allocated = 0;
       // Clean Cache & Retry logic is inside now
       status = cub_allocator_->DeviceAllocate(device, ptr, size, pstream->get(), size_allocated);


### PR DESCRIPTION
Currently, caffe-0.16 has a memory leak  inside `Solver::Step()`.  All streams ever created were permanently kept around in memory (saved in `Caffe::all_streams_`).  Every time `Solver::Step` is called, a new thread is created and new streams are allocated.  These streams are never destroyed. 
 The pattern of calling `Solver::Step(1)` repeatedly is common for custom Python-based solvers.  In this case, the GPU gradually runs out of memory.

We can't simply remove `Caffe::all_streams_` because then the GPU memory manager can't deallocate its memory at the right time.

Instead, this PR proposes the solution of having the GPU memory manager keep a reference to streams that it wants to later use to deallocate memory (in `GPUMemory::Manager::used_streams_`).

This fixes #426.