### PR TITLE
Add SSD Object detection

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,11 @@
 COPYRIGHT
 
+All changes from Caffe SSD (https://github.com/weiliu89/caffe/tree/ssd)
+Copyright (c) 2015, 2016 Wei Liu (UNC Chapel Hill), Dragomir Anguelov (Zoox),
+Dumitru Erhan (Google), Christian Szegedy (Google), Scott Reed (UMich Ann Arbor),
+Cheng-Yang Fu (UNC Chapel Hill), Alexander C. Berg (UNC Chapel Hill).
+All rights reserved.
+
 All contributions by the University of California:
 Copyright (c) 2014, 2015, The Regents of the University of California (Regents)
 All rights reserved.

--- a/Makefile
+++ b/Makefile
@@ -281,7 +281,7 @@ ifeq ($(LINUX), 1)
 	endif
 	# boost::thread is reasonably called boost_thread (compare OS X)
 	# We will also explicitly add stdc++ to the link target.
-	LIBRARIES += boost_thread stdc++
+	LIBRARIES += boost_thread boost_regex stdc++
 	VERSIONFLAGS += -Wl,-soname,$(DYNAMIC_SONAME_SHORT) -Wl,-rpath,$(ORIGIN)/../lib
 endif
 

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -4,7 +4,7 @@ set(Caffe_LINKER_LIBS "")
 # ---[ Boost
 find_package(Boost 1.46 REQUIRED COMPONENTS system thread filesystem)
 include_directories(SYSTEM ${Boost_INCLUDE_DIR})
-list(APPEND Caffe_LINKER_LIBS ${Boost_LIBRARIES})
+list(APPEND Caffe_LINKER_LIBS ${Boost_LIBRARIES} boost_regex)
 
 # ---[ Threads
 find_package(Threads REQUIRED)

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -2,9 +2,9 @@
 set(Caffe_LINKER_LIBS "")
 
 # ---[ Boost
-find_package(Boost 1.46 REQUIRED COMPONENTS system thread filesystem)
+find_package(Boost 1.46 REQUIRED COMPONENTS system thread filesystem regex)
 include_directories(SYSTEM ${Boost_INCLUDE_DIR})
-list(APPEND Caffe_LINKER_LIBS ${Boost_LIBRARIES} boost_regex)
+list(APPEND Caffe_LINKER_LIBS ${Boost_LIBRARIES})
 
 # ---[ Threads
 find_package(Threads REQUIRED)

--- a/include/caffe/data_reader.hpp
+++ b/include/caffe/data_reader.hpp
@@ -23,6 +23,7 @@ namespace caffe {
  * to allow deterministic ordering down the road. Data is distributed to solvers
  * in a round-robin way to keep parallel training deterministic.
  */
+template <typename DatumType>
 class DataReader : public InternalThread {
  private:
   class CursorManager {
@@ -41,8 +42,8 @@ class DataReader : public InternalThread {
         size_t solver_rank, size_t parser_threads, size_t parser_thread_id, size_t batch_size_,
         bool cache, bool shuffle);
     ~CursorManager();
-    void next(shared_ptr<Datum>& datum);
-    void fetch(Datum* datum);
+    void next(shared_ptr<DatumType>& datum);
+    void fetch(DatumType* datum);
     void rewind();
 
     size_t full_cycle() const {
@@ -64,8 +65,8 @@ class DataReader : public InternalThread {
       return data_cache_inst_.get();
     }
 
-    shared_ptr<Datum>& next_new();
-    shared_ptr<Datum>& next_cached();
+    shared_ptr<DatumType>& next_new();
+    shared_ptr<DatumType>& next_cached();
     bool check_memory();
     void check_db(const std::string& db_source) {
       std::lock_guard<std::mutex> lock(cache_mutex_);
@@ -90,7 +91,7 @@ class DataReader : public InternalThread {
           just_cached_(false) {}
 
     std::string db_source_;
-    vector<shared_ptr<Datum>> cache_buffer_;
+    vector<shared_ptr<DatumType>> cache_buffer_;
     size_t cache_idx_;
     boost::barrier cache_bar_;
     bool shuffle_;
@@ -117,37 +118,37 @@ class DataReader : public InternalThread {
     start_reading_flag_.set();
   }
 
-  void free_push(size_t queue_id, const shared_ptr<Datum>& datum) {
+  void free_push(size_t queue_id, const shared_ptr<DatumType>& datum) {
     if (!sample_only_) {
       free_[queue_id]->push(datum);
     }
   }
 
-  shared_ptr<Datum> free_pop(size_t queue_id) {
+  shared_ptr<DatumType> free_pop(size_t queue_id) {
     return free_[queue_id]->pop();
   }
 
-  shared_ptr<Datum> sample() {
+  shared_ptr<DatumType> sample() {
     return init_->peek();
   }
 
-  void full_push(size_t queue_id, const shared_ptr<Datum>& datum) {
+  void full_push(size_t queue_id, const shared_ptr<DatumType>& datum) {
     full_[queue_id]->push(datum);
   }
 
-  shared_ptr<Datum> full_peek(size_t queue_id) {
+  shared_ptr<DatumType> full_peek(size_t queue_id) {
     return full_[queue_id]->peek();
   }
 
-  shared_ptr<Datum> full_pop(size_t queue_id, const char* log_on_wait) {
+  shared_ptr<DatumType> full_pop(size_t queue_id, const char* log_on_wait) {
     return full_[queue_id]->pop(log_on_wait);
   }
 
-  shared_ptr<Datum>& next_new() {
+  shared_ptr<DatumType>& next_new() {
     return data_cache_->next_new();
   }
 
-  shared_ptr<Datum>& next_cached() {
+  shared_ptr<DatumType>& next_cached() {
     return data_cache_->next_cached();
   }
 
@@ -171,9 +172,9 @@ class DataReader : public InternalThread {
   const bool skip_one_batch_;
   DataParameter_DB backend_;
 
-  shared_ptr<BlockingQueue<shared_ptr<Datum>>> init_;
-  vector<shared_ptr<BlockingQueue<shared_ptr<Datum>>>> free_;
-  vector<shared_ptr<BlockingQueue<shared_ptr<Datum>>>> full_;
+  shared_ptr<BlockingQueue<shared_ptr<DatumType>>> init_;
+  vector<shared_ptr<BlockingQueue<shared_ptr<DatumType>>>> free_;
+  vector<shared_ptr<BlockingQueue<shared_ptr<DatumType>>>> full_;
 
  private:
   int current_rec_;

--- a/include/caffe/data_transformer.hpp
+++ b/include/caffe/data_transformer.hpp
@@ -15,6 +15,9 @@
 #include "caffe/proto/caffe.pb.h"
 #include "caffe/util/blocking_queue.hpp"
 
+#include "google/protobuf/repeated_field.h"
+using google::protobuf::RepeatedPtrField;
+
 namespace caffe {
 
 /**
@@ -136,8 +139,86 @@ class DataTransformer {
    *    This is destination blob. It can be part of top blob's data if
    *    set_cpu_data() is used. See memory_layer.cpp for an example.
    */
-  void Transform(const vector<Datum>& datum_vector, TBlob<Dtype>* transformed_blob);
+  void Transform(const vector<Datum> & datum_vector,
+                TBlob<Dtype>* transformed_blob);
 
+  /**
+   * @brief Applies the transformation defined in the data layer's
+   * transform_param block to the annotated data.
+   *
+   * @param anno_datum
+   *    AnnotatedDatum containing the data and annotation to be transformed.
+   * @param transformed_blob
+   *    This is destination blob. It can be part of top blob's data if
+   *    set_cpu_data() is used. See annotated_data_layer.cpp for an example.
+   * @param transformed_anno_vec
+   *    This is destination annotation.
+   */
+  void Transform(const AnnotatedDatum& anno_datum,
+                 TBlob<Dtype>* transformed_blob,
+                 RepeatedPtrField<AnnotationGroup>* transformed_anno_vec);
+  void Transform(const AnnotatedDatum& anno_datum,
+                 TBlob<Dtype>* transformed_blob,
+                 RepeatedPtrField<AnnotationGroup>* transformed_anno_vec,
+                 bool* do_mirror);
+  void Transform(const AnnotatedDatum& anno_datum,
+                 TBlob<Dtype>* transformed_blob,
+                 vector<AnnotationGroup>* transformed_anno_vec,
+                 bool* do_mirror);
+  void Transform(const AnnotatedDatum& anno_datum,
+                 TBlob<Dtype>* transformed_blob,
+                 vector<AnnotationGroup>* transformed_anno_vec);
+				 
+
+  /**
+   * @brief Transform the annotation according to the transformation applied
+   * to the datum.
+   *
+   * @param anno_datum
+   *    AnnotatedDatum containing the data and annotation to be transformed.
+   * @param do_resize
+   *    If true, resize the annotation accordingly before crop.
+   * @param crop_bbox
+   *    The cropped region applied to anno_datum.datum()
+   * @param do_mirror
+   *    If true, meaning the datum has mirrored.
+   * @param transformed_anno_group_all
+   *    Stores all transformed AnnotationGroup.
+   */
+  void TransformAnnotation(
+      const AnnotatedDatum& anno_datum, const bool do_resize,
+      const NormalizedBBox& crop_bbox, const bool do_mirror,
+      RepeatedPtrField<AnnotationGroup>* transformed_anno_group_all);
+
+  /**
+   * @brief Crops the datum according to bbox.
+   */
+  void CropImage(const Datum& datum, const NormalizedBBox& bbox,
+                 Datum* crop_datum);
+
+  /**
+   * @brief Crops the datum and AnnotationGroup according to bbox.
+   */
+  void CropImage(const AnnotatedDatum& anno_datum, const NormalizedBBox& bbox,
+                 AnnotatedDatum* cropped_anno_datum);
+
+  /**
+   * @brief Expand the datum.
+   */
+  void ExpandImage(const Datum& datum, const float expand_ratio,
+                   NormalizedBBox* expand_bbox, Datum* expanded_datum);
+
+  /**
+   * @brief Expand the datum and adjust AnnotationGroup.
+   */
+  void ExpandImage(const AnnotatedDatum& anno_datum,
+                   AnnotatedDatum* expanded_anno_datum);
+
+  /**
+   * @brief Apply distortion to the datum.
+   */
+  void DistortImage(const Datum& datum, Datum* distort_datum);
+  
 #ifdef USE_OPENCV
   /**
    * @brief Applies the transformation defined in the data layer's
@@ -186,6 +267,35 @@ class DataTransformer {
   vector<int> InferDatumShape(const Datum& datum);
 #ifdef USE_OPENCV
   vector<int> InferCVMatShape(const cv::Mat& img);
+  /**
+   * @brief Applies the transformation defined in the data layer's
+   * transform_param block to a cv::Mat
+   *
+   * @param cv_img
+   *    cv::Mat containing the data to be transformed.
+   * @param transformed_blob
+   *    This is destination blob. It can be part of top blob's data if
+   *    set_cpu_data() is used. See image_data_layer.cpp for an example.
+   */
+  void Transform(const cv::Mat& cv_img, TBlob<Dtype>* transformed_blob,
+                 NormalizedBBox* crop_bbox, bool* do_mirror);
+
+  /**
+   * @brief Crops img according to bbox.
+   */
+  void CropImage(const cv::Mat& img, const NormalizedBBox& bbox,
+                 cv::Mat* crop_img);
+
+  /**
+   * @brief Expand img to include mean value as background.
+   */
+  void ExpandImage(const cv::Mat& img, const float expand_ratio,
+                   NormalizedBBox* expand_bbox, cv::Mat* expand_img);
+
+  void TransformInv(const TBlob<Dtype>* blob, vector<cv::Mat>* cv_imgs);
+  void TransformInv(const Dtype* data, cv::Mat* cv_img, const int height,
+                    const int width, const int channels);
+					
 #endif  // USE_OPENCV
 
   /**
@@ -204,9 +314,21 @@ class DataTransformer {
    * @param datum
    *    Datum containing the data to be transformed.
    */
-  vector<int> InferBlobShape(const Datum& datum, bool use_gpu = false);
-
+  vector<int> InferBlobShape(const Datum& datum, bool use_gpu /*= false*/);
+  vector<int> InferBlobShape(const Datum& datum);
+  
+  /**
+   * @brief Infers the shape of transformed_blob will have when
+   *    the transformation is applied to the data.
+   *    It uses the first element to infer the shape of the blob.
+   *
+   * @param datum_vector
+   *    A vector of Datum containing the data to be transformed.
+   */
+  vector<int> InferBlobShape(const vector<Datum> & datum_vector);
+  
 #ifdef USE_OPENCV
+  vector<int> InferBlobShape(const vector<cv::Mat> & mat_vector);
   /**
    * @brief Infers the shape of transformed_blob will have when
    *    the transformation is applied to the data.
@@ -214,7 +336,9 @@ class DataTransformer {
    * @param cv_img
    *    cv::Mat containing the data to be transformed.
    */
-  vector<int> InferBlobShape(const cv::Mat& cv_img, bool use_gpu = false);
+  vector<int> InferBlobShape(const cv::Mat& cv_img, bool use_gpu /*= false*/);
+  
+  vector<int> InferBlobShape(const cv::Mat& cv_img);  
 #endif  // USE_OPENCV
 
   void Fill3Randoms(unsigned int* rand) const;
@@ -230,6 +354,18 @@ class DataTransformer {
       const std::array<unsigned int, 3>& rand);
   void TransformPtrInt(Datum& datum, Dtype* transformed_data,
       const std::array<unsigned int, 3>& rand);
+
+  // Transform and return the transformation information.
+  void Transform(const Datum& datum, Dtype* transformed_data,
+                 NormalizedBBox* crop_bbox, bool* do_mirror);
+  void Transform(const Datum& datum, Dtype* transformed_data);
+
+  /**
+   * @brief Applies the transformation defined in the data layer's
+   * transform_param block to the data and return transform information.
+   */
+  void Transform(const Datum& datum, TBlob<Dtype>* transformed_blob,
+                 NormalizedBBox* crop_bbox, bool* do_mirror);
 
   // Tranformation parameters
   TransformationParameter param_;

--- a/include/caffe/layers/annotated_data_layer.hpp
+++ b/include/caffe/layers/annotated_data_layer.hpp
@@ -1,0 +1,74 @@
+#ifndef CAFFE_ANNOTATED_DATA_LAYER_HPP_
+#define CAFFE_ANNOTATED_DATA_LAYER_HPP_
+
+#include <string>
+#include <map>
+#include <vector>
+#include <atomic>
+
+#include "caffe/blob.hpp"
+#include "caffe/data_reader.hpp"
+#include "caffe/data_transformer.hpp"
+#include "caffe/internal_thread.hpp"
+#include "caffe/layer.hpp"
+#include "caffe/layers/base_data_layer.hpp"
+#include "caffe/proto/caffe.pb.h"
+#include "caffe/util/db.hpp"
+
+namespace caffe {
+
+template <typename Ftype, typename Btype>
+class AnnotatedDataLayer : public BasePrefetchingDataLayer<Ftype, Btype> {
+ typedef Ftype Dtype;
+ public:
+  explicit AnnotatedDataLayer(const LayerParameter& param);
+  virtual ~AnnotatedDataLayer();
+  virtual void DataLayerSetUp(const vector<Blob*>& bottom, const vector<Blob*>& top) override;
+	  
+  // AnnotatedDataLayer uses DataReader instead for sharing for parallelism
+  virtual bool ShareInParallel() const override { 
+  	return false; 
+  }
+  virtual inline const char* type() const override { 
+  	return "AnnotatedData"; 
+  }
+  virtual inline int ExactNumBottomBlobs() const override { 
+  	return 0; 
+  }
+  virtual inline int MinTopBlobs() const override { 
+  	return 1; 
+  }
+
+  Flag* layer_inititialized_flag() override {
+    return this->phase_ == TRAIN ? &layer_inititialized_flag_ : nullptr;
+  }
+  
+ protected:
+  void InitializePrefetch() override;
+  bool auto_mode() const override {
+    return false;
+  }
+  virtual void load_batch(Batch<Dtype>* batch, int thread_id, size_t queue_id);
+  size_t queue_id(size_t thread_id) const override;
+
+  void init_offsets();
+  void start_reading() override {
+    reader_->start_reading();
+  }
+
+  shared_ptr<DataReader<AnnotatedDatum>> sample_reader_, reader_;
+  mutable vector<size_t> parser_offsets_, queue_ids_;
+  Flag layer_inititialized_flag_;
+  std::atomic_bool sample_only_;
+  mutable std::mutex mutex_setup_, mutex_prefetch_;
+  const bool cache_, shuffle_;
+  
+  bool has_anno_type_;
+  AnnotatedDatum_AnnotationType anno_type_;
+  vector<BatchSampler> batch_samplers_;
+  string label_map_file_;
+};
+
+}  // namespace caffe
+
+#endif  // CAFFE_DATA_LAYER_HPP_

--- a/include/caffe/layers/data_layer.hpp
+++ b/include/caffe/layers/data_layer.hpp
@@ -54,7 +54,7 @@ class DataLayer : public BasePrefetchingDataLayer<Ftype, Btype> {
     reader_->start_reading();
   }
 
-  shared_ptr<DataReader> sample_reader_, reader_;
+  shared_ptr<DataReader<Datum>> sample_reader_, reader_;
   mutable vector<size_t> parser_offsets_, queue_ids_;
   Flag layer_inititialized_flag_;
   std::atomic_bool sample_only_;

--- a/include/caffe/layers/detection_evaluate_layer.hpp
+++ b/include/caffe/layers/detection_evaluate_layer.hpp
@@ -1,0 +1,72 @@
+#ifndef CAFFE_DETECTION_EVALUATE_LAYER_HPP_
+#define CAFFE_DETECTION_EVALUATE_LAYER_HPP_
+
+#include <utility>
+#include <vector>
+
+#include "caffe/blob.hpp"
+#include "caffe/layer.hpp"
+#include "caffe/proto/caffe.pb.h"
+
+namespace caffe {
+
+/**
+ * @brief Generate the detection evaluation based on DetectionOutputLayer and
+ * ground truth bounding box labels.
+ *
+ * Intended for use with MultiBox detection method.
+ *
+ * NOTE: does not implement Backwards operation.
+ */
+template <typename Ftype, typename Btype>
+class DetectionEvaluateLayer : public Layer<Ftype,Btype> {
+ typedef Ftype Dtype;
+ public:
+  explicit DetectionEvaluateLayer(const LayerParameter& param)
+      : Layer<Ftype,Btype>(param) {}
+  virtual void LayerSetUp(const vector<Blob*>& bottom,
+      const vector<Blob*>& top);
+  virtual void Reshape(const vector<Blob*>& bottom,
+      const vector<Blob*>& top);
+
+  virtual inline const char* type() const { return "DetectionEvaluate"; }
+  virtual inline int ExactBottomBlobs() const { return 2; }
+  virtual inline int ExactNumTopBlobs() const { return 1; }
+
+ protected:
+  /**
+   * @brief Evaluate the detection output.
+   *
+   * @param bottom input Blob vector (exact 2)
+   *   -# @f$ (1 \times 1 \times N \times 7) @f$
+   *      N detection results.
+   *   -# @f$ (1 \times 1 \times M \times 7) @f$
+   *      M ground truth.
+   * @param top Blob vector (length 1)
+   *   -# @f$ (1 \times 1 \times N \times 4) @f$
+   *      N is the number of detections, and each row is:
+   *      [image_id, label, confidence, true_pos, false_pos]
+   */
+  virtual void Forward_cpu(const vector<Blob*>& bottom,
+      const vector<Blob*>& top);
+  /// @brief Not implemented
+  virtual void Backward_cpu(const vector<Blob*>& top,
+      const vector<bool>& propagate_down, const vector<Blob*>& bottom) {
+    NOT_IMPLEMENTED;
+  }
+
+  int num_classes_;
+  int background_label_id_;
+  float overlap_threshold_;
+  bool evaluate_difficult_gt_;
+  vector<pair<int, int> > sizes_;
+  int count_;
+  bool use_normalized_bbox_;
+
+  bool has_resize_;
+  ResizeParameter resize_param_;
+};
+
+}  // namespace caffe
+
+#endif  // CAFFE_DETECTION_EVALUATE_LAYER_HPP_

--- a/include/caffe/layers/detection_output_layer.hpp
+++ b/include/caffe/layers/detection_output_layer.hpp
@@ -1,0 +1,121 @@
+#ifndef CAFFE_DETECTION_OUTPUT_LAYER_HPP_
+#define CAFFE_DETECTION_OUTPUT_LAYER_HPP_
+
+#ifdef WITH_JSON
+#include <boost/property_tree/json_parser.hpp>
+#endif
+#include <boost/property_tree/ptree.hpp>
+#include <boost/regex.hpp>
+
+#include <map>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "caffe/blob.hpp"
+#include "caffe/data_transformer.hpp"
+#include "caffe/layer.hpp"
+#include "caffe/proto/caffe.pb.h"
+#include "caffe/util/bbox_util.hpp"
+
+using namespace boost::property_tree;  // NOLINT(build/namespaces)
+
+namespace caffe {
+
+/**
+ * @brief Generate the detection output based on location and confidence
+ * predictions by doing non maximum suppression.
+ *
+ * Intended for use with MultiBox detection method.
+ *
+ * NOTE: does not implement Backwards operation.
+ */
+template <typename Ftype, typename Btype>
+class DetectionOutputLayer : public Layer<Ftype,Btype> {
+ typedef Ftype Dtype;
+ public:
+  explicit DetectionOutputLayer(const LayerParameter& param)
+      : Layer<Ftype,Btype>(param) {}
+  virtual void LayerSetUp(const vector<Blob*>& bottom,
+      const vector<Blob*>& top);
+  virtual void Reshape(const vector<Blob*>& bottom,
+      const vector<Blob*>& top);
+
+  virtual inline const char* type() const { return "DetectionOutput"; }
+  virtual inline int MinBottomBlobs() const { return 3; }
+  virtual inline int MaxBottomBlobs() const { return 4; }
+  virtual inline int ExactNumTopBlobs() const { return 1; }
+
+ protected:
+  /**
+   * @brief Do non maximum suppression (nms) on prediction results.
+   *
+   * @param bottom input Blob vector (at least 2)
+   *   -# @f$ (N \times C1 \times 1 \times 1) @f$
+   *      the location predictions with C1 predictions.
+   *   -# @f$ (N \times C2 \times 1 \times 1) @f$
+   *      the confidence predictions with C2 predictions.
+   *   -# @f$ (N \times 2 \times C3 \times 1) @f$
+   *      the prior bounding boxes with C3 values.
+   * @param top output Blob vector (length 1)
+   *   -# @f$ (1 \times 1 \times N \times 7) @f$
+   *      N is the number of detections after nms, and each row is:
+   *      [image_id, label, confidence, xmin, ymin, xmax, ymax]
+   */
+  virtual void Forward_cpu(const vector<Blob*>& bottom,
+      const vector<Blob*>& top);
+  virtual void Forward_gpu(const vector<Blob*>& bottom,
+      const vector<Blob*>& top);
+  /// @brief Not implemented
+  virtual void Backward_cpu(const vector<Blob*>& top,
+      const vector<bool>& propagate_down, const vector<Blob*>& bottom) {
+    NOT_IMPLEMENTED;
+  }
+  virtual void Backward_gpu(const vector<Blob*>& top,
+      const vector<bool>& propagate_down, const vector<Blob*>& bottom) {
+    NOT_IMPLEMENTED;
+  }
+
+  int num_classes_;
+  bool share_location_;
+  int num_loc_classes_;
+  int background_label_id_;
+  CodeType code_type_;
+  bool variance_encoded_in_target_;
+  int keep_top_k_;
+  float confidence_threshold_;
+
+  int num_;
+  int num_priors_;
+
+  float nms_threshold_;
+  int top_k_;
+  float eta_;
+
+  bool need_save_;
+  string output_directory_;
+  string output_name_prefix_;
+  string output_format_;
+  map<int, string> label_to_name_;
+  map<int, string> label_to_display_name_;
+  vector<string> names_;
+  vector<pair<int, int> > sizes_;
+  int num_test_image_;
+  int name_count_;
+  bool has_resize_;
+  ResizeParameter resize_param_;
+
+  ptree detections_;
+
+  bool visualize_;
+  float visualize_threshold_;
+  shared_ptr<DataTransformer<Ftype> > data_transformer_;
+  string save_file_;
+  TBlob<Dtype> bbox_preds_;
+  TBlob<Dtype> bbox_permute_;
+  TBlob<Dtype> conf_permute_;
+};
+
+}  // namespace caffe
+
+#endif  // CAFFE_DETECTION_OUTPUT_LAYER_HPP_

--- a/include/caffe/layers/loss_layer.hpp
+++ b/include/caffe/layers/loss_layer.hpp
@@ -21,6 +21,7 @@ const float kLOG_THRESHOLD = 1e-20;
  */
 template <typename Ftype, typename Btype>
 class LossLayer : public Layer<Ftype, Btype> {
+ typedef Ftype Dtype;
  public:
   explicit LossLayer(const LayerParameter& param)
      : Layer<Ftype, Btype>(param) {}
@@ -28,6 +29,16 @@ class LossLayer : public Layer<Ftype, Btype> {
       const vector<Blob*>& bottom, const vector<Blob*>& top);
   virtual void Reshape(
       const vector<Blob*>& bottom, const vector<Blob*>& top);
+
+  /**
+   * Read the normalization mode parameter and compute the normalizer based
+   * on the blob size. If normalization_mode is VALID, the count of valid
+   * outputs will be read from valid_count, unless it is -1 in which case
+   * all outputs are assumed to be valid.
+   */
+  Ftype GetNormalizer(
+      const LossParameter_NormalizationMode normalization_mode,
+      const int outer_num, const int inner_num, const int valid_count);
 
   virtual inline int ExactNumBottomBlobs() const { return 2; }
 

--- a/include/caffe/layers/multibox_loss_layer.hpp
+++ b/include/caffe/layers/multibox_loss_layer.hpp
@@ -1,0 +1,113 @@
+#ifndef CAFFE_MULTIBOX_LOSS_LAYER_HPP_
+#define CAFFE_MULTIBOX_LOSS_LAYER_HPP_
+
+#include <map>
+#include <utility>
+#include <vector>
+
+#include "caffe/blob.hpp"
+#include "caffe/layer.hpp"
+#include "caffe/proto/caffe.pb.h"
+#include "caffe/util/bbox_util.hpp"
+
+#include "caffe/layers/loss_layer.hpp"
+
+namespace caffe {
+
+/**
+ * @brief Perform MultiBox operations. Including the following:
+ *
+ *  - decode the predictions.
+ *  - perform matching between priors/predictions and ground truth.
+ *  - use matched boxes and confidences to compute loss.
+ *
+ */
+template <typename Ftype,typename Btype>
+class MultiBoxLossLayer : public LossLayer<Ftype,Btype> {
+ typedef Ftype Dtype;
+ public:
+  explicit MultiBoxLossLayer(const LayerParameter& param)
+      : LossLayer<Ftype,Btype>(param) {}
+  virtual void LayerSetUp(const vector<Blob*>& bottom,
+      const vector<Blob*>& top);
+  virtual void Reshape(const vector<Blob*>& bottom,
+      const vector<Blob*>& top);
+
+  virtual inline const char* type() const { return "MultiBoxLoss"; }
+  // bottom[0] stores the location predictions.
+  // bottom[1] stores the confidence predictions.
+  // bottom[2] stores the prior bounding boxes.
+  // bottom[3] stores the ground truth bounding boxes.
+  virtual inline int ExactNumBottomBlobs() const { return 4; }
+  virtual inline int ExactNumTopBlobs() const { return 1; }
+
+ protected:
+  virtual void Forward_cpu(const vector<Blob*>& bottom,
+      const vector<Blob*>& top);
+  virtual void Backward_cpu(const vector<Blob*>& top,
+      const vector<bool>& propagate_down, const vector<Blob*>& bottom);
+
+  // The internal localization loss layer.
+  shared_ptr<LayerBase> loc_loss_layer_;
+  LocLossType loc_loss_type_;
+  float loc_weight_;
+  // bottom vector holder used in Forward function.
+  vector<Blob*> loc_bottom_vec_;
+  // top vector holder used in Forward function.
+  vector<Blob*> loc_top_vec_;
+  // blob which stores the matched location prediction.
+  TBlob<Dtype> loc_pred_;
+  // blob which stores the corresponding matched ground truth.
+  TBlob<Dtype> loc_gt_;
+  // localization loss.
+  TBlob<Dtype> loc_loss_;
+
+  // The internal confidence loss layer.
+  shared_ptr<LayerBase> conf_loss_layer_;
+  ConfLossType conf_loss_type_;
+  // bottom vector holder used in Forward function.
+  vector<Blob*> conf_bottom_vec_;
+  // top vector holder used in Forward function.
+  vector<Blob*> conf_top_vec_;
+  // blob which stores the confidence prediction.
+  TBlob<Dtype> conf_pred_;
+  // blob which stores the corresponding ground truth label.
+  TBlob<Dtype> conf_gt_;
+  // confidence loss.
+  TBlob<Dtype> conf_loss_;
+
+  MultiBoxLossParameter multibox_loss_param_;
+  int num_classes_;
+  bool share_location_;
+  MatchType match_type_;
+  float overlap_threshold_;
+  bool use_prior_for_matching_;
+  int background_label_id_;
+  bool use_difficult_gt_;
+  bool do_neg_mining_;
+  float neg_pos_ratio_;
+  float neg_overlap_;
+  CodeType code_type_;
+  bool encode_variance_in_target_;
+  bool map_object_to_agnostic_;
+  bool ignore_cross_boundary_bbox_;
+  bool bp_inside_;
+  MiningType mining_type_;
+
+  int loc_classes_;
+  int num_gt_;
+  int num_;
+  int num_priors_;
+
+  int num_matches_;
+  int num_conf_;
+  vector<map<int, vector<int> > > all_match_indices_;
+  vector<vector<int> > all_neg_indices_;
+
+  // How to normalize the loss.
+  LossParameter_NormalizationMode normalization_;
+};
+
+}  // namespace caffe
+
+#endif  // CAFFE_MULTIBOX_LOSS_LAYER_HPP_

--- a/include/caffe/layers/normalize_layer.hpp
+++ b/include/caffe/layers/normalize_layer.hpp
@@ -1,0 +1,52 @@
+#ifndef CAFFE_NORMALIZE_LAYER_HPP_
+#define CAFFE_NORMALIZE_LAYER_HPP_
+
+#include <vector>
+
+#include "caffe/blob.hpp"
+#include "caffe/layer.hpp"
+#include "caffe/proto/caffe.pb.h"
+
+namespace caffe {
+
+/**
+ * @brief Normalizes the input to have L_p norm of 1 with scale learnable.
+ *
+ * TODO(weiliu89): thorough documentation for Forward, Backward, and proto params.
+ */
+template <typename Ftype, typename Btype>
+class NormalizeLayer : public Layer<Ftype,Btype> {
+ typedef Ftype Dtype;
+ public:
+  explicit NormalizeLayer(const LayerParameter& param)
+      : Layer<Ftype,Btype>(param) {}
+  virtual void LayerSetUp(const vector<Blob*>& bottom,
+      const vector<Blob*>& top);
+  virtual void Reshape(const vector<Blob*>& bottom,
+      const vector<Blob*>& top);
+
+  virtual inline const char* type() const { return "Normalize"; }
+  virtual inline int ExactNumBottomBlobs() const { return 1; }
+  virtual inline int ExactNumTopBlobs() const { return 1; }
+
+ protected:
+  virtual void Forward_cpu(const vector<Blob*>& bottom,
+      const vector<Blob*>& top);
+  virtual void Forward_gpu(const vector<Blob*>& bottom,
+      const vector<Blob*>& top);
+  virtual void Backward_cpu(const vector<Blob*>& top,
+      const vector<bool>& propagate_down, const vector<Blob*>& bottom);
+  virtual void Backward_gpu(const vector<Blob*>& top,
+     const vector<bool>& propagate_down, const vector<Blob*>& bottom);
+
+  TBlob<Dtype> norm_;
+  TBlob<Dtype> sum_channel_multiplier_, sum_spatial_multiplier_;
+  TBlob<Dtype> buffer_, buffer_channel_, buffer_spatial_;
+  bool across_spatial_;
+  bool channel_shared_;
+  Dtype eps_;
+};
+
+}  // namespace caffe
+
+#endif  // CAFFE_MVN_LAYER_HPP_

--- a/include/caffe/layers/permute_layer.hpp
+++ b/include/caffe/layers/permute_layer.hpp
@@ -1,0 +1,60 @@
+#ifndef CAFFE_PERMUTE_LAYER_HPP_
+#define CAFFE_PERMUTE_LAYER_HPP_
+
+#include <vector>
+
+#include "caffe/blob.hpp"
+#include "caffe/layer.hpp"
+#include "caffe/proto/caffe.pb.h"
+
+namespace caffe {
+
+/**
+ * @brief Permute the input blob by changing the memory order of the data.
+ *
+ * TODO(weiliu89): thorough documentation for Forward, Backward, and proto params.
+ */
+
+// The main function which does the permute.
+template <typename Dtype>
+void Permute(const int count, Dtype* bottom_data, const bool forward,
+    const int* permute_order, const int* old_steps, const int* new_steps,
+    const int num_axes, Dtype* top_data);
+
+template <typename Ftype, typename Btype>
+class PermuteLayer : public Layer<Ftype,Btype> {
+ typedef Ftype Dtype;
+ public:
+  explicit PermuteLayer(const LayerParameter& param)
+      : Layer<Ftype,Btype>(param) {}
+  virtual void LayerSetUp(const vector<Blob*>& bottom,
+      const vector<Blob*>& top);
+  virtual void Reshape(const vector<Blob*>& bottom,
+      const vector<Blob*>& top);
+
+  virtual inline const char* type() const { return "Permute"; }
+  virtual inline int ExactNumBottomBlobs() const { return 1; }
+  virtual inline int ExactNumTopBlobs() const { return 1; }
+
+ protected:
+  virtual void Forward_cpu(const vector<Blob*>& bottom,
+      const vector<Blob*>& top);
+  virtual void Forward_gpu(const vector<Blob*>& bottom,
+      const vector<Blob*>& top);
+  virtual void Backward_cpu(const vector<Blob*>& top,
+      const vector<bool>& propagate_down, const vector<Blob*>& bottom);
+  virtual void Backward_gpu(const vector<Blob*>& top,
+      const vector<bool>& propagate_down, const vector<Blob*>& bottom);
+
+  int num_axes_;
+  bool need_permute_;
+
+  // Use Blob because it is convenient to be accessible in .cu file.
+  TBlob<int> permute_order_;
+  TBlob<int> old_steps_;
+  TBlob<int> new_steps_;
+};
+
+}  // namespace caffe
+
+#endif  // CAFFE_PERMUTE_LAYER_HPP_

--- a/include/caffe/layers/prior_box_layer.hpp
+++ b/include/caffe/layers/prior_box_layer.hpp
@@ -1,0 +1,85 @@
+#ifndef CAFFE_PRIORBOX_LAYER_HPP_
+#define CAFFE_PRIORBOX_LAYER_HPP_
+
+#include <vector>
+
+#include "caffe/blob.hpp"
+#include "caffe/layer.hpp"
+#include "caffe/proto/caffe.pb.h"
+
+namespace caffe {
+
+/**
+ * @brief Generate the prior boxes of designated sizes and aspect ratios across
+ *        all dimensions @f$ (H \times W) @f$.
+ *
+ * Intended for use with MultiBox detection method to generate prior (template).
+ *
+ * NOTE: does not implement Backwards operation.
+ */
+template <typename Ftype, typename Btype>
+class PriorBoxLayer : public Layer<Ftype,Btype> {
+ typedef Ftype Dtype;
+ public:
+  /**
+   * @param param provides PriorBoxParameter prior_box_param,
+   *     with PriorBoxLayer options:
+   *   - min_size (\b minimum box size in pixels. can be multiple. required!).
+   *   - max_size (\b maximum box size in pixels. can be ignored or same as the
+   *   # of min_size.).
+   *   - aspect_ratio (\b optional aspect ratios of the boxes. can be multiple).
+   *   - flip (\b optional bool, default true).
+   *     if set, flip the aspect ratio.
+   */
+  explicit PriorBoxLayer(const LayerParameter& param)
+      : Layer<Ftype,Btype>(param) {}
+  virtual void LayerSetUp(const vector<Blob*>& bottom,
+      const vector<Blob*>& top);
+  virtual void Reshape(const vector<Blob*>& bottom,
+      const vector<Blob*>& top);
+
+  virtual inline const char* type() const { return "PriorBox"; }
+  virtual inline int ExactBottomBlobs() const { return 2; }
+  virtual inline int ExactNumTopBlobs() const { return 1; }
+
+ protected:
+  /**
+   * @brief Generates prior boxes for a layer with specified parameters.
+   *
+   * @param bottom input Blob vector (at least 2)
+   *   -# @f$ (N \times C \times H_i \times W_i) @f$
+   *      the input layer @f$ x_i @f$
+   *   -# @f$ (N \times C \times H_0 \times W_0) @f$
+   *      the data layer @f$ x_0 @f$
+   * @param top output Blob vector (length 1)
+   *   -# @f$ (N \times 2 \times K*4) @f$ where @f$ K @f$ is the prior numbers
+   *   By default, a box of aspect ratio 1 and min_size and a box of aspect
+   *   ratio 1 and sqrt(min_size * max_size) are created.
+   */
+  virtual void Forward_cpu(const vector<Blob*>& bottom,
+      const vector<Blob*>& top);
+  /// @brief Not implemented
+  virtual void Backward_cpu(const vector<Blob*>& top,
+      const vector<bool>& propagate_down, const vector<Blob*>& bottom) {
+    return;
+  }
+
+  vector<float> min_sizes_;
+  vector<float> max_sizes_;
+  vector<float> aspect_ratios_;
+  bool flip_;
+  int num_priors_;
+  bool clip_;
+  vector<float> variance_;
+
+  int img_w_;
+  int img_h_;
+  float step_w_;
+  float step_h_;
+
+  float offset_;
+};
+
+}  // namespace caffe
+
+#endif  // CAFFE_PRIORBOX_LAYER_HPP_

--- a/include/caffe/layers/smooth_L1_loss_layer.hpp
+++ b/include/caffe/layers/smooth_L1_loss_layer.hpp
@@ -1,0 +1,69 @@
+// ------------------------------------------------------------------
+// Fast R-CNN
+// copyright (c) 2015 Microsoft
+// Licensed under The MIT License [see fast-rcnn/LICENSE for details]
+// Written by Ross Girshick
+// Modified by Wei Liu
+// ------------------------------------------------------------------
+
+#ifndef CAFFE_SMOOTH_L1_LOSS_LAYER_HPP_
+#define CAFFE_SMOOTH_L1_LOSS_LAYER_HPP_
+
+#include <vector>
+
+#include "caffe/blob.hpp"
+#include "caffe/layer.hpp"
+#include "caffe/proto/caffe.pb.h"
+
+#include "caffe/layers/loss_layer.hpp"
+
+namespace caffe {
+
+/**
+ * @brief Computes the SmoothL1 loss as introduced in:@f$
+ *  Fast R-CNN, Ross Girshick, ICCV 2015.
+ */
+template <typename Ftype, typename Btype>
+class SmoothL1LossLayer : public LossLayer<Ftype,Btype> {
+ typedef Ftype Dtype;
+ public:
+  explicit SmoothL1LossLayer(const LayerParameter& param)
+      : LossLayer<Ftype,Btype>(param), diff_() {}
+  virtual void LayerSetUp(const vector<Blob*>& bottom,
+      const vector<Blob*>& top);
+  virtual void Reshape(const vector<Blob*>& bottom,
+      const vector<Blob*>& top);
+
+  virtual inline const char* type() const { return "SmoothL1Loss"; }
+
+  virtual inline int MinBottomBlobs() const { return 2; }
+  virtual inline int MaxBottomBlobs() const { return 3; }
+
+  /**
+   * Unlike most loss layers, in the SmoothL1LossLayer we can backpropagate
+   * to both inputs -- override to return true and always allow force_backward.
+   */
+  virtual inline bool AllowForceBackward(const int bottom_index) const {
+    return true;
+  }
+
+ protected:
+  /// @copydoc SmoothL1LossLayer
+  virtual void Forward_cpu(const vector<Blob*>& bottom,
+      const vector<Blob*>& top);
+  virtual void Forward_gpu(const vector<Blob*>& bottom,
+      const vector<Blob*>& top);
+
+  virtual void Backward_cpu(const vector<Blob*>& top,
+      const vector<bool>& propagate_down, const vector<Blob*>& bottom);
+  virtual void Backward_gpu(const vector<Blob*>& top,
+      const vector<bool>& propagate_down, const vector<Blob*>& bottom);
+
+  TBlob<Dtype> diff_;
+  TBlob<Dtype> errors_;
+  bool has_weights_;
+};
+
+}  // namespace caffe
+
+#endif  // CAFFE_SMOOTH_L1_LOSS_LAYER_HPP_

--- a/include/caffe/layers/video_data_layer.hpp
+++ b/include/caffe/layers/video_data_layer.hpp
@@ -1,0 +1,59 @@
+#ifndef CAFFE_VIDEO_DATA_LAYER_HPP_
+#define CAFFE_VIDEO_DATA_LAYER_HPP_
+
+#ifdef USE_OPENCV
+#if OPENCV_VERSION == 3
+#include <opencv2/videoio.hpp>
+#else
+#include <opencv2/opencv.hpp>
+#endif  // OPENCV_VERSION == 3
+
+#include <string>
+#include <vector>
+
+#include "caffe/blob.hpp"
+#include "caffe/data_transformer.hpp"
+#include "caffe/internal_thread.hpp"
+#include "caffe/layer.hpp"
+#include "caffe/layers/base_data_layer.hpp"
+#include "caffe/proto/caffe.pb.h"
+#include "caffe/util/db.hpp"
+
+namespace caffe {
+
+/**
+ * @brief Provides data to the Net from webcam or video files.
+ *
+ * TODO(weiliu89): thorough documentation for Forward and proto params.
+ */
+template <typename Ftype, typename Btype>
+class VideoDataLayer : public BasePrefetchingDataLayer<Ftype,Btype> {
+ typedef Ftype Dtype;
+ public:
+  explicit VideoDataLayer(const LayerParameter& param);
+  virtual ~VideoDataLayer();
+  virtual void DataLayerSetUp(const vector<Blob*>& bottom,
+      const vector<Blob*>& top);
+  virtual inline bool ShareInParallel() const { return false; }
+  virtual inline const char* type() const { return "VideoData"; }
+  virtual inline int ExactNumBottomBlobs() const { return 0; }
+  virtual inline int MinTopBlobs() const { return 1; }
+
+ protected:
+  virtual void load_batch(Batch<Ftype>* batch, int thread_id, size_t queue_id);
+  void start_reading() override {}
+  
+  VideoDataParameter_VideoType video_type_;
+  cv::VideoCapture cap_;
+
+  int skip_frames_;
+
+  int total_frames_;
+  int processed_frames_;
+  vector<int> top_shape_;
+};
+
+}  // namespace caffe
+#endif  // USE_OPENCV
+
+#endif  // CAFFE_VIDEO_DATA_LAYER_HPP_

--- a/include/caffe/parallel.hpp
+++ b/include/caffe/parallel.hpp
@@ -36,7 +36,7 @@ struct SharedScores {
 
  private:
   vector<vector<Dtype>> memory_;
-  static constexpr size_t MAX_SCORES = 1000;
+  static constexpr size_t MAX_SCORES = 1000*10;
 };
 
 template<typename Dtype>

--- a/include/caffe/solver.hpp
+++ b/include/caffe/solver.hpp
@@ -152,6 +152,7 @@ class Solver {
   // The test routine
   bool TestAll(const int iters = 0, bool use_multi_gpu = false);
   bool Test(const int test_net_id = 0, const int iters = 0, bool use_multi_gpu = false);
+  void TestDetection(const int test_net_id = 0);
   virtual void SnapshotSolverState(const string& model_filename) = 0;
   virtual void RestoreSolverStateFromHDF5(const string& state_file) = 0;
   virtual void RestoreSolverStateFromBinaryProto(const string& state_file) = 0;

--- a/include/caffe/type.hpp
+++ b/include/caffe/type.hpp
@@ -35,7 +35,22 @@ template <>
 inline constexpr Type tp<unsigned int>() {
   return UINT;
 }
+template <>
+inline constexpr Type tp<bool>() {
+  //CHECK(false) << "Should not reach here: tp<bool>()";
+  return BOOL;
+}
 
+template <typename Dtype>
+constexpr DatumTypeInfo datum_tp();
+template <>
+inline constexpr DatumTypeInfo datum_tp<Datum>() {
+  return DatumTypeInfo_DATUM;
+}
+template <>
+inline constexpr DatumTypeInfo datum_tp<AnnotatedDatum>() {
+  return DatumTypeInfo_ANNOTATED_DATUM;
+}
 
 template <typename T1, typename T2>
 Type tpmax() {

--- a/include/caffe/util/bbox_util.hpp
+++ b/include/caffe/util/bbox_util.hpp
@@ -1,0 +1,524 @@
+#ifdef USE_OPENCV
+#include <opencv2/core/core.hpp>
+#include <opencv2/highgui/highgui.hpp>
+#include <opencv2/imgproc/imgproc.hpp>
+#endif  // USE_OPENCV
+
+#ifndef CAFFE_UTIL_BBOX_UTIL_H_
+#define CAFFE_UTIL_BBOX_UTIL_H_
+
+#include <stdint.h>
+#include <cmath>  // for std::fabs and std::signbit
+#include <map>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "glog/logging.h"
+
+#include "caffe/caffe.hpp"
+
+namespace caffe {
+
+typedef EmitConstraint_EmitType EmitType;
+typedef PriorBoxParameter_CodeType CodeType;
+typedef MultiBoxLossParameter_MatchType MatchType;
+typedef MultiBoxLossParameter_LocLossType LocLossType;
+typedef MultiBoxLossParameter_ConfLossType ConfLossType;
+typedef MultiBoxLossParameter_MiningType MiningType;
+
+typedef map<int, vector<NormalizedBBox> > LabelBBox;
+
+// Function used to sort NormalizedBBox, stored in STL container (e.g. vector),
+// in ascend order based on the score value.
+bool SortBBoxAscend(const NormalizedBBox& bbox1, const NormalizedBBox& bbox2);
+
+// Function used to sort NormalizedBBox, stored in STL container (e.g. vector),
+// in descend order based on the score value.
+bool SortBBoxDescend(const NormalizedBBox& bbox1, const NormalizedBBox& bbox2);
+
+// Function sued to sort pair<float, T>, stored in STL container (e.g. vector)
+// in descend order based on the score (first) value.
+template <typename T>
+bool SortScorePairAscend(const pair<float, T>& pair1,
+                         const pair<float, T>& pair2);
+
+// Function sued to sort pair<float, T>, stored in STL container (e.g. vector)
+// in descend order based on the score (first) value.
+template <typename T>
+bool SortScorePairDescend(const pair<float, T>& pair1,
+                          const pair<float, T>& pair2);
+
+// Generate unit bbox [0, 0, 1, 1]
+NormalizedBBox UnitBBox();
+
+// Check if a bbox is cross boundary or not.
+bool IsCrossBoundaryBBox(const NormalizedBBox& bbox);
+
+// Compute the intersection between two bboxes.
+void IntersectBBox(const NormalizedBBox& bbox1, const NormalizedBBox& bbox2,
+                   NormalizedBBox* intersect_bbox);
+
+// Compute bbox size.
+float BBoxSize(const NormalizedBBox& bbox, const bool normalized = true);
+
+template <typename Dtype>
+Dtype BBoxSize(const Dtype* bbox, const bool normalized = true);
+
+// Clip the NormalizedBBox such that the range for each corner is [0, 1].
+void ClipBBox(const NormalizedBBox& bbox, NormalizedBBox* clip_bbox);
+
+// Clip the bbox such that the bbox is within [0, 0; width, height].
+void ClipBBox(const NormalizedBBox& bbox, const float height, const float width,
+              NormalizedBBox* clip_bbox);
+
+// Scale the NormalizedBBox w.r.t. height and width.
+void ScaleBBox(const NormalizedBBox& bbox, const int height, const int width,
+               NormalizedBBox* scale_bbox);
+
+// Output predicted bbox on the actual image.
+void OutputBBox(const NormalizedBBox& bbox, const pair<int, int>& img_size,
+                const bool has_resize, const ResizeParameter& resize_param,
+                NormalizedBBox* out_bbox);
+
+// Locate bbox in the coordinate system that src_bbox sits.
+void LocateBBox(const NormalizedBBox& src_bbox, const NormalizedBBox& bbox,
+                NormalizedBBox* loc_bbox);
+
+// Project bbox onto the coordinate system defined by src_bbox.
+bool ProjectBBox(const NormalizedBBox& src_bbox, const NormalizedBBox& bbox,
+                 NormalizedBBox* proj_bbox);
+
+// Extrapolate the transformed bbox if height_scale and width_scale is
+// explicitly provided, and it is only effective for FIT_SMALL_SIZE case.
+void ExtrapolateBBox(const ResizeParameter& param, const int height,
+    const int width, const NormalizedBBox& crop_bbox, NormalizedBBox* bbox);
+
+// Compute the jaccard (intersection over union IoU) overlap between two bboxes.
+float JaccardOverlap(const NormalizedBBox& bbox1, const NormalizedBBox& bbox2,
+                     const bool normalized = true);
+
+template <typename Dtype>
+Dtype JaccardOverlap(const Dtype* bbox1, const Dtype* bbox2);
+
+// Compute the coverage of bbox1 by bbox2.
+float BBoxCoverage(const NormalizedBBox& bbox1, const NormalizedBBox& bbox2);
+
+// Encode a bbox according to a prior bbox.
+void EncodeBBox(const NormalizedBBox& prior_bbox,
+    const vector<float>& prior_variance, const CodeType code_type,
+    const bool encode_variance_in_target, const NormalizedBBox& bbox,
+    NormalizedBBox* encode_bbox);
+
+// Check if a bbox meet emit constraint w.r.t. src_bbox.
+bool MeetEmitConstraint(const NormalizedBBox& src_bbox,
+    const NormalizedBBox& bbox, const EmitConstraint& emit_constraint);
+
+// Decode a bbox according to a prior bbox.
+void DecodeBBox(const NormalizedBBox& prior_bbox,
+    const vector<float>& prior_variance, const CodeType code_type,
+    const bool variance_encoded_in_target, const bool clip_bbox,
+    const NormalizedBBox& bbox, NormalizedBBox* decode_bbox);
+
+// Decode a set of bboxes according to a set of prior bboxes.
+void DecodeBBoxes(const vector<NormalizedBBox>& prior_bboxes,
+    const vector<vector<float> >& prior_variances,
+    const CodeType code_type, const bool variance_encoded_in_target,
+    const bool clip_bbox, const vector<NormalizedBBox>& bboxes,
+    vector<NormalizedBBox>* decode_bboxes);
+
+// Decode all bboxes in a batch.
+void DecodeBBoxesAll(const vector<LabelBBox>& all_loc_pred,
+    const vector<NormalizedBBox>& prior_bboxes,
+    const vector<vector<float> >& prior_variances,
+    const int num, const bool share_location,
+    const int num_loc_classes, const int background_label_id,
+    const CodeType code_type, const bool variance_encoded_in_target,
+    const bool clip, vector<LabelBBox>* all_decode_bboxes);
+
+// Match prediction bboxes with ground truth bboxes.
+void MatchBBox(const vector<NormalizedBBox>& gt,
+    const vector<NormalizedBBox>& pred_bboxes, const int label,
+    const MatchType match_type, const float overlap_threshold,
+    const bool ignore_cross_boundary_bbox,
+    vector<int>* match_indices, vector<float>* match_overlaps);
+
+// Find matches between prediction bboxes and ground truth bboxes.
+//    all_loc_preds: stores the location prediction, where each item contains
+//      location prediction for an image.
+//    all_gt_bboxes: stores ground truth bboxes for the batch.
+//    prior_bboxes: stores all the prior bboxes in the format of NormalizedBBox.
+//    prior_variances: stores all the variances needed by prior bboxes.
+//    multibox_loss_param: stores the parameters for MultiBoxLossLayer.
+//    all_match_overlaps: stores jaccard overlaps between predictions and gt.
+//    all_match_indices: stores mapping between predictions and ground truth.
+void FindMatches(const vector<LabelBBox>& all_loc_preds,
+      const map<int, vector<NormalizedBBox> >& all_gt_bboxes,
+      const vector<NormalizedBBox>& prior_bboxes,
+      const vector<vector<float> >& prior_variances,
+      const MultiBoxLossParameter& multibox_loss_param,
+      vector<map<int, vector<float> > >* all_match_overlaps,
+      vector<map<int, vector<int> > >* all_match_indices);
+
+// Count the number of matches from the match indices.
+int CountNumMatches(const vector<map<int, vector<int> > >& all_match_indices,
+                    const int num);
+
+// Mine the hard examples from the batch.
+//    conf_blob: stores the confidence prediction.
+//    all_loc_preds: stores the location prediction, where each item contains
+//      location prediction for an image.
+//    all_gt_bboxes: stores ground truth bboxes for the batch.
+//    prior_bboxes: stores all the prior bboxes in the format of NormalizedBBox.
+//    prior_variances: stores all the variances needed by prior bboxes.
+//    all_match_overlaps: stores jaccard overlap between predictions and gt.
+//    multibox_loss_param: stores the parameters for MultiBoxLossLayer.
+//    all_match_indices: stores mapping between predictions and ground truth.
+//    all_loc_loss: stores the confidence loss per location for each image.
+template <typename Dtype>
+void MineHardExamples(const TBlob<Dtype>& conf_blob,
+    const vector<LabelBBox>& all_loc_preds,
+    const map<int, vector<NormalizedBBox> >& all_gt_bboxes,
+    const vector<NormalizedBBox>& prior_bboxes,
+    const vector<vector<float> >& prior_variances,
+    const vector<map<int, vector<float> > >& all_match_overlaps,
+    const MultiBoxLossParameter& multibox_loss_param,
+    int* num_matches, int* num_negs,
+    vector<map<int, vector<int> > >* all_match_indices,
+    vector<vector<int> >* all_neg_indices);
+
+// Retrieve bounding box ground truth from gt_data.
+//    gt_data: 1 x 1 x num_gt x 7 blob.
+//    num_gt: the number of ground truth.
+//    background_label_id: the label for background class which is used to do
+//      santity check so that no ground truth contains it.
+//    all_gt_bboxes: stores ground truth for each image. Label of each bbox is
+//      stored in NormalizedBBox.
+template <typename Dtype>
+void GetGroundTruth(const Dtype* gt_data, const int num_gt,
+      const int background_label_id, const bool use_difficult_gt,
+      map<int, vector<NormalizedBBox> >* all_gt_bboxes);
+// Store ground truth bboxes of same label in a group.
+template <typename Dtype>
+void GetGroundTruth(const Dtype* gt_data, const int num_gt,
+      const int background_label_id, const bool use_difficult_gt,
+      map<int, LabelBBox>* all_gt_bboxes);
+
+// Get location predictions from loc_data.
+//    loc_data: num x num_preds_per_class * num_loc_classes * 4 blob.
+//    num: the number of images.
+//    num_preds_per_class: number of predictions per class.
+//    num_loc_classes: number of location classes. It is 1 if share_location is
+//      true; and is equal to number of classes needed to predict otherwise.
+//    share_location: if true, all classes share the same location prediction.
+//    loc_preds: stores the location prediction, where each item contains
+//      location prediction for an image.
+template <typename Dtype>
+void GetLocPredictions(const Dtype* loc_data, const int num,
+      const int num_preds_per_class, const int num_loc_classes,
+      const bool share_location, vector<LabelBBox>* loc_preds);
+
+// Encode the localization prediction and ground truth for each matched prior.
+//    all_loc_preds: stores the location prediction, where each item contains
+//      location prediction for an image.
+//    all_gt_bboxes: stores ground truth bboxes for the batch.
+//    all_match_indices: stores mapping between predictions and ground truth.
+//    prior_bboxes: stores all the prior bboxes in the format of NormalizedBBox.
+//    prior_variances: stores all the variances needed by prior bboxes.
+//    multibox_loss_param: stores the parameters for MultiBoxLossLayer.
+//    loc_pred_data: stores the location prediction results.
+//    loc_gt_data: stores the encoded location ground truth.
+template <typename Dtype>
+void EncodeLocPrediction(const vector<LabelBBox>& all_loc_preds,
+      const map<int, vector<NormalizedBBox> >& all_gt_bboxes,
+      const vector<map<int, vector<int> > >& all_match_indices,
+      const vector<NormalizedBBox>& prior_bboxes,
+      const vector<vector<float> >& prior_variances,
+      const MultiBoxLossParameter& multibox_loss_param,
+      Dtype* loc_pred_data, Dtype* loc_gt_data);
+
+// Compute the localization loss per matched prior.
+//    loc_pred: stores the location prediction results.
+//    loc_gt: stores the encoded location ground truth.
+//    all_match_indices: stores mapping between predictions and ground truth.
+//    num: number of images in the batch.
+//    num_priors: total number of priors.
+//    loc_loss_type: type of localization loss, Smooth_L1 or L2.
+//    all_loc_loss: stores the localization loss for all priors in a batch.
+template <typename Dtype>
+void ComputeLocLoss(const TBlob<Dtype>& loc_pred, const TBlob<Dtype>& loc_gt,
+      const vector<map<int, vector<int> > >& all_match_indices,
+      const int num, const int num_priors, const LocLossType loc_loss_type,
+      vector<vector<float> >* all_loc_loss);
+
+// Get confidence predictions from conf_data.
+//    conf_data: num x num_preds_per_class * num_classes blob.
+//    num: the number of images.
+//    num_preds_per_class: number of predictions per class.
+//    num_classes: number of classes.
+//    conf_preds: stores the confidence prediction, where each item contains
+//      confidence prediction for an image.
+template <typename Dtype>
+void GetConfidenceScores(const Dtype* conf_data, const int num,
+      const int num_preds_per_class, const int num_classes,
+      vector<map<int, vector<float> > >* conf_scores);
+
+// Get confidence predictions from conf_data.
+//    conf_data: num x num_preds_per_class * num_classes blob.
+//    num: the number of images.
+//    num_preds_per_class: number of predictions per class.
+//    num_classes: number of classes.
+//    class_major: if true, data layout is
+//      num x num_classes x num_preds_per_class; otherwise, data layerout is
+//      num x num_preds_per_class * num_classes.
+//    conf_preds: stores the confidence prediction, where each item contains
+//      confidence prediction for an image.
+template <typename Dtype>
+void GetConfidenceScores(const Dtype* conf_data, const int num,
+      const int num_preds_per_class, const int num_classes,
+      const bool class_major, vector<map<int, vector<float> > >* conf_scores);
+
+// Compute the confidence loss for each prior from conf_data.
+//    conf_data: num x num_preds_per_class * num_classes blob.
+//    num: the number of images.
+//    num_preds_per_class: number of predictions per class.
+//    num_classes: number of classes.
+//    background_label_id: it is used to skip selecting max scores from
+//      background class.
+//    loss_type: compute the confidence loss according to the loss type.
+//    all_match_indices: stores mapping between predictions and ground truth.
+//    all_gt_bboxes: stores ground truth bboxes from the batch.
+//    all_conf_loss: stores the confidence loss per location for each image.
+template <typename Dtype>
+void ComputeConfLoss(const Dtype* conf_data, const int num,
+      const int num_preds_per_class, const int num_classes,
+      const int background_label_id, const ConfLossType loss_type,
+      const vector<map<int, vector<int> > >& all_match_indices,
+      const map<int, vector<NormalizedBBox> >& all_gt_bboxes,
+      vector<vector<float> >* all_conf_loss);
+
+// Compute the negative confidence loss for each prior from conf_data.
+//    conf_data: num x num_preds_per_class * num_classes blob.
+//    num: the number of images.
+//    num_preds_per_class: number of predictions per class.
+//    num_classes: number of classes.
+//    background_label_id: it is used to skip selecting max scores from
+//      background class.
+//    loss_type: compute the confidence loss according to the loss type.
+//    all_conf_loss: stores the confidence loss per location for each image.
+template <typename Dtype>
+void ComputeConfLoss(const Dtype* conf_data, const int num,
+      const int num_preds_per_class, const int num_classes,
+      const int background_label_id, const ConfLossType loss_type,
+      vector<vector<float> >* all_conf_loss);
+
+// Encode the confidence predictions and ground truth for each matched prior.
+//    conf_data: num x num_priors * num_classes blob.
+//    num: number of images.
+//    num_priors: number of priors (predictions) per image.
+//    multibox_loss_param: stores the parameters for MultiBoxLossLayer.
+//    all_match_indices: stores mapping between predictions and ground truth.
+//    all_neg_indices: stores the indices for negative samples.
+//    all_gt_bboxes: stores ground truth bboxes for the batch.
+//    conf_pred_data: stores the confidence prediction results.
+//    conf_gt_data: stores the confidence ground truth.
+template <typename Dtype>
+void EncodeConfPrediction(const Dtype* conf_data, const int num,
+      const int num_priors, const MultiBoxLossParameter& multibox_loss_param,
+      const vector<map<int, vector<int> > >& all_match_indices,
+      const vector<vector<int> >& all_neg_indices,
+      const map<int, vector<NormalizedBBox> >& all_gt_bboxes,
+      Dtype* conf_pred_data, Dtype* conf_gt_data);
+
+// Get prior bounding boxes from prior_data.
+//    prior_data: 1 x 2 x num_priors * 4 x 1 blob.
+//    num_priors: number of priors.
+//    prior_bboxes: stores all the prior bboxes in the format of NormalizedBBox.
+//    prior_variances: stores all the variances needed by prior bboxes.
+template <typename Dtype>
+void GetPriorBBoxes(const Dtype* prior_data, const int num_priors,
+      vector<NormalizedBBox>* prior_bboxes,
+      vector<vector<float> >* prior_variances);
+
+// Get detection results from det_data.
+//    det_data: 1 x 1 x num_det x 7 blob.
+//    num_det: the number of detections.
+//    background_label_id: the label for background class which is used to do
+//      santity check so that no detection contains it.
+//    all_detections: stores detection results for each class from each image.
+template <typename Dtype>
+void GetDetectionResults(const Dtype* det_data, const int num_det,
+      const int background_label_id,
+      map<int, LabelBBox>* all_detections);
+
+// Get top_k scores with corresponding indices.
+//    scores: a set of scores.
+//    indices: a set of corresponding indices.
+//    top_k: if -1, keep all; otherwise, keep at most top_k.
+//    score_index_vec: store the sorted (score, index) pair.
+void GetTopKScoreIndex(const vector<float>& scores, const vector<int>& indices,
+      const int top_k, vector<pair<float, int> >* score_index_vec);
+
+// Get max scores with corresponding indices.
+//    scores: a set of scores.
+//    threshold: only consider scores higher than the threshold.
+//    top_k: if -1, keep all; otherwise, keep at most top_k.
+//    score_index_vec: store the sorted (score, index) pair.
+void GetMaxScoreIndex(const vector<float>& scores, const float threshold,
+      const int top_k, vector<pair<float, int> >* score_index_vec);
+
+// Get max scores with corresponding indices.
+//    scores: an array of scores.
+//    num: number of total scores in the array.
+//    threshold: only consider scores higher than the threshold.
+//    top_k: if -1, keep all; otherwise, keep at most top_k.
+//    score_index_vec: store the sorted (score, index) pair.
+template <typename Dtype>
+void GetMaxScoreIndex(const Dtype* scores, const int num, const float threshold,
+      const int top_k, vector<pair<Dtype, int> >* score_index_vec);
+
+// Get max scores with corresponding indices.
+//    scores: a set of scores.
+//    threshold: only consider scores higher than the threshold.
+//    top_k: if -1, keep all; otherwise, keep at most top_k.
+//    score_index_vec: store the sorted (score, index) pair.
+void GetMaxScoreIndex(const vector<float>& scores, const float threshold,
+      const int top_k, vector<pair<float, int> >* score_index_vec);
+
+// Do non maximum suppression given bboxes and scores.
+//    bboxes: a set of bounding boxes.
+//    scores: a set of corresponding confidences.
+//    threshold: the threshold used in non maximum suppression.
+//    top_k: if not -1, keep at most top_k picked indices.
+//    reuse_overlaps: if true, use and update overlaps; otherwise, always
+//      compute overlap.
+//    overlaps: a temp place to optionally store the overlaps between pairs of
+//      bboxes if reuse_overlaps is true.
+//    indices: the kept indices of bboxes after nms.
+void ApplyNMS(const vector<NormalizedBBox>& bboxes, const vector<float>& scores,
+      const float threshold, const int top_k, const bool reuse_overlaps,
+      map<int, map<int, float> >* overlaps, vector<int>* indices);
+
+void ApplyNMS(const vector<NormalizedBBox>& bboxes, const vector<float>& scores,
+      const float threshold, const int top_k, vector<int>* indices);
+
+void ApplyNMS(const bool* overlapped, const int num, vector<int>* indices);
+
+// Do non maximum suppression given bboxes and scores.
+// Inspired by Piotr Dollar's NMS implementation in EdgeBox.
+// https://goo.gl/jV3JYS
+//    bboxes: a set of bounding boxes.
+//    scores: a set of corresponding confidences.
+//    score_threshold: a threshold used to filter detection results.
+//    nms_threshold: a threshold used in non maximum suppression.
+//    eta: adaptation rate for nms threshold (see Piotr's paper).
+//    top_k: if not -1, keep at most top_k picked indices.
+//    indices: the kept indices of bboxes after nms.
+void ApplyNMSFast(const vector<NormalizedBBox>& bboxes,
+      const vector<float>& scores, const float score_threshold,
+      const float nms_threshold, const float eta, const int top_k,
+      vector<int>* indices);
+
+// Do non maximum suppression based on raw bboxes and scores data.
+// Inspired by Piotr Dollar's NMS implementation in EdgeBox.
+// https://goo.gl/jV3JYS
+//    bboxes: an array of bounding boxes.
+//    scores: an array of corresponding confidences.
+//    num: number of total boxes/confidences in the array.
+//    score_threshold: a threshold used to filter detection results.
+//    nms_threshold: a threshold used in non maximum suppression.
+//    eta: adaptation rate for nms threshold (see Piotr's paper).
+//    top_k: if not -1, keep at most top_k picked indices.
+//    indices: the kept indices of bboxes after nms.
+template <typename Dtype>
+void ApplyNMSFast(const Dtype* bboxes, const Dtype* scores, const int num,
+      const float score_threshold, const float nms_threshold,
+      const float eta, const int top_k, vector<int>* indices);
+
+// Compute cumsum of a set of pairs.
+void CumSum(const vector<pair<float, int> >& pairs, vector<int>* cumsum);
+
+// Compute average precision given true positive and false positive vectors.
+//    tp: contains pairs of scores and true positive.
+//    num_pos: number of positives.
+//    fp: contains pairs of scores and false positive.
+//    ap_version: different ways of computing Average Precision.
+//      Check https://sanchom.wordpress.com/tag/average-precision/ for details.
+//      11point: the 11-point interpolated average precision. Used in VOC2007.
+//      MaxIntegral: maximally interpolated AP. Used in VOC2012/ILSVRC.
+//      Integral: the natural integral of the precision-recall curve.
+//    prec: stores the computed precisions.
+//    rec: stores the computed recalls.
+//    ap: the computed Average Precision.
+void ComputeAP(const vector<pair<float, int> >& tp, const int num_pos,
+               const vector<pair<float, int> >& fp, const string ap_version,
+               vector<float>* prec, vector<float>* rec, float* ap);
+
+#ifndef CPU_ONLY  // GPU
+template <typename Dtype>
+__host__ __device__ Dtype BBoxSizeGPU(const Dtype* bbox,
+                                      const bool normalized = true);
+
+template <typename Dtype>
+__host__ __device__ Dtype JaccardOverlapGPU(const Dtype* bbox1,
+                                            const Dtype* bbox2);
+
+template <typename Dtype>
+void DecodeBBoxesGPU(const int nthreads,
+          const Dtype* loc_data, const Dtype* prior_data,
+          const CodeType code_type, const bool variance_encoded_in_target,
+          const int num_priors, const bool share_location,
+          const int num_loc_classes, const int background_label_id,
+          const bool clip_bbox, Dtype* bbox_data);
+
+template <typename Dtype>
+void PermuteDataGPU(const int nthreads,
+          const Dtype* data, const int num_classes, const int num_data,
+          const int num_dim, Dtype* new_data);
+
+template <typename Dtype>
+void SoftMaxGPU(const Dtype* data, const int outer_num, const int channels,
+    const int inner_num, Dtype* prob);
+
+template <typename Dtype>
+void ComputeOverlappedGPU(const int nthreads,
+          const Dtype* bbox_data, const int num_bboxes, const int num_classes,
+          const Dtype overlap_threshold, bool* overlapped_data);
+
+template <typename Dtype>
+void ComputeOverlappedByIdxGPU(const int nthreads,
+          const Dtype* bbox_data, const Dtype overlap_threshold,
+          const int* idx, const int num_idx, bool* overlapped_data);
+
+template <typename Dtype>
+void ApplyNMSGPU(const Dtype* bbox_data, const Dtype* conf_data,
+          const int num_bboxes, const float confidence_threshold,
+          const int top_k, const float nms_threshold, vector<int>* indices);
+
+template <typename Dtype>
+void GetDetectionsGPU(const Dtype* bbox_data, const Dtype* conf_data,
+          const int image_id, const int label, const vector<int>& indices,
+          const bool clip_bbox, TBlob<Dtype>* detection_blob);
+
+template <typename Dtype>
+  void ComputeConfLossGPU(const TBlob<Dtype>& conf_blob, const int num,
+      const int num_preds_per_class, const int num_classes,
+      const int background_label_id, const ConfLossType loss_type,
+      const vector<map<int, vector<int> > >& all_match_indices,
+      const map<int, vector<NormalizedBBox> >& all_gt_bboxes,
+      vector<vector<float> >* all_conf_loss);
+#endif  // !CPU_ONLY
+
+#ifdef USE_OPENCV
+vector<cv::Scalar> GetColors(const int n);
+
+template <typename Dtype>
+void VisualizeBBox(const vector<cv::Mat>& images, const TBlob<Dtype>* detections,
+                   const float threshold, const vector<cv::Scalar>& colors,
+                   const map<int, string>& label_to_display_name,
+                   const string& save_file);
+#endif  // USE_OPENCV
+
+}  // namespace caffe
+
+#endif  // CAFFE_UTIL_BBOX_UTIL_H_

--- a/include/caffe/util/db.hpp
+++ b/include/caffe/util/db.hpp
@@ -20,7 +20,7 @@ class Cursor {
   virtual string value() const = 0;
   virtual const void* data() const = 0;
   virtual size_t size() const = 0;
-  virtual bool parse(Datum* datum) const = 0;
+  virtual bool parse(void* datum, DatumTypeInfo datum_type_info) const = 0;
   virtual bool valid() const = 0;
 
   DISABLE_COPY_MOVE_AND_ASSIGN(Cursor);

--- a/include/caffe/util/db_leveldb.hpp
+++ b/include/caffe/util/db_leveldb.hpp
@@ -20,8 +20,12 @@ class LevelDBCursor : public Cursor {
   void Next() override { iter_->Next(); }
   string key() const override { return iter_->key().ToString(); }
   string value() const override { return iter_->value().ToString(); }
-  bool parse(Datum* datum) const override {
-    return datum->ParseFromArray(iter_->value().data(), iter_->value().size());
+  bool parse(void* datum, DatumTypeInfo datum_type_info) const override {
+    if(datum_type_info == DatumTypeInfo_ANNOTATED_DATUM) {
+      return static_cast<AnnotatedDatum*>(datum)->ParseFromArray(iter_->value().data(), iter_->value().size());
+    } else {
+      return static_cast<Datum*>(datum)->ParseFromArray(iter_->value().data(), iter_->value().size());
+    }
   }
   const void* data() const override {
     return iter_->value().data();

--- a/include/caffe/util/db_lmdb.hpp
+++ b/include/caffe/util/db_lmdb.hpp
@@ -35,8 +35,12 @@ class LMDBCursor : public Cursor {
     return string(static_cast<const char*>(mdb_value_.mv_data),
         mdb_value_.mv_size);
   }
-  bool parse(Datum* datum) const override {
-    return datum->ParseFromArray(mdb_value_.mv_data, mdb_value_.mv_size);
+  bool parse(void* datum, DatumTypeInfo datum_type_info) const override {
+    if(datum_type_info == DatumTypeInfo_ANNOTATED_DATUM) {
+      return static_cast<AnnotatedDatum*>(datum)->ParseFromArray(mdb_value_.mv_data, mdb_value_.mv_size);
+    } else {
+      return static_cast<Datum*>(datum)->ParseFromArray(mdb_value_.mv_data, mdb_value_.mv_size);
+    }
   }
   const void* data() const override {
     return mdb_value_.mv_data;

--- a/include/caffe/util/im_transforms.hpp
+++ b/include/caffe/util/im_transforms.hpp
@@ -1,0 +1,90 @@
+#ifndef IM_TRANSFORMS_HPP
+#define IM_TRANSFORMS_HPP
+
+#ifdef USE_OPENCV
+#include <opencv2/core/core.hpp>
+#include <opencv2/imgproc/imgproc.hpp>
+#endif  // USE_OPENCV
+
+#include <vector>
+
+#include "caffe/common.hpp"
+#include "caffe/proto/caffe.pb.h"
+
+namespace caffe {
+
+// Generate random number given the probablities for each number.
+int roll_weighted_die(const std::vector<float>& probabilities);
+
+void UpdateBBoxByResizePolicy(const ResizeParameter& param,
+                              const int old_width, const int old_height,
+                              NormalizedBBox* bbox);
+
+void InferNewSize(const ResizeParameter& resize_param,
+                  const int old_width, const int old_height,
+                  int* new_width, int* new_height);
+
+#ifdef USE_OPENCV
+template <typename T>
+bool is_border(const cv::Mat& edge, T color);
+
+// Auto cropping image.
+template <typename T>
+cv::Rect CropMask(const cv::Mat& src, T point, int padding = 2);
+
+cv::Mat colorReduce(const cv::Mat& image, int div = 64);
+
+void fillEdgeImage(const cv::Mat& edgesIn, cv::Mat* filledEdgesOut);
+
+void CenterObjectAndFillBg(const cv::Mat& in_img, const bool fill_bg,
+                           cv::Mat* out_img);
+
+cv::Mat AspectKeepingResizeAndPad(const cv::Mat& in_img,
+                                  const int new_width, const int new_height,
+                                  const int pad_type = cv::BORDER_CONSTANT,
+                                  const cv::Scalar pad = cv::Scalar(0, 0, 0),
+                                  const int interp_mode = cv::INTER_LINEAR);
+
+cv::Mat AspectKeepingResizeBySmall(const cv::Mat& in_img,
+                                   const int new_width, const int new_height,
+                                   const int interp_mode = cv::INTER_LINEAR);
+
+void constantNoise(const int n, const vector<uchar>& val, cv::Mat* image);
+
+cv::Mat ApplyResize(const cv::Mat& in_img, const ResizeParameter& param);
+
+cv::Mat ApplyNoise(const cv::Mat& in_img, const NoiseParameter& param);
+
+
+void RandomBrightness(const cv::Mat& in_img, cv::Mat* out_img,
+    const float brightness_prob, const float brightness_delta);
+
+void AdjustBrightness(const cv::Mat& in_img, const float delta,
+                      cv::Mat* out_img);
+
+void RandomContrast(const cv::Mat& in_img, cv::Mat* out_img,
+    const float contrast_prob, const float lower, const float upper);
+
+void AdjustContrast(const cv::Mat& in_img, const float delta,
+                    cv::Mat* out_img);
+
+void RandomSaturation(const cv::Mat& in_img, cv::Mat* out_img,
+    const float saturation_prob, const float lower, const float upper);
+
+void AdjustSaturation(const cv::Mat& in_img, const float delta,
+                      cv::Mat* out_img);
+
+void RandomHue(const cv::Mat& in_img, cv::Mat* out_img,
+               const float hue_prob, const float hue_delta);
+
+void AdjustHue(const cv::Mat& in_img, const float delta, cv::Mat* out_img);
+
+void RandomOrderChannels(const cv::Mat& in_img, cv::Mat* out_img,
+                         const float random_order_prob);
+
+cv::Mat ApplyDistort(const cv::Mat& in_img, const DistortionParameter& param);
+#endif  // USE_OPENCV
+
+}  // namespace caffe
+
+#endif  // IM_TRANSFORMS_HPP

--- a/include/caffe/util/io.hpp
+++ b/include/caffe/util/io.hpp
@@ -4,6 +4,7 @@
 #include <boost/filesystem.hpp>
 #include <iomanip>
 #include <iostream>  // NOLINT(readability/streams)
+#include <map>
 #include <string>
 
 #include "google/protobuf/message.h"
@@ -97,6 +98,24 @@ inline bool ReadFileToDatum(const string& filename, Datum* datum) {
 }
 
 bool ReadImageToDatum(const string& filename, const int label,
+    const int height, const int width, const int min_dim, const int max_dim,
+    const bool is_color, const std::string & encoding, Datum* datum);
+
+inline bool ReadImageToDatum(const string& filename, const int label,
+    const int height, const int width, const int min_dim, const int max_dim,
+    const bool is_color, Datum* datum) {
+  return ReadImageToDatum(filename, label, height, width, min_dim, max_dim,
+                          is_color, "", datum);
+}
+
+inline bool ReadImageToDatum(const string& filename, const int label,
+    const int height, const int width, const int min_dim, const int max_dim,
+    Datum* datum) {
+  return ReadImageToDatum(filename, label, height, width, min_dim, max_dim,
+                          true, datum);
+}
+
+bool ReadImageToDatum(const string& filename, const int label,
     const int height, const int width, const bool is_color,
     const std::string & encoding, Datum* datum);
 
@@ -129,7 +148,79 @@ inline bool ReadImageToDatum(const string& filename, const int label,
 bool DecodeDatumNative(Datum* datum);
 bool DecodeDatum(Datum* datum, bool is_color);
 
+
+void GetImageSize(const string& filename, int* height, int* width);
+
+bool ReadRichImageToAnnotatedDatum(const string& filename,
+    const string& labelname, const int height, const int width,
+    const int min_dim, const int max_dim, const bool is_color,
+    const std::string& encoding, const AnnotatedDatum_AnnotationType type,
+    const string& labeltype, const std::map<string, int>& name_to_label,
+    AnnotatedDatum* anno_datum);
+
+inline bool ReadRichImageToAnnotatedDatum(const string& filename,
+    const string& labelname, const int height, const int width,
+    const bool is_color, const std::string & encoding,
+    const AnnotatedDatum_AnnotationType type, const string& labeltype,
+    const std::map<string, int>& name_to_label, AnnotatedDatum* anno_datum) {
+  return ReadRichImageToAnnotatedDatum(filename, labelname, height, width, 0, 0,
+                      is_color, encoding, type, labeltype, name_to_label,
+                      anno_datum);
+}
+
+bool ReadXMLToAnnotatedDatum(const string& labelname, const int img_height,
+    const int img_width, const std::map<string, int>& name_to_label,
+    AnnotatedDatum* anno_datum);
+
+bool ReadJSONToAnnotatedDatum(const string& labelname, const int img_height,
+    const int img_width, const std::map<string, int>& name_to_label,
+    AnnotatedDatum* anno_datum);
+
+bool ReadTxtToAnnotatedDatum(const string& labelname, const int height,
+    const int width, AnnotatedDatum* anno_datum);
+
+bool ReadLabelFileToLabelMap(const string& filename, bool include_background,
+    const string& delimiter, LabelMap* map);
+
+inline bool ReadLabelFileToLabelMap(const string& filename,
+      bool include_background, LabelMap* map) {
+  return ReadLabelFileToLabelMap(filename, include_background, " ", map);
+}
+
+inline bool ReadLabelFileToLabelMap(const string& filename, LabelMap* map) {
+  return ReadLabelFileToLabelMap(filename, true, map);
+}
+
+bool MapNameToLabel(const LabelMap& map, const bool strict_check,
+                    std::map<string, int>* name_to_label);
+
+inline bool MapNameToLabel(const LabelMap& map,
+                           std::map<string, int>* name_to_label) {
+  return MapNameToLabel(map, true, name_to_label);
+}
+
+bool MapLabelToName(const LabelMap& map, const bool strict_check,
+                    std::map<int, string>* label_to_name);
+
+inline bool MapLabelToName(const LabelMap& map,
+                           std::map<int, string>* label_to_name) {
+  return MapLabelToName(map, true, label_to_name);
+}
+
+bool MapLabelToDisplayName(const LabelMap& map, const bool strict_check,
+                           std::map<int, string>* label_to_display_name);
+
+inline bool MapLabelToDisplayName(const LabelMap& map,
+                              std::map<int, string>* label_to_display_name) {
+  return MapLabelToDisplayName(map, true, label_to_display_name);
+}
 #ifdef USE_OPENCV
+cv::Mat ReadImageToCVMat(const string& filename, const int height,
+    const int width, const int min_dim, const int max_dim, const bool is_color);
+
+cv::Mat ReadImageToCVMat(const string& filename, const int height,
+    const int width, const int min_dim, const int max_dim);
+
 cv::Mat ReadImageToCVMat(const string& filename,
     const int height, const int width, const bool is_color);
 
@@ -146,6 +237,9 @@ void DecodeDatumToCVMatNative(const Datum& datum, cv::Mat& img);
 cv::Mat DecodeDatumToCVMat(const Datum& datum, bool is_color);
 void DecodeDatumToCVMat(const Datum& datum, bool is_color, cv::Mat& img);
 
+void EncodeCVMatToDatum(const cv::Mat& cv_img, const string& encoding,
+                        Datum* datum);
+						
 void DatumToCVMat(const Datum& datum, cv::Mat& img);
 void CVMatToDatum(const cv::Mat& cv_img, Datum& datum);
 #endif  // USE_OPENCV

--- a/include/caffe/util/sampler.hpp
+++ b/include/caffe/util/sampler.hpp
@@ -1,0 +1,39 @@
+#ifndef CAFFE_UTIL_SAMPLER_H_
+#define CAFFE_UTIL_SAMPLER_H_
+
+#include <vector>
+
+#include "glog/logging.h"
+
+#include "caffe/caffe.hpp"
+
+namespace caffe {
+
+// Find all annotated NormalizedBBox.
+void GroupObjectBBoxes(const AnnotatedDatum& anno_datum,
+                       vector<NormalizedBBox>* object_bboxes);
+
+// Check if a sampled bbox satisfy the constraints with all object bboxes.
+bool SatisfySampleConstraint(const NormalizedBBox& sampled_bbox,
+                             const vector<NormalizedBBox>& object_bboxes,
+                             const SampleConstraint& sample_constraint);
+
+// Sample a NormalizedBBox given the specifictions.
+void SampleBBox(const Sampler& sampler, NormalizedBBox* sampled_bbox);
+
+// Generate samples from NormalizedBBox using the BatchSampler.
+void GenerateSamples(const NormalizedBBox& source_bbox,
+                     const vector<NormalizedBBox>& object_bboxes,
+                     const BatchSampler& batch_sampler,
+                     vector<NormalizedBBox>* sampled_bboxes);
+
+// Generate samples from AnnotatedDatum using the BatchSampler.
+// All sampled bboxes which satisfy the constraints defined in BatchSampler
+// is stored in sampled_bboxes.
+void GenerateBatchSamples(const AnnotatedDatum& anno_datum,
+                          const vector<BatchSampler>& batch_samplers,
+                          vector<NormalizedBBox>* sampled_bboxes);
+
+}  // namespace caffe
+
+#endif  // CAFFE_UTIL_SAMPLER_H_

--- a/python/caffe/net_spec.py
+++ b/python/caffe/net_spec.py
@@ -93,6 +93,9 @@ class Top(object):
 
         return to_proto(self)
 
+    def _update(self, params):
+        self.fn._update(params)
+
     def _to_proto(self, layers, names, autonames):
         return self.fn._to_proto(layers, names, autonames)
 
@@ -127,6 +130,9 @@ class Function(object):
             autonames[top.fn.type_name] += 1
             names[top] = top.fn.type_name + str(autonames[top.fn.type_name])
         return names[top]
+
+    def _update(self, params):
+        self.params.update(params)
 
     def _to_proto(self, layers, names, autonames):
         if self in layers:
@@ -181,7 +187,18 @@ class NetSpec(object):
     def __getitem__(self, item):
         return self.__getattr__(item)
 
-    def to_proto(self):
+    def keys(self):
+        keys = [k for k, v in six.iteritems(self.tops)]
+        return keys
+
+    def vals(self):
+        vals = [v for k, v in six.iteritems(self.tops)]
+        return vals
+
+    def update(self, name, params):
+        self.tops[name]._update(params)
+		
+    def to_proto(self, verbose=False):
         names = {v: k for k, v in six.iteritems(self.tops)}
         autonames = Counter()
         layers = OrderedDict()

--- a/scripts/create_annoset.py
+++ b/scripts/create_annoset.py
@@ -1,0 +1,167 @@
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+
+from caffe.proto import caffe_pb2
+from google.protobuf import text_format
+
+if __name__ == "__main__":
+  parser = argparse.ArgumentParser(description="Create AnnotatedDatum database")
+  parser.add_argument("root",
+      help="The root directory which contains the images and annotations.")
+  parser.add_argument("listfile",
+      help="The file which contains image paths and annotation info.")
+  parser.add_argument("outdir",
+      help="The output directory which stores the database file.")
+  parser.add_argument("exampledir",
+      help="The directory to store the link of the database files.")
+  parser.add_argument("--redo", default = False, action = "store_true",
+      help="Recreate the database.")
+  parser.add_argument("--anno-type", default = "classification",
+      help="The type of annotation {classification, detection}.")
+  parser.add_argument("--label-type", default = "xml",
+      help="The type of label file format for detection {xml, json, txt}.")
+  parser.add_argument("--backend", default = "lmdb",
+      help="The backend {lmdb, leveldb} for storing the result")
+  parser.add_argument("--check-size", default = False, action = "store_true",
+      help="Check that all the datum have the same size.")
+  parser.add_argument("--encode-type", default = "",
+      help="What type should we encode the image as ('png','jpg',...).")
+  parser.add_argument("--encoded", default = False, action = "store_true",
+      help="The encoded image will be save in datum.")
+  parser.add_argument("--gray", default = False, action = "store_true",
+      help="Treat images as grayscale ones.")
+  parser.add_argument("--label-map-file", default = "",
+      help="A file with LabelMap protobuf message.")
+  parser.add_argument("--min-dim", default = 0, type = int,
+      help="Minimum dimension images are resized to.")
+  parser.add_argument("--max-dim", default = 0, type = int,
+      help="Maximum dimension images are resized to.")
+  parser.add_argument("--resize-height", default = 0, type = int,
+      help="Height images are resized to.")
+  parser.add_argument("--resize-width", default = 0, type = int,
+      help="Width images are resized to.")
+  parser.add_argument("--shuffle", default = False, action = "store_true",
+      help="Randomly shuffle the order of images and their labels.")
+  parser.add_argument("--check-label", default = False, action = "store_true",
+      help="Check that there is no duplicated name/label.")
+
+  args = parser.parse_args()
+  root_dir = args.root
+  list_file = args.listfile
+  out_dir = args.outdir
+  example_dir = args.exampledir
+
+  redo = args.redo
+  anno_type = args.anno_type
+  label_type = args.label_type
+  backend = args.backend
+  check_size = args.check_size
+  encode_type = args.encode_type
+  encoded = args.encoded
+  gray = args.gray
+  label_map_file = args.label_map_file
+  min_dim = args.min_dim
+  max_dim = args.max_dim
+  resize_height = args.resize_height
+  resize_width = args.resize_width
+  shuffle = args.shuffle
+  check_label = args.check_label
+
+  # check if root directory exists
+  if not os.path.exists(root_dir):
+    print "root directory: {} does not exist".format(root_dir)
+    sys.exit()
+  # add "/" to root directory if needed
+  if root_dir[-1] != "/":
+    root_dir += "/"
+  # check if list file exists
+  if not os.path.exists(list_file):
+    print "list file: {} does not exist".format(list_file)
+    sys.exit()
+  # check list file format is correct
+  with open(list_file, "r") as lf:
+    for line in lf.readlines():
+      img_file, anno = line.strip("\n").split(" ")
+      if not os.path.exists(root_dir + img_file):
+        print "image file: {} does not exist".format(root_dir + img_file)
+      if anno_type == "classification":
+        if not anno.isdigit():
+          print "annotation: {} is not an integer".format(anno)
+      elif anno_type == "detection":
+        if not os.path.exists(root_dir + anno):
+          print "annofation file: {} does not exist".format(root_dir + anno)
+          sys.exit()
+      break
+  # check if label map file exist
+  if anno_type == "detection":
+    if not os.path.exists(label_map_file):
+      print "label map file: {} does not exist".format(label_map_file)
+      sys.exit()
+    label_map = caffe_pb2.LabelMap()
+    lmf = open(label_map_file, "r")
+    try:
+      text_format.Merge(str(lmf.read()), label_map)
+    except:
+      print "Cannot parse label map file: {}".format(label_map_file)
+      sys.exit()
+  out_parent_dir = os.path.dirname(out_dir)
+  if not os.path.exists(out_parent_dir):
+    os.makedirs(out_parent_dir)
+  if os.path.exists(out_dir) and not redo:
+    print "{} already exists and I do not hear redo".format(out_dir)
+    sys.exit()
+  if os.path.exists(out_dir):
+    shutil.rmtree(out_dir)
+
+  # get caffe root directory
+  caffe_root = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+  if anno_type == "detection":
+    cmd = "{}/build/tools/convert_annoset" \
+        " --anno_type={}" \
+        " --label_type={}" \
+        " --label_map_file={}" \
+        " --check_label={}" \
+        " --min_dim={}" \
+        " --max_dim={}" \
+        " --resize_height={}" \
+        " --resize_width={}" \
+        " --backend={}" \
+        " --shuffle={}" \
+        " --check_size={}" \
+        " --encode_type={}" \
+        " --encoded={}" \
+        " --gray={}" \
+        " {} {} {}" \
+        .format(caffe_root, anno_type, label_type, label_map_file, check_label,
+            min_dim, max_dim, resize_height, resize_width, backend, shuffle,
+            check_size, encode_type, encoded, gray, root_dir, list_file, out_dir)
+  elif anno_type == "classification":
+    cmd = "{}/build/tools/convert_annoset" \
+        " --anno_type={}" \
+        " --min_dim={}" \
+        " --max_dim={}" \
+        " --resize_height={}" \
+        " --resize_width={}" \
+        " --backend={}" \
+        " --shuffle={}" \
+        " --check_size={}" \
+        " --encode_type={}" \
+        " --encoded={}" \
+        " --gray={}" \
+        " {} {} {}" \
+        .format(caffe_root, anno_type, min_dim, max_dim, resize_height,
+            resize_width, backend, shuffle, check_size, encode_type, encoded,
+            gray, root_dir, list_file, out_dir)
+  print cmd
+  process = subprocess.Popen(cmd.split(), stdout=subprocess.PIPE)
+  output = process.communicate()[0]
+
+  if not os.path.exists(example_dir):
+    os.makedirs(example_dir)
+  link_dir = os.path.join(example_dir, os.path.basename(out_dir))
+  if os.path.exists(link_dir):
+    os.unlink(link_dir)
+  os.symlink(out_dir, link_dir)

--- a/src/caffe/data_reader.cpp
+++ b/src/caffe/data_reader.cpp
@@ -8,10 +8,16 @@
 
 namespace caffe {
 
-std::mutex DataReader::DataCache::cache_mutex_;
-unique_ptr<DataReader::DataCache> DataReader::DataCache::data_cache_inst_;
 
-DataReader::DataReader(const LayerParameter& param,
+// https://stackoverflow.com/questions/26935824/gcc-gives-an-undefined-reference-error-to-static-data-members-in-templated-cla
+
+template<typename DatumType> std::mutex DataReader<DatumType>::DataCache::cache_mutex_{};
+
+template<> std::unique_ptr<caffe::DataReader<Datum>::DataCache> caffe::DataReader<Datum>::DataCache::data_cache_inst_{};
+template<> std::unique_ptr<caffe::DataReader<AnnotatedDatum>::DataCache> caffe::DataReader<AnnotatedDatum>::DataCache::data_cache_inst_{};
+		
+template<typename DatumType>
+DataReader<DatumType>::DataReader(const LayerParameter& param,
     size_t solver_count,
     size_t solver_rank,
     size_t parser_threads_num,
@@ -52,26 +58,30 @@ DataReader::DataReader(const LayerParameter& param,
   LOG(INFO) << (sample_only ? "Sample " : "") << "Data Reader threads: "
       << this->threads_num() << ", out queues: " << queues_num_ << ", depth: " << queue_depth_;
   for (size_t i = 0; i < queues_num_; ++i) {
-    full_[i] = make_shared<BlockingQueue<shared_ptr<Datum>>>();
-    free_[i] = make_shared<BlockingQueue<shared_ptr<Datum>>>();
+    full_[i] = make_shared<BlockingQueue<shared_ptr<DatumType>>>();
+    free_[i] = make_shared<BlockingQueue<shared_ptr<DatumType>>>();
     for (size_t j = 0; j < queue_depth_ - 1U; ++j) {  // +1 in InternalThreadEntryN
-      free_[i]->push(make_shared<Datum>());
+      free_[i]->push(make_shared<DatumType>());
     }
   }
   db_source_ = param.data_param().source();
-  init_ = make_shared<BlockingQueue<shared_ptr<Datum>>>();
+  init_ = make_shared<BlockingQueue<shared_ptr<DatumType>>>();
   StartInternalThread(false, Caffe::next_seed());
 }
 
-DataReader::~DataReader() {
+	
+template<typename DatumType>
+DataReader<DatumType>::~DataReader() {
   StopInternalThread();
 }
 
-void DataReader::InternalThreadEntry() {
+template<typename DatumType>
+void DataReader<DatumType>::InternalThreadEntry() {
   InternalThreadEntryN(0U);
 }
 
-void DataReader::InternalThreadEntryN(size_t thread_id) {
+template<typename DatumType>
+void DataReader<DatumType>::InternalThreadEntryN(size_t thread_id) {
   if (cache_) {
     data_cache_->check_db(db_source_);
     data_cache_->register_new_thread();
@@ -87,7 +97,7 @@ void DataReader::InternalThreadEntryN(size_t thread_id) {
       batch_size_,
       cache_ && !sample_only_,
       shuffle_ && !sample_only_);
-  shared_ptr<Datum> init_datum = make_shared<Datum>();
+  shared_ptr<DatumType> init_datum = make_shared<DatumType>();
   cm.fetch(init_datum.get());
   init_->push(init_datum);
 
@@ -98,7 +108,7 @@ void DataReader::InternalThreadEntryN(size_t thread_id) {
   size_t skip = skip_one_batch_ ? batch_size_ : 0UL;
 
   size_t queue_id, ranked_rec, batch_on_solver, sample_count = 0UL;
-  shared_ptr<Datum> datum = make_shared<Datum>();
+  shared_ptr<DatumType> datum = make_shared<DatumType>();
   try {
     while (!must_stop(thread_id)) {
       cm.next(datum);
@@ -127,13 +137,15 @@ void DataReader::InternalThreadEntryN(size_t thread_id) {
   }
 }
 
-shared_ptr<Datum>& DataReader::DataCache::next_new() {
+template<typename DatumType>
+shared_ptr<DatumType>& DataReader<DatumType>::DataCache::next_new() {
   std::lock_guard<std::mutex> lock(cache_mutex_);
-  cache_buffer_.emplace_back(make_shared<Datum>());
+  cache_buffer_.emplace_back(make_shared<DatumType>());
   return cache_buffer_.back();
 }
 
-shared_ptr<Datum>& DataReader::DataCache::next_cached() {
+template<typename DatumType>
+shared_ptr<DatumType>& DataReader<DatumType>::DataCache::next_cached() {
   if (just_cached_.load()) {
     cache_bar_.wait();
     just_cached_.store(false);
@@ -160,19 +172,21 @@ shared_ptr<Datum>& DataReader::DataCache::next_cached() {
     LOG(INFO) << "Shuffling " << cache_buffer_.size() << " records...";
     caffe::shuffle(cache_buffer_.begin(), cache_buffer_.end());
   }
-  shared_ptr<Datum>& datum = cache_buffer_[cache_idx_++];
+  shared_ptr<DatumType>& datum = cache_buffer_[cache_idx_++];
   if (cache_idx_ >= cache_buffer_.size()) {
     cache_idx_= 0UL;
   }
   return datum;
 }
 
-void DataReader::DataCache::just_cached() {
+template<typename DatumType>
+void DataReader<DatumType>::DataCache::just_cached() {
   just_cached_.store(true);
   cached_flags_[std::this_thread::get_id()]->set();
 }
 
-bool DataReader::DataCache::check_memory() {
+template<typename DatumType>
+bool DataReader<DatumType>::DataCache::check_memory() {
   if (cache_buffer_.size() == 0UL || cache_buffer_.size() % 1000UL != 0UL) {
     return true;
   }
@@ -225,7 +239,8 @@ bool DataReader::DataCache::check_memory() {
   return mem_ok;
 }
 
-DataReader::CursorManager::CursorManager(shared_ptr<db::DB> db, DataReader* reader,
+template<typename DatumType>
+DataReader<DatumType>::CursorManager::CursorManager(shared_ptr<db::DB> db, DataReader<DatumType>* reader,
     size_t solver_count, size_t solver_rank, size_t parser_threads, size_t parser_thread_id,
     size_t batch_size, bool cache, bool shuffle)
     : db_(db),
@@ -244,12 +259,14 @@ DataReader::CursorManager::CursorManager(shared_ptr<db::DB> db, DataReader* read
       shuffle_(shuffle),
       cached_all_(false) {}
 
-DataReader::CursorManager::~CursorManager() {
+template<typename DatumType>
+DataReader<DatumType>::CursorManager::~CursorManager() {
   cursor_.reset();
   db_->Close();
 }
 
-void DataReader::CursorManager::next(shared_ptr<Datum>& datum) {
+template<typename DatumType>
+void DataReader<DatumType>::CursorManager::next(shared_ptr<DatumType>& datum) {
   if (cached_all_) {
     datum = reader_->next_cached();
   } else {
@@ -311,7 +328,8 @@ S1 |                          r1pt1.q1                    --> S1.tr0 S1.q2
       <-- rank cycle ->
       <---------- full cycle ----------->
 */
-void DataReader::CursorManager::rewind() {
+template<typename DatumType>
+void DataReader<DatumType>::CursorManager::rewind() {
   CHECK(parser_threads_);
   size_t rank_cycle_begin = rank_cycle_ * solver_rank_;
   rec_id_ = rank_cycle_begin + parser_thread_id_ * batch_size_;
@@ -325,10 +343,14 @@ void DataReader::CursorManager::rewind() {
   }
 }
 
-void DataReader::CursorManager::fetch(Datum* datum) {
-  if (!cursor_->parse(datum)) {
+template<typename DatumType>
+void DataReader<DatumType>::CursorManager::fetch(DatumType* datum) {
+  if (!cursor_->parse(datum, datum_tp<DatumType>())) {
     LOG(ERROR) << "Database cursor failed to parse Datum record";
   }
 }
+
+template class DataReader<Datum>;
+template class DataReader<AnnotatedDatum>;
 
 }  // namespace caffe

--- a/src/caffe/data_transformer.cpp
+++ b/src/caffe/data_transformer.cpp
@@ -9,8 +9,12 @@
 #include <vector>
 
 #include "caffe/data_transformer.hpp"
+#include "caffe/util/bbox_util.hpp"
+#include "caffe/util/im_transforms.hpp"
 #include "caffe/util/io.hpp"
+#include "caffe/util/math_functions.hpp"
 #include "caffe/util/rng.hpp"
+
 
 namespace caffe {
 
@@ -650,6 +654,178 @@ void DataTransformer<Dtype>::Transform(const Datum& datum,
 }
 
 template<typename Dtype>
+void DataTransformer<Dtype>::Transform(const Datum& datum,
+                                       Dtype* transformed_data,
+                                       NormalizedBBox* crop_bbox,
+                                       bool* do_mirror) {
+  const string& data = datum.data();
+  const int datum_channels = datum.channels();
+  const int datum_height = datum.height();
+  const int datum_width = datum.width();
+
+  const int crop_size = param_.crop_size();
+  const Dtype scale = param_.scale();
+  *do_mirror = param_.mirror() && Rand(2);
+  const bool has_mean_file = param_.has_mean_file();
+  const bool has_uint8 = data.size() > 0;
+  const bool has_mean_values = mean_values_.size() > 0;
+
+  CHECK_GT(datum_channels, 0);
+  CHECK_GE(datum_height, crop_size);
+  CHECK_GE(datum_width, crop_size);
+
+  float* mean = NULL;
+  if (has_mean_file) {
+    CHECK_EQ(datum_channels, data_mean_.channels());
+    CHECK_EQ(datum_height, data_mean_.height());
+    CHECK_EQ(datum_width, data_mean_.width());
+    mean = data_mean_.mutable_cpu_data();
+  }
+  if (has_mean_values) {
+    CHECK(mean_values_.size() == 1 || mean_values_.size() == datum_channels) <<
+     "Specify either 1 mean_value or as many as channels: " << datum_channels;
+    if (datum_channels > 1 && mean_values_.size() == 1) {
+      // Replicate the mean_value for simplicity
+      for (int c = 1; c < datum_channels; ++c) {
+        mean_values_.push_back(mean_values_[0]);
+      }
+    }
+  }
+
+  int height = datum_height;
+  int width = datum_width;
+
+  int h_off = 0;
+  int w_off = 0;
+  if (crop_size) {
+    height = crop_size;
+    width = crop_size;
+    // We only do random crop when we do training.
+    if (phase_ == TRAIN) {
+      h_off = Rand(datum_height - crop_size + 1);
+      w_off = Rand(datum_width - crop_size + 1);
+    } else {
+      h_off = (datum_height - crop_size) / 2;
+      w_off = (datum_width - crop_size) / 2;
+    }
+  }
+
+  // Return the normalized crop bbox.
+  crop_bbox->set_xmin(Dtype(w_off) / datum_width);
+  crop_bbox->set_ymin(Dtype(h_off) / datum_height);
+  crop_bbox->set_xmax(Dtype(w_off + width) / datum_width);
+  crop_bbox->set_ymax(Dtype(h_off + height) / datum_height);
+
+  Dtype datum_element;
+  int top_index, data_index;
+  for (int c = 0; c < datum_channels; ++c) {
+    for (int h = 0; h < height; ++h) {
+      for (int w = 0; w < width; ++w) {
+        data_index = (c * datum_height + h_off + h) * datum_width + w_off + w;
+        if (*do_mirror) {
+          top_index = (c * height + h) * width + (width - 1 - w);
+        } else {
+          top_index = (c * height + h) * width + w;
+        }
+        if (has_uint8) {
+          datum_element =
+            static_cast<Dtype>(static_cast<uint8_t>(data[data_index]));
+        } else {
+          datum_element = datum.float_data(data_index);
+        }
+        if (has_mean_file) {
+          transformed_data[top_index] =
+            (datum_element - mean[data_index]) * scale;
+        } else {
+          if (has_mean_values) {
+            transformed_data[top_index] =
+              (datum_element - mean_values_[c]) * scale;
+          } else {
+            transformed_data[top_index] = datum_element * scale;
+          }
+        }
+      }
+    }
+  }
+}
+
+
+/*
+template<typename Dtype>
+void DataTransformer<Dtype>::Transform(const Datum& datum,
+                                       Dtype* transformed_data) {
+  NormalizedBBox crop_bbox;
+  bool do_mirror;
+  Transform(datum, transformed_data, &crop_bbox, &do_mirror);
+}
+*/
+template<typename Dtype>
+void DataTransformer<Dtype>::Transform(const Datum& datum,
+                                       TBlob<Dtype>* transformed_blob,
+                                       NormalizedBBox* crop_bbox,
+                                       bool* do_mirror) {
+  // If datum is encoded, decoded and transform the cv::image.
+  if (datum.encoded()) {
+#ifdef USE_OPENCV
+    CHECK(!(param_.force_color() && param_.force_gray()))
+        << "cannot set both force_color and force_gray";
+    cv::Mat cv_img;
+    if (param_.force_color() || param_.force_gray()) {
+    // If force_color then decode in color otherwise decode in gray.
+      cv_img = DecodeDatumToCVMat(datum, param_.force_color());
+    } else {
+      cv_img = DecodeDatumToCVMatNative(datum);
+    }
+    // Transform the cv::image into blob.
+    return Transform(cv_img, transformed_blob, crop_bbox, do_mirror);
+#else
+    LOG(FATAL) << "Encoded datum requires OpenCV; compile with USE_OPENCV.";
+#endif  // USE_OPENCV
+  } else {
+    if (param_.force_color() || param_.force_gray()) {
+      LOG(ERROR) << "force_color and force_gray only for encoded datum";
+    }
+  }
+
+  const int crop_size = param_.crop_size();
+  const int datum_channels = datum.channels();
+  const int datum_height = datum.height();
+  const int datum_width = datum.width();
+
+  // Check dimensions.
+  const int channels = transformed_blob->channels();
+  const int height = transformed_blob->height();
+  const int width = transformed_blob->width();
+  const int num = transformed_blob->num();
+
+  CHECK_EQ(channels, datum_channels);
+  CHECK_LE(height, datum_height);
+  CHECK_LE(width, datum_width);
+  CHECK_GE(num, 1);
+
+  if (crop_size) {
+    CHECK_EQ(crop_size, height);
+    CHECK_EQ(crop_size, width);
+  } else {
+    CHECK_EQ(datum_height, height);
+    CHECK_EQ(datum_width, width);
+  }
+
+  Dtype* transformed_data = transformed_blob->mutable_cpu_data();
+  Transform(datum, transformed_data, crop_bbox, do_mirror);
+}
+
+
+/*
+template<typename Dtype>
+void DataTransformer<Dtype>::Transform(const Datum& datum,
+                                       TBlob<Dtype>* transformed_blob) {
+  NormalizedBBox crop_bbox;
+  bool do_mirror;
+  Transform(datum, transformed_blob, &crop_bbox, &do_mirror);
+}
+*/
+template<typename Dtype>
 void DataTransformer<Dtype>::Transform(const vector<Datum>& datum_vector,
     TBlob<Dtype> *transformed_blob) {
   const int datum_num = datum_vector.size();
@@ -669,6 +845,338 @@ void DataTransformer<Dtype>::Transform(const vector<Datum>& datum_vector,
   }
 }
 
+template<typename Dtype>
+void DataTransformer<Dtype>::Transform(
+    const AnnotatedDatum& anno_datum, TBlob<Dtype>* transformed_blob,
+    RepeatedPtrField<AnnotationGroup>* transformed_anno_group_all,
+    bool* do_mirror) {
+  // Transform datum.
+  const Datum& datum = anno_datum.datum();
+  NormalizedBBox crop_bbox;
+  Transform(datum, transformed_blob, &crop_bbox, do_mirror);
+
+  // Transform annotation.
+  const bool do_resize = true;
+  TransformAnnotation(anno_datum, do_resize, crop_bbox, *do_mirror,
+                      transformed_anno_group_all);
+}
+
+template<typename Dtype>
+void DataTransformer<Dtype>::Transform(
+    const AnnotatedDatum& anno_datum, TBlob<Dtype>* transformed_blob,
+    RepeatedPtrField<AnnotationGroup>* transformed_anno_group_all) {
+  bool do_mirror;
+  Transform(anno_datum, transformed_blob, transformed_anno_group_all,
+            &do_mirror);
+}
+
+template<typename Dtype>
+void DataTransformer<Dtype>::Transform(
+    const AnnotatedDatum& anno_datum, TBlob<Dtype>* transformed_blob,
+    vector<AnnotationGroup>* transformed_anno_vec, bool* do_mirror) {
+  RepeatedPtrField<AnnotationGroup> transformed_anno_group_all;
+  Transform(anno_datum, transformed_blob, &transformed_anno_group_all,
+            do_mirror);
+  for (int g = 0; g < transformed_anno_group_all.size(); ++g) {
+    transformed_anno_vec->push_back(transformed_anno_group_all.Get(g));
+  }
+}
+
+template<typename Dtype>
+void DataTransformer<Dtype>::Transform(
+    const AnnotatedDatum& anno_datum, TBlob<Dtype>* transformed_blob,
+    vector<AnnotationGroup>* transformed_anno_vec) {
+  bool do_mirror;
+  Transform(anno_datum, transformed_blob, transformed_anno_vec, &do_mirror);
+}
+
+template<typename Dtype>
+void DataTransformer<Dtype>::TransformAnnotation(
+    const AnnotatedDatum& anno_datum, const bool do_resize,
+    const NormalizedBBox& crop_bbox, const bool do_mirror,
+    RepeatedPtrField<AnnotationGroup>* transformed_anno_group_all) {
+  const int img_height = anno_datum.datum().height();
+  const int img_width = anno_datum.datum().width();
+  if (anno_datum.type() == AnnotatedDatum_AnnotationType_BBOX) {
+    // Go through each AnnotationGroup.
+    for (int g = 0; g < anno_datum.annotation_group_size(); ++g) {
+      const AnnotationGroup& anno_group = anno_datum.annotation_group(g);
+      AnnotationGroup transformed_anno_group;
+      // Go through each Annotation.
+      bool has_valid_annotation = false;
+      for (int a = 0; a < anno_group.annotation_size(); ++a) {
+        const Annotation& anno = anno_group.annotation(a);
+        const NormalizedBBox& bbox = anno.bbox();
+        // Adjust bounding box annotation.
+        NormalizedBBox resize_bbox = bbox;
+        if (do_resize && param_.has_resize_param()) {
+          CHECK_GT(img_height, 0);
+          CHECK_GT(img_width, 0);
+          UpdateBBoxByResizePolicy(param_.resize_param(), img_width, img_height,
+                                   &resize_bbox);
+        }
+        if (param_.has_emit_constraint() &&
+            !MeetEmitConstraint(crop_bbox, resize_bbox,
+                                param_.emit_constraint())) {
+          continue;
+        }
+        NormalizedBBox proj_bbox;
+        if (ProjectBBox(crop_bbox, resize_bbox, &proj_bbox)) {
+          has_valid_annotation = true;
+          Annotation* transformed_anno =
+              transformed_anno_group.add_annotation();
+          transformed_anno->set_instance_id(anno.instance_id());
+          NormalizedBBox* transformed_bbox = transformed_anno->mutable_bbox();
+          transformed_bbox->CopyFrom(proj_bbox);
+          if (do_mirror) {
+            Dtype temp = transformed_bbox->xmin();
+            transformed_bbox->set_xmin(1 - transformed_bbox->xmax());
+            transformed_bbox->set_xmax(1 - temp);
+          }
+          if (do_resize && param_.has_resize_param()) {
+            ExtrapolateBBox(param_.resize_param(), img_height, img_width,
+                crop_bbox, transformed_bbox);
+          }
+        }
+      }
+      // Save for output.
+      if (has_valid_annotation) {
+        transformed_anno_group.set_group_label(anno_group.group_label());
+        transformed_anno_group_all->Add()->CopyFrom(transformed_anno_group);
+      }
+    }
+  } else {
+    LOG(FATAL) << "Unknown annotation type.";
+  }
+}
+
+template<typename Dtype>
+void DataTransformer<Dtype>::CropImage(const Datum& datum,
+                                       const NormalizedBBox& bbox,
+                                       Datum* crop_datum) {
+  // If datum is encoded, decode and crop the cv::image.
+  if (datum.encoded()) {
+#ifdef USE_OPENCV
+    CHECK(!(param_.force_color() && param_.force_gray()))
+        << "cannot set both force_color and force_gray";
+    cv::Mat cv_img;
+    if (param_.force_color() || param_.force_gray()) {
+      // If force_color then decode in color otherwise decode in gray.
+      cv_img = DecodeDatumToCVMat(datum, param_.force_color());
+    } else {
+      cv_img = DecodeDatumToCVMatNative(datum);
+    }
+    // Crop the image.
+    cv::Mat crop_img;
+    CropImage(cv_img, bbox, &crop_img);
+    // Save the image into datum.
+    EncodeCVMatToDatum(crop_img, "jpg", crop_datum);
+    crop_datum->set_label(datum.label());
+    return;
+#else
+    LOG(FATAL) << "Encoded datum requires OpenCV; compile with USE_OPENCV.";
+#endif  // USE_OPENCV
+  } else {
+    if (param_.force_color() || param_.force_gray()) {
+      LOG(ERROR) << "force_color and force_gray only for encoded datum";
+    }
+  }
+
+  const int datum_channels = datum.channels();
+  const int datum_height = datum.height();
+  const int datum_width = datum.width();
+
+  // Get the bbox dimension.
+  NormalizedBBox clipped_bbox;
+  ClipBBox(bbox, &clipped_bbox);
+  NormalizedBBox scaled_bbox;
+  ScaleBBox(clipped_bbox, datum_height, datum_width, &scaled_bbox);
+  const int w_off = static_cast<int>(scaled_bbox.xmin());
+  const int h_off = static_cast<int>(scaled_bbox.ymin());
+  const int width = static_cast<int>(scaled_bbox.xmax() - scaled_bbox.xmin());
+  const int height = static_cast<int>(scaled_bbox.ymax() - scaled_bbox.ymin());
+
+  // Crop the image using bbox.
+  crop_datum->set_channels(datum_channels);
+  crop_datum->set_height(height);
+  crop_datum->set_width(width);
+  crop_datum->set_label(datum.label());
+  crop_datum->clear_data();
+  crop_datum->clear_float_data();
+  crop_datum->set_encoded(false);
+  const int crop_datum_size = datum_channels * height * width;
+  const std::string& datum_buffer = datum.data();
+  std::string buffer(crop_datum_size, ' ');
+  for (int h = h_off; h < h_off + height; ++h) {
+    for (int w = w_off; w < w_off + width; ++w) {
+      for (int c = 0; c < datum_channels; ++c) {
+        int datum_index = (c * datum_height + h) * datum_width + w;
+        int crop_datum_index = (c * height + h - h_off) * width + w - w_off;
+        buffer[crop_datum_index] = datum_buffer[datum_index];
+      }
+    }
+  }
+  crop_datum->set_data(buffer);
+}
+
+template<typename Dtype>
+void DataTransformer<Dtype>::CropImage(const AnnotatedDatum& anno_datum,
+                                       const NormalizedBBox& bbox,
+                                       AnnotatedDatum* cropped_anno_datum) {
+  // Crop the datum.
+  CropImage(anno_datum.datum(), bbox, cropped_anno_datum->mutable_datum());
+  cropped_anno_datum->set_type(anno_datum.type());
+
+  // Transform the annotation according to crop_bbox.
+  const bool do_resize = false;
+  const bool do_mirror = false;
+  NormalizedBBox crop_bbox;
+  ClipBBox(bbox, &crop_bbox);
+  TransformAnnotation(anno_datum, do_resize, crop_bbox, do_mirror,
+                      cropped_anno_datum->mutable_annotation_group());
+}
+
+template<typename Dtype>
+void DataTransformer<Dtype>::ExpandImage(const Datum& datum,
+                                         const float expand_ratio,
+                                         NormalizedBBox* expand_bbox,
+                                         Datum* expand_datum) {
+  // If datum is encoded, decode and crop the cv::image.
+  if (datum.encoded()) {
+#ifdef USE_OPENCV
+    CHECK(!(param_.force_color() && param_.force_gray()))
+        << "cannot set both force_color and force_gray";
+    cv::Mat cv_img;
+    if (param_.force_color() || param_.force_gray()) {
+      // If force_color then decode in color otherwise decode in gray.
+      cv_img = DecodeDatumToCVMat(datum, param_.force_color());
+    } else {
+      cv_img = DecodeDatumToCVMatNative(datum);
+    }
+    // Expand the image.
+    cv::Mat expand_img;
+    ExpandImage(cv_img, expand_ratio, expand_bbox, &expand_img);
+    // Save the image into datum.
+    EncodeCVMatToDatum(expand_img, "jpg", expand_datum);
+    expand_datum->set_label(datum.label());
+    return;
+#else
+    LOG(FATAL) << "Encoded datum requires OpenCV; compile with USE_OPENCV.";
+#endif  // USE_OPENCV
+  } else {
+    if (param_.force_color() || param_.force_gray()) {
+      LOG(ERROR) << "force_color and force_gray only for encoded datum";
+    }
+  }
+
+  const int datum_channels = datum.channels();
+  const int datum_height = datum.height();
+  const int datum_width = datum.width();
+
+  // Get the bbox dimension.
+  int height = static_cast<int>(datum_height * expand_ratio);
+  int width = static_cast<int>(datum_width * expand_ratio);
+  float h_off, w_off;
+  caffe_rng_uniform(1, 0.f, static_cast<float>(height - datum_height), &h_off);
+  caffe_rng_uniform(1, 0.f, static_cast<float>(width - datum_width), &w_off);
+  h_off = floor(h_off);
+  w_off = floor(w_off);
+  expand_bbox->set_xmin(-w_off/datum_width);
+  expand_bbox->set_ymin(-h_off/datum_height);
+  expand_bbox->set_xmax((width - w_off)/datum_width);
+  expand_bbox->set_ymax((height - h_off)/datum_height);
+
+  // Crop the image using bbox.
+  expand_datum->set_channels(datum_channels);
+  expand_datum->set_height(height);
+  expand_datum->set_width(width);
+  expand_datum->set_label(datum.label());
+  expand_datum->clear_data();
+  expand_datum->clear_float_data();
+  expand_datum->set_encoded(false);
+  const int expand_datum_size = datum_channels * height * width;
+  const std::string& datum_buffer = datum.data();
+  std::string buffer(expand_datum_size, ' ');
+  for (int h = h_off; h < h_off + datum_height; ++h) {
+    for (int w = w_off; w < w_off + datum_width; ++w) {
+      for (int c = 0; c < datum_channels; ++c) {
+        int datum_index =
+            (c * datum_height + h - h_off) * datum_width + w - w_off;
+        int expand_datum_index = (c * height + h) * width + w;
+        buffer[expand_datum_index] = datum_buffer[datum_index];
+      }
+    }
+  }
+  expand_datum->set_data(buffer);
+}
+
+template<typename Dtype>
+void DataTransformer<Dtype>::ExpandImage(const AnnotatedDatum& anno_datum,
+                                         AnnotatedDatum* expanded_anno_datum) {
+  if (!param_.has_expand_param()) {
+    expanded_anno_datum->CopyFrom(anno_datum);
+    return;
+  }
+  const ExpansionParameter& expand_param = param_.expand_param();
+  const float expand_prob = expand_param.prob();
+  float prob;
+  caffe_rng_uniform(1, 0.f, 1.f, &prob);
+  if (prob > expand_prob) {
+    expanded_anno_datum->CopyFrom(anno_datum);
+    return;
+  }
+  const float max_expand_ratio = expand_param.max_expand_ratio();
+  if (fabs(max_expand_ratio - 1.) < 1e-2) {
+    expanded_anno_datum->CopyFrom(anno_datum);
+    return;
+  }
+  float expand_ratio;
+  caffe_rng_uniform(1, 1.f, max_expand_ratio, &expand_ratio);
+  // Expand the datum.
+  NormalizedBBox expand_bbox;
+  ExpandImage(anno_datum.datum(), expand_ratio, &expand_bbox,
+              expanded_anno_datum->mutable_datum());
+  expanded_anno_datum->set_type(anno_datum.type());
+
+  // Transform the annotation according to crop_bbox.
+  const bool do_resize = false;
+  const bool do_mirror = false;
+  TransformAnnotation(anno_datum, do_resize, expand_bbox, do_mirror,
+                      expanded_anno_datum->mutable_annotation_group());
+}
+
+template<typename Dtype>
+void DataTransformer<Dtype>::DistortImage(const Datum& datum,
+                                          Datum* distort_datum) {
+  if (!param_.has_distort_param()) {
+    distort_datum->CopyFrom(datum);
+    return;
+  }
+  // If datum is encoded, decode and crop the cv::image.
+  if (datum.encoded()) {
+#ifdef USE_OPENCV
+    CHECK(!(param_.force_color() && param_.force_gray()))
+        << "cannot set both force_color and force_gray";
+    cv::Mat cv_img;
+    if (param_.force_color() || param_.force_gray()) {
+      // If force_color then decode in color otherwise decode in gray.
+      cv_img = DecodeDatumToCVMat(datum, param_.force_color());
+    } else {
+      cv_img = DecodeDatumToCVMatNative(datum);
+    }
+    // Distort the image.
+    cv::Mat distort_img = ApplyDistort(cv_img, param_.distort_param());
+    // Save the image into datum.
+    EncodeCVMatToDatum(distort_img, "jpg", distort_datum);
+    distort_datum->set_label(datum.label());
+    return;
+#else
+    LOG(FATAL) << "Encoded datum requires OpenCV; compile with USE_OPENCV.";
+#endif  // USE_OPENCV
+  } else {
+    LOG(ERROR) << "Only support encoded datum now";
+  }
+}
 #ifdef USE_OPENCV
 
 template<typename Dtype>
@@ -881,6 +1389,302 @@ void DataTransformer<Dtype>::TransformPtr(const cv::Mat& cv_img,
   }
 }
 
+template<typename Dtype>
+void DataTransformer<Dtype>::Transform(const cv::Mat& cv_img,
+                                       TBlob<Dtype>* transformed_blob,
+                                       NormalizedBBox* crop_bbox,
+                                       bool* do_mirror) {
+  // Check dimensions.
+  const int img_channels = cv_img.channels();
+  const int channels = transformed_blob->channels();
+  const int height = transformed_blob->height();
+  const int width = transformed_blob->width();
+  const int num = transformed_blob->num();
+
+  CHECK_GT(img_channels, 0);
+  CHECK(cv_img.depth() == CV_8U) << "Image data type must be unsigned byte";
+  CHECK_EQ(channels, img_channels);
+  CHECK_GE(num, 1);
+
+  const int crop_size = param_.crop_size();
+  const Dtype scale = param_.scale();
+  *do_mirror = param_.mirror() && Rand(2);
+  const bool has_mean_file = param_.has_mean_file();
+  const bool has_mean_values = mean_values_.size() > 0;
+
+  float* mean = NULL;
+  if (has_mean_file) {
+    CHECK_EQ(img_channels, data_mean_.channels());
+    mean = data_mean_.mutable_cpu_data();
+  }
+  if (has_mean_values) {
+    CHECK(mean_values_.size() == 1 || mean_values_.size() == img_channels) <<
+        "Specify either 1 mean_value or as many as channels: " << img_channels;
+    if (img_channels > 1 && mean_values_.size() == 1) {
+      // Replicate the mean_value for simplicity
+      for (int c = 1; c < img_channels; ++c) {
+        mean_values_.push_back(mean_values_[0]);
+      }
+    }
+  }
+
+  int crop_h = param_.crop_h();
+  int crop_w = param_.crop_w();
+  if (crop_size) {
+    crop_h = crop_size;
+    crop_w = crop_size;
+  }
+
+  cv::Mat cv_resized_image, cv_noised_image, cv_cropped_image;
+  if (param_.has_resize_param()) {
+    cv_resized_image = ApplyResize(cv_img, param_.resize_param());
+  } else {
+    cv_resized_image = cv_img;
+  }
+  if (param_.has_noise_param()) {
+    cv_noised_image = ApplyNoise(cv_resized_image, param_.noise_param());
+  } else {
+    cv_noised_image = cv_resized_image;
+  }
+  int img_height = cv_noised_image.rows;
+  int img_width = cv_noised_image.cols;
+  CHECK_GE(img_height, crop_h);
+  CHECK_GE(img_width, crop_w);
+
+  int h_off = 0;
+  int w_off = 0;
+  if ((crop_h > 0) && (crop_w > 0)) {
+    CHECK_EQ(crop_h, height);
+    CHECK_EQ(crop_w, width);
+    // We only do random crop when we do training.
+    if (phase_ == TRAIN) {
+      h_off = Rand(img_height - crop_h + 1);
+      w_off = Rand(img_width - crop_w + 1);
+    } else {
+      h_off = (img_height - crop_h) / 2;
+      w_off = (img_width - crop_w) / 2;
+    }
+    cv::Rect roi(w_off, h_off, crop_w, crop_h);
+    cv_cropped_image = cv_noised_image(roi);
+  } else {
+    cv_cropped_image = cv_noised_image;
+  }
+
+  // Return the normalized crop bbox.
+  crop_bbox->set_xmin(Dtype(w_off) / img_width);
+  crop_bbox->set_ymin(Dtype(h_off) / img_height);
+  crop_bbox->set_xmax(Dtype(w_off + width) / img_width);
+  crop_bbox->set_ymax(Dtype(h_off + height) / img_height);
+
+  if (has_mean_file) {
+    CHECK_EQ(cv_cropped_image.rows, data_mean_.height());
+    CHECK_EQ(cv_cropped_image.cols, data_mean_.width());
+  }
+  CHECK(cv_cropped_image.data);
+
+  Dtype* transformed_data = transformed_blob->mutable_cpu_data();
+  int top_index;
+  for (int h = 0; h < height; ++h) {
+    const uchar* ptr = cv_cropped_image.ptr<uchar>(h);
+    int img_index = 0;
+    int h_idx = h;
+    for (int w = 0; w < width; ++w) {
+      int w_idx = w;
+      if (*do_mirror) {
+        w_idx = (width - 1 - w);
+      }
+      int h_idx_real = h_idx;
+      int w_idx_real = w_idx;
+      for (int c = 0; c < img_channels; ++c) {
+        top_index = (c * height + h_idx_real) * width + w_idx_real;
+        Dtype pixel = static_cast<Dtype>(ptr[img_index++]);
+        if (has_mean_file) {
+          int mean_index = (c * img_height + h_off + h_idx_real) * img_width
+              + w_off + w_idx_real;
+          transformed_data[top_index] =
+              (pixel - mean[mean_index]) * scale;
+        } else {
+          if (has_mean_values) {
+            transformed_data[top_index] =
+                (pixel - mean_values_[c]) * scale;
+          } else {
+            transformed_data[top_index] = pixel * scale;
+          }
+        }
+      }
+    }
+  }
+}
+
+template<typename Dtype>
+void DataTransformer<Dtype>::TransformInv(const Dtype* data, cv::Mat* cv_img,
+                                          const int height, const int width,
+                                          const int channels) {
+  const Dtype scale = param_.scale();
+  const bool has_mean_file = param_.has_mean_file();
+  const bool has_mean_values = mean_values_.size() > 0;
+
+  float* mean = NULL;
+  if (has_mean_file) {
+    CHECK_EQ(channels, data_mean_.channels());
+    CHECK_EQ(height, data_mean_.height());
+    CHECK_EQ(width, data_mean_.width());
+    mean = data_mean_.mutable_cpu_data();
+  }
+  if (has_mean_values) {
+    CHECK(mean_values_.size() == 1 || mean_values_.size() == channels) <<
+        "Specify either 1 mean_value or as many as channels: " << channels;
+    if (channels > 1 && mean_values_.size() == 1) {
+      // Replicate the mean_value for simplicity
+      for (int c = 1; c < channels; ++c) {
+        mean_values_.push_back(mean_values_[0]);
+      }
+    }
+  }
+
+  const int img_type = channels == 3 ? CV_8UC3 : CV_8UC1;
+  cv::Mat orig_img(height, width, img_type, cv::Scalar(0, 0, 0));
+  for (int h = 0; h < height; ++h) {
+    uchar* ptr = orig_img.ptr<uchar>(h);
+    int img_idx = 0;
+    for (int w = 0; w < width; ++w) {
+      for (int c = 0; c < channels; ++c) {
+        int idx = (c * height + h) * width + w;
+        if (has_mean_file) {
+          ptr[img_idx++] = static_cast<uchar>(data[idx] / scale + mean[idx]);
+        } else {
+          if (has_mean_values) {
+            ptr[img_idx++] =
+                static_cast<uchar>(data[idx] / scale + mean_values_[c]);
+          } else {
+            ptr[img_idx++] = static_cast<uchar>(data[idx] / scale);
+          }
+        }
+      }
+    }
+  }
+
+  if (param_.has_resize_param()) {
+    *cv_img = ApplyResize(orig_img, param_.resize_param());
+  } else {
+    *cv_img = orig_img;
+  }
+}
+
+template<typename Dtype>
+void DataTransformer<Dtype>::TransformInv(const TBlob<Dtype>* blob,
+                                          vector<cv::Mat>* cv_imgs) {
+  const int channels = blob->channels();
+  const int height = blob->height();
+  const int width = blob->width();
+  const int num = blob->num();
+  CHECK_GE(num, 1);
+  const Dtype* image_data = blob->cpu_data();
+
+  for (int i = 0; i < num; ++i) {
+    cv::Mat cv_img;
+    TransformInv(image_data, &cv_img, height, width, channels);
+    cv_imgs->push_back(cv_img);
+    image_data += blob->offset(1);
+  }
+}
+/*
+template<typename Dtype>
+void DataTransformer<Dtype>::Transform(const cv::Mat& cv_img,
+                                       TBlob<Dtype>* transformed_blob) {
+  NormalizedBBox crop_bbox;
+  bool do_mirror;
+  Transform(cv_img, transformed_blob, &crop_bbox, &do_mirror);
+}
+*/
+template <typename Dtype>
+void DataTransformer<Dtype>::CropImage(const cv::Mat& img,
+                                       const NormalizedBBox& bbox,
+                                       cv::Mat* crop_img) {
+  const int img_height = img.rows;
+  const int img_width = img.cols;
+
+  // Get the bbox dimension.
+  NormalizedBBox clipped_bbox;
+  ClipBBox(bbox, &clipped_bbox);
+  NormalizedBBox scaled_bbox;
+  ScaleBBox(clipped_bbox, img_height, img_width, &scaled_bbox);
+
+  // Crop the image using bbox.
+  int w_off = static_cast<int>(scaled_bbox.xmin());
+  int h_off = static_cast<int>(scaled_bbox.ymin());
+  int width = static_cast<int>(scaled_bbox.xmax() - scaled_bbox.xmin());
+  int height = static_cast<int>(scaled_bbox.ymax() - scaled_bbox.ymin());
+  cv::Rect bbox_roi(w_off, h_off, width, height);
+
+  img(bbox_roi).copyTo(*crop_img);
+}
+
+template <typename Dtype>
+void DataTransformer<Dtype>::ExpandImage(const cv::Mat& img,
+                                         const float expand_ratio,
+                                         NormalizedBBox* expand_bbox,
+                                         cv::Mat* expand_img) {
+  const int img_height = img.rows;
+  const int img_width = img.cols;
+  const int img_channels = img.channels();
+
+  // Get the bbox dimension.
+  int height = static_cast<int>(img_height * expand_ratio);
+  int width = static_cast<int>(img_width * expand_ratio);
+  float h_off, w_off;
+  caffe_rng_uniform(1, 0.f, static_cast<float>(height - img_height), &h_off);
+  caffe_rng_uniform(1, 0.f, static_cast<float>(width - img_width), &w_off);
+  h_off = floor(h_off);
+  w_off = floor(w_off);
+  expand_bbox->set_xmin(-w_off/img_width);
+  expand_bbox->set_ymin(-h_off/img_height);
+  expand_bbox->set_xmax((width - w_off)/img_width);
+  expand_bbox->set_ymax((height - h_off)/img_height);
+
+  expand_img->create(height, width, img.type());
+  expand_img->setTo(cv::Scalar(0));
+  const bool has_mean_file = param_.has_mean_file();
+  const bool has_mean_values = mean_values_.size() > 0;
+
+  if (has_mean_file) {
+    CHECK_EQ(img_channels, data_mean_.channels());
+    CHECK_EQ(height, data_mean_.height());
+    CHECK_EQ(width, data_mean_.width());
+    float* mean = data_mean_.mutable_cpu_data();
+    for (int h = 0; h < height; ++h) {
+      uchar* ptr = expand_img->ptr<uchar>(h);
+      int img_index = 0;
+      for (int w = 0; w < width; ++w) {
+        for (int c = 0; c < img_channels; ++c) {
+          int blob_index = (c * height + h) * width + w;
+          ptr[img_index++] = static_cast<char>(mean[blob_index]);
+        }
+      }
+    }
+  }
+  if (has_mean_values) {
+    CHECK(mean_values_.size() == 1 || mean_values_.size() == img_channels) <<
+        "Specify either 1 mean_value or as many as channels: " << img_channels;
+    if (img_channels > 1 && mean_values_.size() == 1) {
+      // Replicate the mean_value for simplicity
+      for (int c = 1; c < img_channels; ++c) {
+        mean_values_.push_back(mean_values_[0]);
+      }
+    }
+    vector<cv::Mat> channels(img_channels);
+    cv::split(*expand_img, channels);
+    CHECK_EQ(channels.size(), mean_values_.size());
+    for (int c = 0; c < img_channels; ++c) {
+      channels[c] = mean_values_[c];
+    }
+    cv::merge(channels, *expand_img);
+  }
+
+  cv::Rect bbox_roi(w_off, h_off, img_width, img_height);
+  img.copyTo((*expand_img)(bbox_roi));
+}
+
 #endif  // USE_OPENCV
 
 template<typename Dtype>
@@ -913,18 +1717,131 @@ vector<int> DataTransformer<Dtype>::InferDatumShape(const Datum& datum) {
   return datum_shape;
 }
 
+template<typename Dtype>
+vector<int> DataTransformer<Dtype>::InferBlobShape(const Datum& datum) {
+  if (datum.encoded()) {
 #ifdef USE_OPENCV
+    CHECK(!(param_.force_color() && param_.force_gray()))
+        << "cannot set both force_color and force_gray";
+    cv::Mat cv_img;
+    if (param_.force_color() || param_.force_gray()) {
+    // If force_color then decode in color otherwise decode in gray.
+      cv_img = DecodeDatumToCVMat(datum, param_.force_color());
+    } else {
+      cv_img = DecodeDatumToCVMatNative(datum);
+    }
+    // InferBlobShape using the cv::image.
+    return InferBlobShape(cv_img);
+#else
+    LOG(FATAL) << "Encoded datum requires OpenCV; compile with USE_OPENCV.";
+#endif  // USE_OPENCV
+  }
+
+  const int crop_size = param_.crop_size();
+  int crop_h = param_.crop_h();
+  int crop_w = param_.crop_w();
+  if (crop_size) {
+    crop_h = crop_size;
+    crop_w = crop_size;
+  }
+  const int datum_channels = datum.channels();
+  int datum_height = datum.height();
+  int datum_width = datum.width();
+
+  // Check dimensions.
+  CHECK_GT(datum_channels, 0);
+  if (param_.has_resize_param()) {
+    InferNewSize(param_.resize_param(), datum_width, datum_height,
+                 &datum_width, &datum_height);
+  }
+  CHECK_GE(datum_height, crop_h);
+  CHECK_GE(datum_width, crop_w);
+
+  // Build BlobShape.
+  vector<int> shape(4);
+  shape[0] = 1;
+  shape[1] = datum_channels;
+  shape[2] = (crop_h)? crop_h: datum_height;
+  shape[3] = (crop_w)? crop_w: datum_width;
+  return shape;
+}
+
+template<typename Dtype>
+vector<int> DataTransformer<Dtype>::InferBlobShape(
+    const vector<Datum> & datum_vector) {
+  const int num = datum_vector.size();
+  CHECK_GT(num, 0) << "There is no datum to in the vector";
+  // Use first datum in the vector to InferBlobShape.
+  vector<int> shape = InferBlobShape(datum_vector[0]);
+  // Adjust num to the size of the vector.
+  shape[0] = num;
+  return shape;
+}
+
+#ifdef USE_OPENCV
+template<typename Dtype>
+vector<int> DataTransformer<Dtype>::InferBlobShape(const cv::Mat& cv_img) {
+  const int crop_size = param_.crop_size();
+  int crop_h = param_.crop_h();
+  int crop_w = param_.crop_w();
+  if (crop_size) {
+    crop_h = crop_size;
+    crop_w = crop_size;
+  }
+  const int img_channels = cv_img.channels();
+  int img_height = cv_img.rows;
+  int img_width = cv_img.cols;
+  // Check dimensions.
+  CHECK_GT(img_channels, 0);
+  if (param_.has_resize_param()) {
+    InferNewSize(param_.resize_param(), img_width, img_height,
+                 &img_width, &img_height);
+  }
+  CHECK_GE(img_height, crop_h);
+  CHECK_GE(img_width, crop_w);
+
+  // Build BlobShape.
+  vector<int> shape(4);
+  shape[0] = 1;
+  shape[1] = img_channels;
+  shape[2] = (crop_h)? crop_h: img_height;
+  shape[3] = (crop_w)? crop_w: img_width;
+  return shape;
+}
 
 template<typename Dtype>
 vector<int> DataTransformer<Dtype>::InferCVMatShape(const cv::Mat& cv_img) {
-  const int img_channels = cv_img.channels();
-  const int img_height = cv_img.rows;
-  const int img_width = cv_img.cols;
+  int img_channels = cv_img.channels();
+  int img_height = cv_img.rows;
+  int img_width = cv_img.cols;
   vector<int> shape(4);
   shape[0] = 1;
   shape[1] = img_channels;
   shape[2] = img_height;
   shape[3] = img_width;
+  
+  const int crop_size = param_.crop_size();
+  int crop_h = param_.crop_h();
+  int crop_w = param_.crop_w();
+  if (crop_size) {
+    crop_h = crop_size;
+    crop_w = crop_size;
+  }
+
+  // Check dimensions.
+  if (param_.has_resize_param()) {
+    InferNewSize(param_.resize_param(), img_width, img_height,
+                 &img_width, &img_height);
+  }
+  CHECK_GE(img_height, crop_h);
+  CHECK_GE(img_width, crop_w);
+
+  // Build BlobShape.
+  shape[0] = 1;
+  shape[1] = img_channels;
+  shape[2] = (crop_h)? crop_h: img_height;
+  shape[3] = (crop_w)? crop_w: img_width;
+    
   return shape;
 }
 

--- a/src/caffe/layers/annotated_data_layer.cpp
+++ b/src/caffe/layers/annotated_data_layer.cpp
@@ -1,0 +1,493 @@
+#ifdef USE_OPENCV
+#include <opencv2/core/core.hpp>
+#endif  // USE_OPENCV
+#include <stdint.h>
+
+#include <algorithm>
+#include <map>
+#include <vector>
+
+#include "caffe/data_transformer.hpp"
+#include "caffe/layers/annotated_data_layer.hpp"
+#include "caffe/util/benchmark.hpp"
+#include "caffe/util/sampler.hpp"
+#include "caffe/parallel.hpp"
+
+namespace caffe {
+
+template <typename Ftype, typename Btype>
+AnnotatedDataLayer<Ftype, Btype>::AnnotatedDataLayer(const LayerParameter& param)
+  : BasePrefetchingDataLayer<Ftype,Btype>(param),
+      cache_(param.data_param().cache()),
+    shuffle_(param.data_param().shuffle()) {
+  sample_only_.store(this->auto_mode() && this->phase_ == TRAIN);
+  init_offsets();
+}
+
+template<typename Ftype, typename Btype>
+void
+AnnotatedDataLayer<Ftype, Btype>::init_offsets() {
+  CHECK_EQ(this->transf_num_, this->threads_num());
+  CHECK_LE(parser_offsets_.size(), this->transf_num_);
+  CHECK_LE(queue_ids_.size(), this->transf_num_);
+  parser_offsets_.resize(this->transf_num_);
+  queue_ids_.resize(this->transf_num_);
+  for (size_t i = 0; i < this->transf_num_; ++i) {
+    parser_offsets_[i] = 0;
+    queue_ids_[i] = i * this->parsers_num_;
+  }
+}
+
+template <typename Ftype, typename Btype>
+AnnotatedDataLayer<Ftype, Btype>::~AnnotatedDataLayer() {
+  if (layer_inititialized_flag_.is_set()) {
+    this->StopInternalThread();
+  }
+}
+
+template<typename Ftype, typename Btype>
+void
+AnnotatedDataLayer<Ftype, Btype>::InitializePrefetch() {
+  std::lock_guard<std::mutex> lock(mutex_prefetch_);
+  if (layer_inititialized_flag_.is_set()) {
+    return;
+  }
+  if (this->auto_mode()) {
+    this->AllocatePrefetch();
+    P2PManager::dl_bar_wait();
+    // Here we try to optimize memory split between prefetching and convolution.
+    // All data and parameter blobs are allocated at this moment.
+    // Now let's find out what's left...
+    size_t current_parsers_num = this->parsers_num_;
+    size_t current_transf_num = this->threads_num();
+#ifndef CPU_ONLY
+    const size_t batch_bytes = this->prefetch_[0]->bytes(this->is_gpu_transform());
+    size_t gpu_bytes, total_memory;
+    GPUMemory::GetInfo(&gpu_bytes, &total_memory, true);
+    gpu_bytes = Caffe::min_avail_device_memory();
+    size_t batches_fit = gpu_bytes / batch_bytes;
+#else
+    size_t batches_fit = this->queues_num_;
+#endif
+    size_t max_parsers_num = 2;
+    size_t max_transf_num = 3;
+    float ratio = 5.F;
+    Net* pnet = this->parent_net();
+    if (pnet != nullptr) {
+      Solver* psolver = pnet->parent_solver();
+      if (psolver != nullptr) {
+        if (pnet->layers().size() < 100) {
+          max_transf_num = 4;
+          ratio = 2.F; // 1:2 for "i/o bound", 1:5 otherwise
+        }
+      }
+    }
+    const float fit = std::min(float(max_parsers_num * max_transf_num),
+        std::floor(batches_fit / ratio));
+    current_parsers_num = std::min(max_parsers_num, std::max(1UL,
+        static_cast<size_t>(std::sqrt(fit))));
+    if (cache_ && current_parsers_num > 1UL) {
+      LOG(INFO) << this->print_current_device() << " Reduced parser threads count from "
+                << current_parsers_num << " to 1 because cache is used";
+      current_parsers_num = 1UL;
+    }
+    current_transf_num = std::min(max_transf_num, std::max(current_transf_num,
+        static_cast<size_t>(std::lround(fit / current_parsers_num))));
+    this->RestartAllThreads(current_transf_num, true, false, Caffe::next_seed());
+    this->transf_num_ = this->threads_num();
+    this->parsers_num_ = current_parsers_num;
+    this->queues_num_ = this->transf_num_ * this->parsers_num_;
+    BasePrefetchingDataLayer<Ftype, Btype>::InitializePrefetch();
+    if (current_transf_num > 1) {
+      this->next_batch_queue();  // 0th already processed
+    }
+    if (this->parsers_num_ > 1) {
+      parser_offsets_[0]++;  // same as above
+    }
+    this->go();  // kick off new threads if any
+  }
+
+  CHECK_EQ(this->threads_num(), this->transf_num_);
+  LOG(INFO) << this->print_current_device() << " Parser threads: "
+      << this->parsers_num_ << (this->auto_mode() ? " (auto)" : "");
+  LOG(INFO) << this->print_current_device() << " Transformer threads: "
+      << this->transf_num_ << (this->auto_mode() ? " (auto)" : "");
+  layer_inititialized_flag_.set();
+}
+
+template<typename Ftype, typename Btype>
+size_t AnnotatedDataLayer<Ftype, Btype>::queue_id(size_t thread_id) const {
+  const size_t qid = queue_ids_[thread_id] + parser_offsets_[thread_id];
+  parser_offsets_[thread_id]++;
+  if (parser_offsets_[thread_id] >= this->parsers_num_) {
+    parser_offsets_[thread_id] = 0UL;
+    queue_ids_[thread_id] += this->parsers_num_ * this->threads_num();
+  }
+  return qid % this->queues_num_;
+};
+
+template <typename Ftype, typename Btype>
+void AnnotatedDataLayer<Ftype, Btype>::DataLayerSetUp(
+    const vector<Blob*>& bottom, const vector<Blob*>& top) {
+  std::lock_guard<std::mutex> lock(mutex_setup_);
+  const LayerParameter& param = this->layer_param();
+  const AnnotatedDataParameter& anno_data_param = param.annotated_data_param();
+  const int batch_size = param.data_param().batch_size();
+  //const bool use_gpu_transform = this->is_gpu_transform();
+  const bool cache = this->cache_ && this->phase_ == TRAIN;
+  const bool shuffle = cache && this->shuffle_ && this->phase_ == TRAIN;
+  TBlob<Ftype> transformed_datum;
+  
+  for (int i = 0; i < anno_data_param.batch_sampler_size(); ++i) {
+    batch_samplers_.push_back(anno_data_param.batch_sampler(i));
+  }
+  
+  if (this->auto_mode()) {
+    if (!sample_reader_) {
+	  sample_reader_ = make_shared<DataReader<AnnotatedDatum>>(param,
+          Caffe::solver_count(),
+          this->solver_rank_,
+          this->parsers_num_,
+          this->threads_num(),
+          batch_size,
+          true,
+          false,
+          cache,
+          shuffle);
+    } else if (!reader_) {
+	  reader_ = make_shared<DataReader<AnnotatedDatum>>(param,
+          Caffe::solver_count(),
+          this->solver_rank_,
+          this->parsers_num_,
+          this->threads_num(),
+          batch_size,
+          false,
+          true,
+          cache,
+          shuffle);
+    }
+  } else if (!reader_) {
+    reader_ = make_shared<DataReader<AnnotatedDatum>>(param,
+        Caffe::solver_count(),
+        this->solver_rank_,
+        this->parsers_num_,
+        this->threads_num(),
+        batch_size,
+        false,
+        false,
+        cache,
+        shuffle);
+    start_reading();
+  }
+ 
+  label_map_file_ = anno_data_param.label_map_file();
+  // Make sure dimension is consistent within batch.
+  const TransformationParameter& transform_param =
+    this->layer_param_.transform_param();
+  if (transform_param.has_resize_param()) {
+    if (transform_param.resize_param().resize_mode() ==
+        ResizeParameter_Resize_mode_FIT_SMALL_SIZE) {
+      CHECK_EQ(batch_size, 1)
+        << "Only support batch size of 1 for FIT_SMALL_SIZE.";
+    }
+  }
+    		
+  // Read a data point, and use it to initialize the top blob.
+  shared_ptr<AnnotatedDatum> sample_datum = this->sample_only_ ? this->sample_reader_->sample() : this->reader_->sample();
+  AnnotatedDatum& anno_datum = *sample_datum;
+  this->init_offsets();
+
+  // Calculate the variable sized transformed datum shape.
+  vector<int> sample_datum_shape = this->data_transformers_[0]->InferDatumShape(sample_datum->datum());
+#ifdef USE_OPENCV
+  if (this->data_transformers_[0]->var_sized_transforms_enabled()) {
+    sample_datum_shape =
+        this->data_transformers_[0]->var_sized_transforms_shape(sample_datum_shape);
+  }
+#endif
+
+  // Reshape top[0] and prefetch_data according to the batch_size.
+  // Note: all these reshapings here in load_batch are needed only in case of
+  // different datum shapes coming from database.
+  vector<int> top_shape = this->data_transformers_[0]->InferBlobShape(sample_datum_shape);
+  transformed_datum.Reshape(top_shape);   	  
+  top_shape[0] = batch_size;
+  top[0]->Reshape(top_shape);
+  for (int i = 0; i < this->prefetch_.size(); ++i) {
+    this->prefetch_[i]->data_.Reshape(top_shape);
+  }
+  LOG(INFO) << "output data size: " << top[0]->num() << ","
+      << top[0]->channels() << "," << top[0]->height() << ","
+      << top[0]->width();
+  // label
+  if (this->output_labels_) {
+    has_anno_type_ = anno_datum.has_type() || anno_data_param.has_anno_type();
+    vector<int> label_shape(4, 1);
+    if (has_anno_type_) {
+      anno_type_ = anno_datum.type();
+      if (anno_data_param.has_anno_type()) {
+        // If anno_type is provided in AnnotatedDataParameter, replace
+        // the type stored in each individual AnnotatedDatum.
+        LOG(WARNING) << "type stored in AnnotatedDatum is shadowed.";
+        anno_type_ = anno_data_param.anno_type();
+      }
+      // Infer the label shape from anno_datum.AnnotationGroup().
+      int num_bboxes = 0;
+      if (anno_type_ == AnnotatedDatum_AnnotationType_BBOX) {
+        // Since the number of bboxes can be different for each image,
+        // we store the bbox information in a specific format. In specific:
+        // All bboxes are stored in one spatial plane (num and channels are 1)
+        // And each row contains one and only one box in the following format:
+        // [item_id, group_label, instance_id, xmin, ymin, xmax, ymax, diff]
+        // Note: Refer to caffe.proto for details about group_label and
+        // instance_id.
+        for (int g = 0; g < anno_datum.annotation_group_size(); ++g) {
+          num_bboxes += anno_datum.annotation_group(g).annotation_size();
+        }
+        label_shape[0] = 1;
+        label_shape[1] = 1;
+        // BasePrefetchingDataLayer<Dtype>::LayerSetUp() requires to call
+        // cpu_data and gpu_data for consistent prefetch thread. Thus we make
+        // sure there is at least one bbox.
+        label_shape[2] = std::max(num_bboxes, 1);
+        label_shape[3] = 8;
+      } else {
+        LOG(FATAL) << "Unknown annotation type.";
+      }
+    } else {
+      label_shape[0] = batch_size;
+    }
+    top[1]->Reshape(label_shape);
+    for (int i = 0; i < this->prefetch_.size(); ++i) {
+      this->prefetch_[i]->label_.Reshape(label_shape);
+    }
+  }
+  LOG(INFO) << this->print_current_device() << " Output data size: "
+      << top[0]->num() << ", "
+      << top[0]->channels() << ", "
+      << top[0]->height() << ", "
+      << top[0]->width();
+}
+
+// This function is called on prefetch thread
+template <typename Ftype, typename Btype>
+void AnnotatedDataLayer<Ftype, Btype>::load_batch(Batch<Dtype>* batch, int thread_id, size_t queue_id) {
+  CPUTimer batch_timer;
+  batch_timer.Start();
+  double read_time = 0;
+  double trans_time = 0;
+  CPUTimer timer;
+  CHECK(batch->data_.count());
+
+  const bool sample_only = sample_only_.load();
+  TBlob<Ftype> transformed_datum;
+
+  //const bool use_gpu_transform = false;//this->is_gpu_transform();
+  // Reshape according to the first anno_datum of each batch
+  // on single input batches allows for inputs of varying dimension.
+  const int batch_size = this->layer_param_.data_param().batch_size();
+  const AnnotatedDataParameter& anno_data_param =
+      this->layer_param_.annotated_data_param();
+  const TransformationParameter& transform_param =
+    this->layer_param_.transform_param();
+
+  const size_t qid = sample_only ? 0UL : queue_id;
+  DataReader<AnnotatedDatum>* reader = sample_only ? sample_reader_.get() : reader_.get();
+  shared_ptr<AnnotatedDatum> init_datum = reader->full_peek(qid);
+  CHECK(init_datum);
+ 
+  // Calculate the variable sized transformed datum shape.
+  vector<int> datum_shape = this->data_transformers_[thread_id]->InferDatumShape(init_datum->datum());
+#ifdef USE_OPENCV
+  if (this->data_transformers_[thread_id]->var_sized_transforms_enabled()) {
+    datum_shape = this->data_transformers_[thread_id]->var_sized_transforms_shape(datum_shape);
+  }
+#endif
+    
+  // Use data_transformer to infer the expected blob shape from datum.
+  //vector<int> top_shape = this->data_transformers_[thread_id]->InferBlobShape(datum_shape,
+  //    use_gpu_transform);  
+  vector<int> top_shape =
+      this->data_transformers_[thread_id]->InferBlobShape(init_datum->datum());
+  transformed_datum.Reshape(top_shape);
+  // Reshape batch according to the batch_size.
+  top_shape[0] = batch_size;
+  batch->data_.Reshape(top_shape);
+
+  Dtype* top_data = batch->data_.mutable_cpu_data();
+  Dtype* top_label = NULL;  // suppress warnings about uninitialized variables
+  if (this->output_labels_ && !has_anno_type_) {
+    top_label = batch->label_.mutable_cpu_data();
+  }
+
+  // Store transformed annotation.
+  map<int, vector<AnnotationGroup> > all_anno;
+  int num_bboxes = 0;
+
+  for (int item_id = 0; item_id < batch_size; ++item_id) {
+    timer.Start();
+    // get a anno_datum
+    shared_ptr<AnnotatedDatum> anno_datum = reader_->full_pop(queue_id, "Waiting for data");
+    read_time += timer.MicroSeconds();
+    timer.Start();
+    AnnotatedDatum distort_datum;
+    AnnotatedDatum* expand_datum = NULL;
+    if (transform_param.has_distort_param()) {
+      distort_datum.CopyFrom(*anno_datum);
+      this->data_transformers_[thread_id]->DistortImage(anno_datum->datum(),
+                                            distort_datum.mutable_datum());
+      if (transform_param.has_expand_param()) {
+        expand_datum = new AnnotatedDatum();
+        this->data_transformers_[thread_id]->ExpandImage(distort_datum, expand_datum);
+      } else {
+        expand_datum = &distort_datum;
+      }
+    } else {
+      if (transform_param.has_expand_param()) {
+        expand_datum = new AnnotatedDatum();
+        this->data_transformers_[thread_id]->ExpandImage(*anno_datum, expand_datum);
+      } else {
+        expand_datum = &(*anno_datum);
+      }
+    }
+    AnnotatedDatum* sampled_datum = NULL;
+    bool has_sampled = false;
+    if (batch_samplers_.size() > 0) {
+      // Generate sampled bboxes from expand_datum.
+      vector<NormalizedBBox> sampled_bboxes;
+      GenerateBatchSamples(*expand_datum, batch_samplers_, &sampled_bboxes);
+      if (sampled_bboxes.size() > 0) {
+        // Randomly pick a sampled bbox and crop the expand_datum.
+        int rand_idx = caffe_rng_rand() % sampled_bboxes.size();
+        sampled_datum = new AnnotatedDatum();
+        this->data_transformers_[thread_id]->CropImage(*expand_datum,
+                                           sampled_bboxes[rand_idx],
+                                           sampled_datum);
+        has_sampled = true;
+      } else {
+        sampled_datum = expand_datum;
+      }
+    } else {
+      sampled_datum = expand_datum;
+    }
+    CHECK(sampled_datum != NULL);
+    timer.Start();
+    vector<int> shape =
+        this->data_transformers_[thread_id]->InferBlobShape(sampled_datum->datum());
+    if (transform_param.has_resize_param()) {
+      if (transform_param.resize_param().resize_mode() ==
+          ResizeParameter_Resize_mode_FIT_SMALL_SIZE) {
+        transformed_datum.Reshape(shape);
+        batch->data_.Reshape(shape);
+        top_data = batch->data_.mutable_cpu_data();
+      } else {
+        CHECK(std::equal(top_shape.begin() + 1, top_shape.begin() + 4,
+              shape.begin() + 1));
+      }
+    } else {
+      CHECK(std::equal(top_shape.begin() + 1, top_shape.begin() + 4,
+            shape.begin() + 1));
+    }
+    // Apply data transformations (mirror, scale, crop...)
+    int offset = batch->data_.offset(item_id);
+    transformed_datum.set_cpu_data(top_data + offset);
+    vector<AnnotationGroup> transformed_anno_vec;
+    if (this->output_labels_) {
+      if (has_anno_type_) {
+        // Make sure all data have same annotation type.
+        CHECK(sampled_datum->has_type()) << "Some datum misses AnnotationType.";
+        if (anno_data_param.has_anno_type()) {
+          sampled_datum->set_type(anno_type_);
+        } else {
+          CHECK_EQ(anno_type_, sampled_datum->type()) <<
+              "Different AnnotationType.";
+        }
+        // Transform datum and annotation_group at the same time
+        transformed_anno_vec.clear();
+        this->data_transformers_[thread_id]->Transform(*sampled_datum,
+                                           &(transformed_datum),
+                                           &transformed_anno_vec);
+        if (anno_type_ == AnnotatedDatum_AnnotationType_BBOX) {
+          // Count the number of bboxes.
+          for (int g = 0; g < transformed_anno_vec.size(); ++g) {
+            num_bboxes += transformed_anno_vec[g].annotation_size();
+          }
+        } else {
+          LOG(FATAL) << "Unknown annotation type.";
+        }
+        all_anno[item_id] = transformed_anno_vec;
+      } else {
+        this->data_transformers_[thread_id]->Transform(sampled_datum->datum(),
+                                           &(transformed_datum));
+        // Otherwise, store the label from datum.
+        CHECK(sampled_datum->datum().has_label()) << "Cannot find any label.";
+        top_label[item_id] = sampled_datum->datum().label();
+      }
+    } else {
+      this->data_transformers_[thread_id]->Transform(sampled_datum->datum(),
+                                         &(transformed_datum));
+    }
+    // clear memory
+    if (has_sampled) {
+      delete sampled_datum;
+    }
+    if (transform_param.has_expand_param()) {
+      delete expand_datum;
+    }
+    trans_time += timer.MicroSeconds();
+
+    reader_->free_push(queue_id, anno_datum);
+  }
+
+  // Store "rich" annotation if needed.
+  if (this->output_labels_ && has_anno_type_) {
+    vector<int> label_shape(4);
+    if (anno_type_ == AnnotatedDatum_AnnotationType_BBOX) {
+      label_shape[0] = 1;
+      label_shape[1] = 1;
+      label_shape[3] = 8;
+      if (num_bboxes == 0) {
+        // Store all -1 in the label.
+        label_shape[2] = 1;
+        batch->label_.Reshape(label_shape);
+        caffe_set<Dtype>(8, -1, batch->label_.mutable_cpu_data());
+      } else {
+        // Reshape the label and store the annotation.
+        label_shape[2] = num_bboxes;
+        batch->label_.Reshape(label_shape);
+        top_label = batch->label_.mutable_cpu_data();
+        int idx = 0;
+        for (int item_id = 0; item_id < batch_size; ++item_id) {
+          const vector<AnnotationGroup>& anno_vec = all_anno[item_id];
+          for (int g = 0; g < anno_vec.size(); ++g) {
+            const AnnotationGroup& anno_group = anno_vec[g];
+            for (int a = 0; a < anno_group.annotation_size(); ++a) {
+              const Annotation& anno = anno_group.annotation(a);
+              const NormalizedBBox& bbox = anno.bbox();
+              top_label[idx++] = item_id;
+              top_label[idx++] = anno_group.group_label();
+              top_label[idx++] = anno.instance_id();
+              top_label[idx++] = bbox.xmin();
+              top_label[idx++] = bbox.ymin();
+              top_label[idx++] = bbox.xmax();
+              top_label[idx++] = bbox.ymax();
+              top_label[idx++] = bbox.difficult();
+            }
+          }
+        }
+      }
+    } else {
+      LOG(FATAL) << "Unknown annotation type.";
+    }
+  }
+  timer.Stop();
+  batch_timer.Stop();
+  DLOG(INFO) << "Prefetch batch: " << batch_timer.MilliSeconds() << " ms.";
+  DLOG(INFO) << "     Read time: " << read_time / 1000 << " ms.";
+  DLOG(INFO) << "Transform time: " << trans_time / 1000 << " ms.";
+}
+
+INSTANTIATE_CLASS_FB(AnnotatedDataLayer);
+REGISTER_LAYER_CLASS(AnnotatedData);
+
+}  // namespace caffe

--- a/src/caffe/layers/data_layer.cpp
+++ b/src/caffe/layers/data_layer.cpp
@@ -128,7 +128,7 @@ DataLayer<Ftype, Btype>::DataLayerSetUp(const vector<Blob*>& bottom, const vecto
 
   if (this->auto_mode_) {
     if (!sample_reader_) {
-      sample_reader_ = make_shared<DataReader>(param,
+      sample_reader_ = make_shared<DataReader<Datum>>(param,
           Caffe::solver_count(),
           this->solver_rank_,
           this->parsers_num_,
@@ -139,7 +139,7 @@ DataLayer<Ftype, Btype>::DataLayerSetUp(const vector<Blob*>& bottom, const vecto
           cache,
           shuffle);
     } else if (!reader_) {
-      reader_ = make_shared<DataReader>(param,
+      reader_ = make_shared<DataReader<Datum>>(param,
           Caffe::solver_count(),
           this->solver_rank_,
           this->parsers_num_,
@@ -151,7 +151,7 @@ DataLayer<Ftype, Btype>::DataLayerSetUp(const vector<Blob*>& bottom, const vecto
           shuffle);
     }
   } else if (!reader_) {
-    reader_ = make_shared<DataReader>(param,
+    reader_ = make_shared<DataReader<Datum>>(param,
         Caffe::solver_count(),
         this->solver_rank_,
         this->parsers_num_,
@@ -227,7 +227,7 @@ void DataLayer<Ftype, Btype>::load_batch(Batch<Ftype>* batch, int thread_id, siz
   const int batch_size = this->layer_param_.data_param().batch_size();
 
   const size_t qid = sample_only ? 0UL : queue_id;
-  DataReader* reader = sample_only ? sample_reader_.get() : reader_.get();
+  DataReader<Datum>* reader = sample_only ? sample_reader_.get() : reader_.get();
   shared_ptr<Datum> init_datum = reader->full_peek(qid);
   CHECK(init_datum);
 

--- a/src/caffe/layers/detection_evaluate_layer.cpp
+++ b/src/caffe/layers/detection_evaluate_layer.cpp
@@ -1,0 +1,250 @@
+#include <algorithm>
+#include <map>
+#include <string>
+#include <vector>
+
+#include "caffe/layers/detection_evaluate_layer.hpp"
+#include "caffe/util/bbox_util.hpp"
+
+namespace caffe {
+
+template <typename Ftype, typename Btype>
+void DetectionEvaluateLayer<Ftype,Btype>::LayerSetUp(
+      const vector<Blob*>& bottom, const vector<Blob*>& top) {
+  const DetectionEvaluateParameter& detection_evaluate_param =
+      this->layer_param_.detection_evaluate_param();
+  CHECK(detection_evaluate_param.has_num_classes())
+      << "Must provide num_classes.";
+  num_classes_ = detection_evaluate_param.num_classes();
+  background_label_id_ = detection_evaluate_param.background_label_id();
+  overlap_threshold_ = detection_evaluate_param.overlap_threshold();
+  CHECK_GT(overlap_threshold_, 0.) << "overlap_threshold must be non negative.";
+  evaluate_difficult_gt_ = detection_evaluate_param.evaluate_difficult_gt();
+  if (detection_evaluate_param.has_name_size_file()) {
+    string name_size_file = detection_evaluate_param.name_size_file();
+    std::ifstream infile(name_size_file.c_str());
+    CHECK(infile.good())
+        << "Failed to open name size file: " << name_size_file;
+    // The file is in the following format:
+    //    name height width
+    //    ...
+    string name;
+    int height, width;
+    while (infile >> name >> height >> width) {
+      sizes_.push_back(std::make_pair(height, width));
+    }
+    infile.close();
+  }
+  count_ = 0;
+  // If there is no name_size_file provided, use normalized bbox to evaluate.
+  use_normalized_bbox_ = sizes_.size() == 0;
+
+  // Retrieve resize parameter if there is any provided.
+  has_resize_ = detection_evaluate_param.has_resize_param();
+  if (has_resize_) {
+    resize_param_ = detection_evaluate_param.resize_param();
+  }
+}
+
+template <typename Ftype, typename Btype>
+void DetectionEvaluateLayer<Ftype,Btype>::Reshape(const vector<Blob*>& bottom,
+      const vector<Blob*>& top) {
+  CHECK_LE(count_, sizes_.size());
+  CHECK_EQ(bottom[0]->num(), 1);
+  CHECK_EQ(bottom[0]->channels(), 1);
+  CHECK_EQ(bottom[0]->width(), 7);
+  CHECK_EQ(bottom[1]->num(), 1);
+  CHECK_EQ(bottom[1]->channels(), 1);
+  CHECK_EQ(bottom[1]->width(), 8);
+
+  // num() and channels() are 1.
+  vector<int> top_shape(2, 1);
+  int num_pos_classes = background_label_id_ == -1 ?
+      num_classes_ : num_classes_ - 1;
+  int num_valid_det = 0;
+  const Dtype* det_data = bottom[0]->cpu_data<Dtype>();
+  for (int i = 0; i < bottom[0]->height(); ++i) {
+    if (det_data[1] != -1) {
+      ++num_valid_det;
+    }
+    det_data += 7;
+  }
+  top_shape.push_back(num_pos_classes + num_valid_det);
+  // Each row is a 5 dimension vector, which stores
+  // [image_id, label, confidence, true_pos, false_pos]
+  top_shape.push_back(5);
+  top[0]->Reshape(top_shape);
+}
+
+template <typename Ftype, typename Btype>
+void DetectionEvaluateLayer<Ftype,Btype>::Forward_cpu(
+    const vector<Blob*>& bottom, const vector<Blob*>& top) {
+  const Dtype* det_data = bottom[0]->cpu_data<Dtype>();
+  const Dtype* gt_data = bottom[1]->cpu_data<Dtype>();
+
+  // Retrieve all detection results.
+  map<int, LabelBBox> all_detections;
+  GetDetectionResults(det_data, bottom[0]->height(), background_label_id_,
+                      &all_detections);
+
+  // Retrieve all ground truth (including difficult ones).
+  map<int, LabelBBox> all_gt_bboxes;
+  GetGroundTruth(gt_data, bottom[1]->height(), background_label_id_,
+                 true, &all_gt_bboxes);
+
+  Dtype* top_data = top[0]->mutable_cpu_data<Dtype>();
+  caffe_set(top[0]->count(), Dtype(0.), top_data);
+  int num_det = 0;
+
+  // Insert number of ground truth for each label.
+  map<int, int> num_pos;
+  for (map<int, LabelBBox>::iterator it = all_gt_bboxes.begin();
+       it != all_gt_bboxes.end(); ++it) {
+    for (LabelBBox::iterator iit = it->second.begin(); iit != it->second.end();
+         ++iit) {
+      int count = 0;
+      if (evaluate_difficult_gt_) {
+        count = iit->second.size();
+      } else {
+        // Get number of non difficult ground truth.
+        for (int i = 0; i < iit->second.size(); ++i) {
+          if (!iit->second[i].difficult()) {
+            ++count;
+          }
+        }
+      }
+      if (num_pos.find(iit->first) == num_pos.end()) {
+        num_pos[iit->first] = count;
+      } else {
+        num_pos[iit->first] += count;
+      }
+    }
+  }
+  for (int c = 0; c < num_classes_; ++c) {
+    if (c == background_label_id_) {
+      continue;
+    }
+    top_data[num_det * 5] = -1;
+    top_data[num_det * 5 + 1] = c;
+    if (num_pos.find(c) == num_pos.end()) {
+      top_data[num_det * 5 + 2] = 0;
+    } else {
+      top_data[num_det * 5 + 2] = num_pos.find(c)->second;
+    }
+    top_data[num_det * 5 + 3] = -1;
+    top_data[num_det * 5 + 4] = -1;
+    ++num_det;
+  }
+
+  // Insert detection evaluate status.
+  for (map<int, LabelBBox>::iterator it = all_detections.begin();
+       it != all_detections.end(); ++it) {
+    int image_id = it->first;
+    LabelBBox& detections = it->second;
+    if (all_gt_bboxes.find(image_id) == all_gt_bboxes.end()) {
+      // No ground truth for current image. All detections become false_pos.
+      for (LabelBBox::iterator iit = detections.begin();
+           iit != detections.end(); ++iit) {
+        int label = iit->first;
+        if (label == -1) {
+          continue;
+        }
+        const vector<NormalizedBBox>& bboxes = iit->second;
+        for (int i = 0; i < bboxes.size(); ++i) {
+          top_data[num_det * 5] = image_id;
+          top_data[num_det * 5 + 1] = label;
+          top_data[num_det * 5 + 2] = bboxes[i].score();
+          top_data[num_det * 5 + 3] = 0;
+          top_data[num_det * 5 + 4] = 1;
+          ++num_det;
+        }
+      }
+    } else {
+      LabelBBox& label_bboxes = all_gt_bboxes.find(image_id)->second;
+      for (LabelBBox::iterator iit = detections.begin();
+           iit != detections.end(); ++iit) {
+        int label = iit->first;
+        if (label == -1) {
+          continue;
+        }
+        vector<NormalizedBBox>& bboxes = iit->second;
+        if (label_bboxes.find(label) == label_bboxes.end()) {
+          // No ground truth for current label. All detections become false_pos.
+          for (int i = 0; i < bboxes.size(); ++i) {
+            top_data[num_det * 5] = image_id;
+            top_data[num_det * 5 + 1] = label;
+            top_data[num_det * 5 + 2] = bboxes[i].score();
+            top_data[num_det * 5 + 3] = 0;
+            top_data[num_det * 5 + 4] = 1;
+            ++num_det;
+          }
+        } else {
+          vector<NormalizedBBox>& gt_bboxes = label_bboxes.find(label)->second;
+          // Scale ground truth if needed.
+          if (!use_normalized_bbox_) {
+            CHECK_LT(count_, sizes_.size());
+            for (int i = 0; i < gt_bboxes.size(); ++i) {
+              OutputBBox(gt_bboxes[i], sizes_[count_], has_resize_,
+                         resize_param_, &(gt_bboxes[i]));
+            }
+          }
+          vector<bool> visited(gt_bboxes.size(), false);
+          // Sort detections in descend order based on scores.
+          std::sort(bboxes.begin(), bboxes.end(), SortBBoxDescend);
+          for (int i = 0; i < bboxes.size(); ++i) {
+            top_data[num_det * 5] = image_id;
+            top_data[num_det * 5 + 1] = label;
+            top_data[num_det * 5 + 2] = bboxes[i].score();
+            if (!use_normalized_bbox_) {
+              OutputBBox(bboxes[i], sizes_[count_], has_resize_,
+                         resize_param_, &(bboxes[i]));
+            }
+            // Compare with each ground truth bbox.
+            float overlap_max = -1;
+            int jmax = -1;
+            for (int j = 0; j < gt_bboxes.size(); ++j) {
+              float overlap = JaccardOverlap(bboxes[i], gt_bboxes[j],
+                                             use_normalized_bbox_);
+              if (overlap > overlap_max) {
+                overlap_max = overlap;
+                jmax = j;
+              }
+            }
+            if (overlap_max >= overlap_threshold_) {
+              if (evaluate_difficult_gt_ ||
+                  (!evaluate_difficult_gt_ && !gt_bboxes[jmax].difficult())) {
+                if (!visited[jmax]) {
+                  // true positive.
+                  top_data[num_det * 5 + 3] = 1;
+                  top_data[num_det * 5 + 4] = 0;
+                  visited[jmax] = true;
+                } else {
+                  // false positive (multiple detection).
+                  top_data[num_det * 5 + 3] = 0;
+                  top_data[num_det * 5 + 4] = 1;
+                }
+              }
+            } else {
+              // false positive.
+              top_data[num_det * 5 + 3] = 0;
+              top_data[num_det * 5 + 4] = 1;
+            }
+            ++num_det;
+          }
+        }
+      }
+    }
+    if (sizes_.size() > 0) {
+      ++count_;
+      if (count_ == sizes_.size()) {
+        // reset count after a full iterations through the DB.
+        count_ = 0;
+      }
+    }
+  }
+}
+
+INSTANTIATE_CLASS_FB(DetectionEvaluateLayer);
+REGISTER_LAYER_CLASS(DetectionEvaluate);
+
+}  // namespace caffe

--- a/src/caffe/layers/detection_output_layer.cpp
+++ b/src/caffe/layers/detection_output_layer.cpp
@@ -1,0 +1,481 @@
+#include <algorithm>
+#include <fstream>  // NOLINT(readability/streams)
+#include <map>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "boost/filesystem.hpp"
+#include "boost/foreach.hpp"
+
+#include "caffe/layers/detection_output_layer.hpp"
+
+namespace caffe {
+
+template <typename Ftype, typename Btype>
+void DetectionOutputLayer<Ftype,Btype>::LayerSetUp(const vector<Blob*>& bottom,
+      const vector<Blob*>& top) {
+  const DetectionOutputParameter& detection_output_param =
+      this->layer_param_.detection_output_param();
+  CHECK(detection_output_param.has_num_classes()) << "Must specify num_classes";
+  num_classes_ = detection_output_param.num_classes();
+  share_location_ = detection_output_param.share_location();
+  num_loc_classes_ = share_location_ ? 1 : num_classes_;
+  background_label_id_ = detection_output_param.background_label_id();
+  code_type_ = detection_output_param.code_type();
+  variance_encoded_in_target_ =
+      detection_output_param.variance_encoded_in_target();
+  keep_top_k_ = detection_output_param.keep_top_k();
+  confidence_threshold_ = detection_output_param.has_confidence_threshold() ?
+      detection_output_param.confidence_threshold() : -FLT_MAX;
+  // Parameters used in nms.
+  nms_threshold_ = detection_output_param.nms_param().nms_threshold();
+  CHECK_GE(nms_threshold_, 0.) << "nms_threshold must be non negative.";
+  eta_ = detection_output_param.nms_param().eta();
+  CHECK_GT(eta_, 0.);
+  CHECK_LE(eta_, 1.);
+  top_k_ = -1;
+  if (detection_output_param.nms_param().has_top_k()) {
+    top_k_ = detection_output_param.nms_param().top_k();
+  }
+  const SaveOutputParameter& save_output_param =
+      detection_output_param.save_output_param();
+  output_directory_ = save_output_param.output_directory();
+  if (!output_directory_.empty()) {
+    if (boost::filesystem::is_directory(output_directory_)) {
+      boost::filesystem::remove_all(output_directory_);
+    }
+    if (!boost::filesystem::create_directories(output_directory_)) {
+        LOG(WARNING) << "Failed to create directory: " << output_directory_;
+    }
+  }
+  output_name_prefix_ = save_output_param.output_name_prefix();
+  need_save_ = output_directory_ == "" ? false : true;
+  output_format_ = save_output_param.output_format();
+  if (save_output_param.has_label_map_file()) {
+    string label_map_file = save_output_param.label_map_file();
+    if (label_map_file.empty()) {
+      // Ignore saving if there is no label_map_file provided.
+      LOG(WARNING) << "Provide label_map_file if output results to files.";
+      need_save_ = false;
+    } else {
+      LabelMap label_map;
+      CHECK(ReadProtoFromTextFile(label_map_file, &label_map))
+          << "Failed to read label map file: " << label_map_file;
+      CHECK(MapLabelToName(label_map, true, &label_to_name_))
+          << "Failed to convert label to name.";
+      CHECK(MapLabelToDisplayName(label_map, true, &label_to_display_name_))
+          << "Failed to convert label to display name.";
+    }
+  } else {
+    need_save_ = false;
+  }
+  if (save_output_param.has_name_size_file()) {
+    string name_size_file = save_output_param.name_size_file();
+    if (name_size_file.empty()) {
+      // Ignore saving if there is no name_size_file provided.
+      LOG(WARNING) << "Provide name_size_file if output results to files.";
+      need_save_ = false;
+    } else {
+      std::ifstream infile(name_size_file.c_str());
+      CHECK(infile.good())
+          << "Failed to open name size file: " << name_size_file;
+      // The file is in the following format:
+      //    name height width
+      //    ...
+      string name;
+      int height, width;
+      while (infile >> name >> height >> width) {
+        names_.push_back(name);
+        sizes_.push_back(std::make_pair(height, width));
+      }
+      infile.close();
+      if (save_output_param.has_num_test_image()) {
+        num_test_image_ = save_output_param.num_test_image();
+      } else {
+        num_test_image_ = names_.size();
+      }
+      CHECK_LE(num_test_image_, names_.size());
+    }
+  } else {
+    need_save_ = false;
+  }
+  has_resize_ = save_output_param.has_resize_param();
+  if (has_resize_) {
+    resize_param_ = save_output_param.resize_param();
+  }
+  name_count_ = 0;
+  visualize_ = detection_output_param.visualize();
+  if (visualize_) {
+    visualize_threshold_ = 0.6;
+    if (detection_output_param.has_visualize_threshold()) {
+      visualize_threshold_ = detection_output_param.visualize_threshold();
+    }
+    data_transformer_.reset(
+        new DataTransformer<Dtype>(this->layer_param_.transform_param(),
+                                   this->phase_));
+    data_transformer_->InitRand();
+    save_file_ = detection_output_param.save_file();
+  }
+  bbox_preds_.ReshapeLike(*(bottom[0]));
+  if (!share_location_) {
+    bbox_permute_.ReshapeLike(*(bottom[0]));
+  }
+  conf_permute_.ReshapeLike(*(bottom[1]));
+}
+
+template <typename Ftype, typename Btype>
+void DetectionOutputLayer<Ftype,Btype>::Reshape(const vector<Blob*>& bottom,
+      const vector<Blob*>& top) {
+  if (need_save_) {
+    CHECK_LE(name_count_, names_.size());
+    if (name_count_ % num_test_image_ == 0) {
+      // Clean all outputs.
+      if (output_format_ == "VOC") {
+        boost::filesystem::path output_directory(output_directory_);
+        for (map<int, string>::iterator it = label_to_name_.begin();
+             it != label_to_name_.end(); ++it) {
+          if (it->first == background_label_id_) {
+            continue;
+          }
+          std::ofstream outfile;
+          boost::filesystem::path file(
+              output_name_prefix_ + it->second + ".txt");
+          boost::filesystem::path out_file = output_directory / file;
+          outfile.open(out_file.string().c_str(), std::ofstream::out);
+        }
+      }
+    }
+  }
+  CHECK_EQ(bottom[0]->num(), bottom[1]->num());
+  if (bbox_preds_.num() != bottom[0]->num() ||
+      bbox_preds_.count(1) != bottom[0]->count(1)) {
+    bbox_preds_.ReshapeLike(*(bottom[0]));
+  }
+  if (!share_location_ && (bbox_permute_.num() != bottom[0]->num() ||
+      bbox_permute_.count(1) != bottom[0]->count(1))) {
+    bbox_permute_.ReshapeLike(*(bottom[0]));
+  }
+  if (conf_permute_.num() != bottom[1]->num() ||
+      conf_permute_.count(1) != bottom[1]->count(1)) {
+    conf_permute_.ReshapeLike(*(bottom[1]));
+  }
+  num_priors_ = bottom[2]->height() / 4;
+  CHECK_EQ(num_priors_ * num_loc_classes_ * 4, bottom[0]->channels())
+      << "Number of priors must match number of location predictions.";
+  CHECK_EQ(num_priors_ * num_classes_, bottom[1]->channels())
+      << "Number of priors must match number of confidence predictions.";
+  // num() and channels() are 1.
+  vector<int> top_shape(2, 1);
+  // Since the number of bboxes to be kept is unknown before nms, we manually
+  // set it to (fake) 1.
+  top_shape.push_back(1);
+  // Each row is a 7 dimension vector, which stores
+  // [image_id, label, confidence, xmin, ymin, xmax, ymax]
+  top_shape.push_back(7);
+  top[0]->Reshape(top_shape);
+}
+
+template <typename Ftype, typename Btype>
+void DetectionOutputLayer<Ftype,Btype>::Forward_cpu(
+    const vector<Blob*>& bottom, const vector<Blob*>& top) {
+  const Dtype* loc_data = bottom[0]->cpu_data<Dtype>();
+  const Dtype* conf_data = bottom[1]->cpu_data<Dtype>();
+  const Dtype* prior_data = bottom[2]->cpu_data<Dtype>();
+  const int num = bottom[0]->num();
+
+  // Retrieve all location predictions.
+  vector<LabelBBox> all_loc_preds;
+  GetLocPredictions(loc_data, num, num_priors_, num_loc_classes_,
+                    share_location_, &all_loc_preds);
+
+  // Retrieve all confidences.
+  vector<map<int, vector<float> > > all_conf_scores;
+  GetConfidenceScores(conf_data, num, num_priors_, num_classes_,
+                      &all_conf_scores);
+
+  // Retrieve all prior bboxes. It is same within a batch since we assume all
+  // images in a batch are of same dimension.
+  vector<NormalizedBBox> prior_bboxes;
+  vector<vector<float> > prior_variances;
+  GetPriorBBoxes(prior_data, num_priors_, &prior_bboxes, &prior_variances);
+
+  // Decode all loc predictions to bboxes.
+  vector<LabelBBox> all_decode_bboxes;
+  const bool clip_bbox = false;
+  DecodeBBoxesAll(all_loc_preds, prior_bboxes, prior_variances, num,
+                  share_location_, num_loc_classes_, background_label_id_,
+                  code_type_, variance_encoded_in_target_, clip_bbox,
+                  &all_decode_bboxes);
+
+  int num_kept = 0;
+  vector<map<int, vector<int> > > all_indices;
+  for (int i = 0; i < num; ++i) {
+    const LabelBBox& decode_bboxes = all_decode_bboxes[i];
+    const map<int, vector<float> >& conf_scores = all_conf_scores[i];
+    map<int, vector<int> > indices;
+    int num_det = 0;
+    for (int c = 0; c < num_classes_; ++c) {
+      if (c == background_label_id_) {
+        // Ignore background class.
+        continue;
+      }
+      if (conf_scores.find(c) == conf_scores.end()) {
+        // Something bad happened if there are no predictions for current label.
+        LOG(FATAL) << "Could not find confidence predictions for label " << c;
+      }
+      const vector<float>& scores = conf_scores.find(c)->second;
+      int label = share_location_ ? -1 : c;
+      if (decode_bboxes.find(label) == decode_bboxes.end()) {
+        // Something bad happened if there are no predictions for current label.
+        LOG(FATAL) << "Could not find location predictions for label " << label;
+        continue;
+      }
+      const vector<NormalizedBBox>& bboxes = decode_bboxes.find(label)->second;
+      ApplyNMSFast(bboxes, scores, confidence_threshold_, nms_threshold_, eta_,
+          top_k_, &(indices[c]));
+      num_det += indices[c].size();
+    }
+    if (keep_top_k_ > -1 && num_det > keep_top_k_) {
+      vector<pair<float, pair<int, int> > > score_index_pairs;
+      for (map<int, vector<int> >::iterator it = indices.begin();
+           it != indices.end(); ++it) {
+        int label = it->first;
+        const vector<int>& label_indices = it->second;
+        if (conf_scores.find(label) == conf_scores.end()) {
+          // Something bad happened for current label.
+          LOG(FATAL) << "Could not find location predictions for " << label;
+          continue;
+        }
+        const vector<float>& scores = conf_scores.find(label)->second;
+        for (int j = 0; j < label_indices.size(); ++j) {
+          int idx = label_indices[j];
+          CHECK_LT(idx, scores.size());
+          score_index_pairs.push_back(std::make_pair(
+                  scores[idx], std::make_pair(label, idx)));
+        }
+      }
+      // Keep top k results per image.
+      std::sort(score_index_pairs.begin(), score_index_pairs.end(),
+                SortScorePairDescend<pair<int, int> >);
+      score_index_pairs.resize(keep_top_k_);
+      // Store the new indices.
+      map<int, vector<int> > new_indices;
+      for (int j = 0; j < score_index_pairs.size(); ++j) {
+        int label = score_index_pairs[j].second.first;
+        int idx = score_index_pairs[j].second.second;
+        new_indices[label].push_back(idx);
+      }
+      all_indices.push_back(new_indices);
+      num_kept += keep_top_k_;
+    } else {
+      all_indices.push_back(indices);
+      num_kept += num_det;
+    }
+  }
+
+  vector<int> top_shape(2, 1);
+  top_shape.push_back(num_kept);
+  top_shape.push_back(7);
+  Dtype* top_data;
+  if (num_kept == 0) {
+    LOG(INFO) << "Couldn't find any detections";
+    top_shape[2] = num;
+    top[0]->Reshape(top_shape);
+    top_data = top[0]->mutable_cpu_data<Dtype>();
+    caffe_set(top[0]->count(), static_cast<Dtype>(-1), top_data);
+    // Generate fake results per image.
+    for (int i = 0; i < num; ++i) {
+      top_data[0] = i;
+      top_data += 7;
+    }
+  } else {
+    top[0]->Reshape(top_shape);
+    top_data = top[0]->mutable_cpu_data<Dtype>();
+  }
+
+  int count = 0;
+  boost::filesystem::path output_directory(output_directory_);
+  for (int i = 0; i < num; ++i) {
+    const map<int, vector<float> >& conf_scores = all_conf_scores[i];
+    const LabelBBox& decode_bboxes = all_decode_bboxes[i];
+    for (map<int, vector<int> >::iterator it = all_indices[i].begin();
+         it != all_indices[i].end(); ++it) {
+      int label = it->first;
+      if (conf_scores.find(label) == conf_scores.end()) {
+        // Something bad happened if there are no predictions for current label.
+        LOG(FATAL) << "Could not find confidence predictions for " << label;
+        continue;
+      }
+      const vector<float>& scores = conf_scores.find(label)->second;
+      int loc_label = share_location_ ? -1 : label;
+      if (decode_bboxes.find(loc_label) == decode_bboxes.end()) {
+        // Something bad happened if there are no predictions for current label.
+        LOG(FATAL) << "Could not find location predictions for " << loc_label;
+        continue;
+      }
+      const vector<NormalizedBBox>& bboxes =
+          decode_bboxes.find(loc_label)->second;
+      vector<int>& indices = it->second;
+      if (need_save_) {
+        CHECK(label_to_name_.find(label) != label_to_name_.end())
+          << "Cannot find label: " << label << " in the label map.";
+        CHECK_LT(name_count_, names_.size());
+      }
+      for (int j = 0; j < indices.size(); ++j) {
+        int idx = indices[j];
+        top_data[count * 7] = i;
+        top_data[count * 7 + 1] = label;
+        top_data[count * 7 + 2] = scores[idx];
+        const NormalizedBBox& bbox = bboxes[idx];
+        top_data[count * 7 + 3] = bbox.xmin();
+        top_data[count * 7 + 4] = bbox.ymin();
+        top_data[count * 7 + 5] = bbox.xmax();
+        top_data[count * 7 + 6] = bbox.ymax();
+        if (need_save_) {
+          NormalizedBBox out_bbox;
+          OutputBBox(bbox, sizes_[name_count_], has_resize_, resize_param_,
+                     &out_bbox);
+          float score = top_data[count * 7 + 2];
+          float xmin = out_bbox.xmin();
+          float ymin = out_bbox.ymin();
+          float xmax = out_bbox.xmax();
+          float ymax = out_bbox.ymax();
+          ptree pt_xmin, pt_ymin, pt_width, pt_height;
+          pt_xmin.put<float>("", round(xmin * 100) / 100.);
+          pt_ymin.put<float>("", round(ymin * 100) / 100.);
+          pt_width.put<float>("", round((xmax - xmin) * 100) / 100.);
+          pt_height.put<float>("", round((ymax - ymin) * 100) / 100.);
+
+          ptree cur_bbox;
+          cur_bbox.push_back(std::make_pair("", pt_xmin));
+          cur_bbox.push_back(std::make_pair("", pt_ymin));
+          cur_bbox.push_back(std::make_pair("", pt_width));
+          cur_bbox.push_back(std::make_pair("", pt_height));
+
+          ptree cur_det;
+          cur_det.put("image_id", names_[name_count_]);
+          if (output_format_ == "ILSVRC") {
+            cur_det.put<int>("category_id", label);
+          } else {
+            cur_det.put("category_id", label_to_name_[label].c_str());
+          }
+          cur_det.add_child("bbox", cur_bbox);
+          cur_det.put<float>("score", score);
+
+          detections_.push_back(std::make_pair("", cur_det));
+        }
+        ++count;
+      }
+    }
+    if (need_save_) {
+      ++name_count_;
+      if (name_count_ % num_test_image_ == 0) {
+        if (output_format_ == "VOC") {
+          map<string, std::ofstream*> outfiles;
+          for (int c = 0; c < num_classes_; ++c) {
+            if (c == background_label_id_) {
+              continue;
+            }
+            string label_name = label_to_name_[c];
+            boost::filesystem::path file(
+                output_name_prefix_ + label_name + ".txt");
+            boost::filesystem::path out_file = output_directory / file;
+            outfiles[label_name] = new std::ofstream(out_file.string().c_str(),
+                std::ofstream::out);
+          }
+          BOOST_FOREACH(ptree::value_type &det, detections_.get_child("")) {
+            ptree pt = det.second;
+            string label_name = pt.get<string>("category_id");
+            if (outfiles.find(label_name) == outfiles.end()) {
+              std::cout << "Cannot find " << label_name << std::endl;
+              continue;
+            }
+            string image_name = pt.get<string>("image_id");
+            float score = pt.get<float>("score");
+            vector<int> bbox;
+            BOOST_FOREACH(ptree::value_type &elem, pt.get_child("bbox")) {
+              bbox.push_back(static_cast<int>(elem.second.get_value<float>()));
+            }
+            *(outfiles[label_name]) << image_name;
+            *(outfiles[label_name]) << " " << score;
+            *(outfiles[label_name]) << " " << bbox[0] << " " << bbox[1];
+            *(outfiles[label_name]) << " " << bbox[0] + bbox[2];
+            *(outfiles[label_name]) << " " << bbox[1] + bbox[3];
+            *(outfiles[label_name]) << std::endl;
+          }
+          for (int c = 0; c < num_classes_; ++c) {
+            if (c == background_label_id_) {
+              continue;
+            }
+            string label_name = label_to_name_[c];
+            outfiles[label_name]->flush();
+            outfiles[label_name]->close();
+            delete outfiles[label_name];
+          }
+        } else if (output_format_ == "COCO") {
+          boost::filesystem::path output_directory(output_directory_);
+          boost::filesystem::path file(output_name_prefix_ + ".json");
+          boost::filesystem::path out_file = output_directory / file;
+          std::ofstream outfile;
+          outfile.open(out_file.string().c_str(), std::ofstream::out);
+
+          boost::regex exp("\"(null|true|false|-?[0-9]+(\\.[0-9]+)?)\"");
+          ptree output;
+          output.add_child("detections", detections_);
+          std::stringstream ss;
+#ifdef WITH_JSON          
+          write_json(ss, output);
+#else
+          CHECK(false) << "Json library is not included";
+#endif          
+          std::string rv = boost::regex_replace(ss.str(), exp, "$1");
+          outfile << rv.substr(rv.find("["), rv.rfind("]") - rv.find("["))
+              << std::endl << "]" << std::endl;
+        } else if (output_format_ == "ILSVRC") {
+          boost::filesystem::path output_directory(output_directory_);
+          boost::filesystem::path file(output_name_prefix_ + ".txt");
+          boost::filesystem::path out_file = output_directory / file;
+          std::ofstream outfile;
+          outfile.open(out_file.string().c_str(), std::ofstream::out);
+
+          BOOST_FOREACH(ptree::value_type &det, detections_.get_child("")) {
+            ptree pt = det.second;
+            int label = pt.get<int>("category_id");
+            string image_name = pt.get<string>("image_id");
+            float score = pt.get<float>("score");
+            vector<int> bbox;
+            BOOST_FOREACH(ptree::value_type &elem, pt.get_child("bbox")) {
+              bbox.push_back(static_cast<int>(elem.second.get_value<float>()));
+            }
+            outfile << image_name << " " << label << " " << score;
+            outfile << " " << bbox[0] << " " << bbox[1];
+            outfile << " " << bbox[0] + bbox[2];
+            outfile << " " << bbox[1] + bbox[3];
+            outfile << std::endl;
+          }
+        }
+        name_count_ = 0;
+        detections_.clear();
+      }
+    }
+  }
+  if (visualize_) {
+#ifdef USE_OPENCV
+    vector<cv::Mat> cv_imgs;
+    this->data_transformer_->TransformInv(static_cast<const TBlob<Dtype>*>(bottom[3]), &cv_imgs);
+    vector<cv::Scalar> colors = GetColors(label_to_display_name_.size());
+    VisualizeBBox(cv_imgs, static_cast<TBlob<Dtype>*>(top[0]), visualize_threshold_, colors,
+        label_to_display_name_, save_file_);
+#endif  // USE_OPENCV
+  }
+}
+
+#ifdef CPU_ONLY
+STUB_GPU_FORWARD(DetectionOutputLayer, Forward);
+#endif
+
+INSTANTIATE_CLASS_FB(DetectionOutputLayer);
+REGISTER_LAYER_CLASS(DetectionOutput);
+
+}  // namespace caffe

--- a/src/caffe/layers/detection_output_layer.cu
+++ b/src/caffe/layers/detection_output_layer.cu
@@ -1,0 +1,308 @@
+#ifdef USE_OPENCV
+#include <opencv2/core/core.hpp>
+#include <opencv2/imgproc/imgproc.hpp>
+#endif  // USE_OPENCV
+#include <algorithm>
+#include <fstream>  // NOLINT(readability/streams)
+#include <map>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "boost/filesystem.hpp"
+#include "boost/foreach.hpp"
+
+#include "caffe/layers/detection_output_layer.hpp"
+
+namespace caffe {
+
+template <typename Ftype, typename Btype>
+void DetectionOutputLayer<Ftype,Btype>::Forward_gpu(
+    const vector<Blob*>& bottom, const vector<Blob*>& top) {
+  const Dtype* loc_data = bottom[0]->gpu_data<Dtype>();
+  const Dtype* prior_data = bottom[2]->gpu_data<Dtype>();
+  const int num = bottom[0]->num();
+
+  // Decode predictions.
+  Dtype* bbox_data = bbox_preds_.mutable_gpu_data();
+  const int loc_count = bbox_preds_.count();
+  const bool clip_bbox = false;
+  DecodeBBoxesGPU<Dtype>(loc_count, loc_data, prior_data, code_type_,
+      variance_encoded_in_target_, num_priors_, share_location_,
+      num_loc_classes_, background_label_id_, clip_bbox, bbox_data);
+  // Retrieve all decoded location predictions.
+  const Dtype* bbox_cpu_data;
+  if (!share_location_) {
+    Dtype* bbox_permute_data = bbox_permute_.mutable_gpu_data();
+    PermuteDataGPU<Dtype>(loc_count, bbox_data, num_loc_classes_, num_priors_,
+        4, bbox_permute_data);
+    bbox_cpu_data = bbox_permute_.cpu_data();
+  } else {
+    bbox_cpu_data = bbox_preds_.cpu_data();
+  }
+
+  // Retrieve all confidences.
+  Dtype* conf_permute_data = conf_permute_.mutable_gpu_data();
+  PermuteDataGPU<Dtype>(bottom[1]->count(), bottom[1]->gpu_data<Dtype>(),
+      num_classes_, num_priors_, 1, conf_permute_data);
+  const Dtype* conf_cpu_data = conf_permute_.cpu_data();
+
+  int num_kept = 0;
+  vector<map<int, vector<int> > > all_indices;
+  for (int i = 0; i < num; ++i) {
+    map<int, vector<int> > indices;
+    int num_det = 0;
+    const int conf_idx = i * num_classes_ * num_priors_;
+    int bbox_idx;
+    if (share_location_) {
+      bbox_idx = i * num_priors_ * 4;
+    } else {
+      bbox_idx = conf_idx * 4;
+    }
+    for (int c = 0; c < num_classes_; ++c) {
+      if (c == background_label_id_) {
+        // Ignore background class.
+        continue;
+      }
+      const Dtype* cur_conf_data = conf_cpu_data + conf_idx + c * num_priors_;
+      const Dtype* cur_bbox_data = bbox_cpu_data + bbox_idx;
+      if (!share_location_) {
+        cur_bbox_data += c * num_priors_ * 4;
+      }
+      ApplyNMSFast(cur_bbox_data, cur_conf_data, num_priors_,
+          confidence_threshold_, nms_threshold_, eta_, top_k_, &(indices[c]));
+      num_det += indices[c].size();
+    }
+    if (keep_top_k_ > -1 && num_det > keep_top_k_) {
+      vector<pair<float, pair<int, int> > > score_index_pairs;
+      for (map<int, vector<int> >::iterator it = indices.begin();
+           it != indices.end(); ++it) {
+        int label = it->first;
+        const vector<int>& label_indices = it->second;
+        for (int j = 0; j < label_indices.size(); ++j) {
+          int idx = label_indices[j];
+          float score = conf_cpu_data[conf_idx + label * num_priors_ + idx];
+          score_index_pairs.push_back(std::make_pair(
+                  score, std::make_pair(label, idx)));
+        }
+      }
+      // Keep top k results per image.
+      std::sort(score_index_pairs.begin(), score_index_pairs.end(),
+                SortScorePairDescend<pair<int, int> >);
+      score_index_pairs.resize(keep_top_k_);
+      // Store the new indices.
+      map<int, vector<int> > new_indices;
+      for (int j = 0; j < score_index_pairs.size(); ++j) {
+        int label = score_index_pairs[j].second.first;
+        int idx = score_index_pairs[j].second.second;
+        new_indices[label].push_back(idx);
+      }
+      all_indices.push_back(new_indices);
+      num_kept += keep_top_k_;
+    } else {
+      all_indices.push_back(indices);
+      num_kept += num_det;
+    }
+  }
+
+  vector<int> top_shape(2, 1);
+  top_shape.push_back(num_kept);
+  top_shape.push_back(7);
+  Dtype* top_data;
+  if (num_kept == 0) {
+    LOG(INFO) << "Couldn't find any detections";
+    top_shape[2] = num;
+    top[0]->Reshape(top_shape);
+    top_data = top[0]->mutable_cpu_data<Dtype>();
+    caffe_set<Dtype>(top[0]->count(), -1, top_data);
+    // Generate fake results per image.
+    for (int i = 0; i < num; ++i) {
+      top_data[0] = i;
+      top_data += 7;
+    }
+  } else {
+    top[0]->Reshape(top_shape);
+    top_data = top[0]->mutable_cpu_data<Dtype>();
+  }
+
+  int count = 0;
+  boost::filesystem::path output_directory(output_directory_);
+  for (int i = 0; i < num; ++i) {
+    const int conf_idx = i * num_classes_ * num_priors_;
+    int bbox_idx;
+    if (share_location_) {
+      bbox_idx = i * num_priors_ * 4;
+    } else {
+      bbox_idx = conf_idx * 4;
+    }
+    for (map<int, vector<int> >::iterator it = all_indices[i].begin();
+         it != all_indices[i].end(); ++it) {
+      int label = it->first;
+      vector<int>& indices = it->second;
+      if (need_save_) {
+        CHECK(label_to_name_.find(label) != label_to_name_.end())
+          << "Cannot find label: " << label << " in the label map.";
+        CHECK_LT(name_count_, names_.size());
+      }
+      const Dtype* cur_conf_data =
+        conf_cpu_data + conf_idx + label * num_priors_;
+      const Dtype* cur_bbox_data = bbox_cpu_data + bbox_idx;
+      if (!share_location_) {
+        cur_bbox_data += label * num_priors_ * 4;
+      }
+      for (int j = 0; j < indices.size(); ++j) {
+        int idx = indices[j];
+        top_data[count * 7] = i;
+        top_data[count * 7 + 1] = label;
+        top_data[count * 7 + 2] = cur_conf_data[idx];
+        for (int k = 0; k < 4; ++k) {
+          top_data[count * 7 + 3 + k] = cur_bbox_data[idx * 4 + k];
+        }
+        if (need_save_) {
+          // Generate output bbox.
+          NormalizedBBox bbox;
+          bbox.set_xmin(top_data[count * 7 + 3]);
+          bbox.set_ymin(top_data[count * 7 + 4]);
+          bbox.set_xmax(top_data[count * 7 + 5]);
+          bbox.set_ymax(top_data[count * 7 + 6]);
+          NormalizedBBox out_bbox;
+          OutputBBox(bbox, sizes_[name_count_], has_resize_, resize_param_,
+                     &out_bbox);
+          float score = top_data[count * 7 + 2];
+          float xmin = out_bbox.xmin();
+          float ymin = out_bbox.ymin();
+          float xmax = out_bbox.xmax();
+          float ymax = out_bbox.ymax();
+          ptree pt_xmin, pt_ymin, pt_width, pt_height;
+          pt_xmin.put<float>("", round(xmin * 100) / 100.);
+          pt_ymin.put<float>("", round(ymin * 100) / 100.);
+          pt_width.put<float>("", round((xmax - xmin) * 100) / 100.);
+          pt_height.put<float>("", round((ymax - ymin) * 100) / 100.);
+
+          ptree cur_bbox;
+          cur_bbox.push_back(std::make_pair("", pt_xmin));
+          cur_bbox.push_back(std::make_pair("", pt_ymin));
+          cur_bbox.push_back(std::make_pair("", pt_width));
+          cur_bbox.push_back(std::make_pair("", pt_height));
+
+          ptree cur_det;
+          cur_det.put("image_id", names_[name_count_]);
+          if (output_format_ == "ILSVRC") {
+            cur_det.put<int>("category_id", label);
+          } else {
+            cur_det.put("category_id", label_to_name_[label].c_str());
+          }
+          cur_det.add_child("bbox", cur_bbox);
+          cur_det.put<float>("score", score);
+
+          detections_.push_back(std::make_pair("", cur_det));
+        }
+        ++count;
+      }
+    }
+    if (need_save_) {
+      ++name_count_;
+      if (name_count_ % num_test_image_ == 0) {
+        if (output_format_ == "VOC") {
+          map<string, std::ofstream*> outfiles;
+          for (int c = 0; c < num_classes_; ++c) {
+            if (c == background_label_id_) {
+              continue;
+            }
+            string label_name = label_to_name_[c];
+            boost::filesystem::path file(
+                output_name_prefix_ + label_name + ".txt");
+            boost::filesystem::path out_file = output_directory / file;
+            outfiles[label_name] = new std::ofstream(out_file.string().c_str(),
+                std::ofstream::out);
+          }
+          BOOST_FOREACH(ptree::value_type &det, detections_.get_child("")) {
+            ptree pt = det.second;
+            string label_name = pt.get<string>("category_id");
+            if (outfiles.find(label_name) == outfiles.end()) {
+              std::cout << "Cannot find " << label_name << std::endl;
+              continue;
+            }
+            string image_name = pt.get<string>("image_id");
+            float score = pt.get<float>("score");
+            vector<int> bbox;
+            BOOST_FOREACH(ptree::value_type &elem, pt.get_child("bbox")) {
+              bbox.push_back(static_cast<int>(elem.second.get_value<float>()));
+            }
+            *(outfiles[label_name]) << image_name;
+            *(outfiles[label_name]) << " " << score;
+            *(outfiles[label_name]) << " " << bbox[0] << " " << bbox[1];
+            *(outfiles[label_name]) << " " << bbox[0] + bbox[2];
+            *(outfiles[label_name]) << " " << bbox[1] + bbox[3];
+            *(outfiles[label_name]) << std::endl;
+          }
+          for (int c = 0; c < num_classes_; ++c) {
+            if (c == background_label_id_) {
+              continue;
+            }
+            string label_name = label_to_name_[c];
+            outfiles[label_name]->flush();
+            outfiles[label_name]->close();
+            delete outfiles[label_name];
+          }
+        } else if (output_format_ == "COCO") {
+          boost::filesystem::path output_directory(output_directory_);
+          boost::filesystem::path file(output_name_prefix_ + ".json");
+          boost::filesystem::path out_file = output_directory / file;
+          std::ofstream outfile;
+          outfile.open(out_file.string().c_str(), std::ofstream::out);
+
+          boost::regex exp("\"(null|true|false|-?[0-9]+(\\.[0-9]+)?)\"");
+          ptree output;
+          output.add_child("detections", detections_);
+          std::stringstream ss;
+#ifdef WITH_JSON              
+          write_json(ss, output);
+#else
+          CHECK(false) << "Json library is not included";
+#endif          
+          std::string rv = boost::regex_replace(ss.str(), exp, "$1");
+          outfile << rv.substr(rv.find("["), rv.rfind("]") - rv.find("["))
+              << std::endl << "]" << std::endl;
+        } else if (output_format_ == "ILSVRC") {
+          boost::filesystem::path output_directory(output_directory_);
+          boost::filesystem::path file(output_name_prefix_ + ".txt");
+          boost::filesystem::path out_file = output_directory / file;
+          std::ofstream outfile;
+          outfile.open(out_file.string().c_str(), std::ofstream::out);
+
+          BOOST_FOREACH(ptree::value_type &det, detections_.get_child("")) {
+            ptree pt = det.second;
+            int label = pt.get<int>("category_id");
+            string image_name = pt.get<string>("image_id");
+            float score = pt.get<float>("score");
+            vector<int> bbox;
+            BOOST_FOREACH(ptree::value_type &elem, pt.get_child("bbox")) {
+              bbox.push_back(static_cast<int>(elem.second.get_value<float>()));
+            }
+            outfile << image_name << " " << label << " " << score;
+            outfile << " " << bbox[0] << " " << bbox[1];
+            outfile << " " << bbox[0] + bbox[2];
+            outfile << " " << bbox[1] + bbox[3];
+            outfile << std::endl;
+          }
+        }
+        name_count_ = 0;
+        detections_.clear();
+      }
+    }
+  }
+  if (visualize_) {
+#ifdef USE_OPENCV
+    vector<cv::Mat> cv_imgs;
+    this->data_transformer_->TransformInv(static_cast<TBlob<Dtype>*>(bottom[3]), &cv_imgs);
+    vector<cv::Scalar> colors = GetColors(label_to_display_name_.size());
+    VisualizeBBox(cv_imgs, static_cast<TBlob<Dtype>*>(top[0]), visualize_threshold_, colors,
+        label_to_display_name_, save_file_);
+#endif  // USE_OPENCV
+  }
+}
+
+INSTANTIATE_LAYER_GPU_FUNCS_FB(DetectionOutputLayer);
+
+}  // namespace caffe

--- a/src/caffe/layers/loss_layer.cpp
+++ b/src/caffe/layers/loss_layer.cpp
@@ -22,6 +22,37 @@ void LossLayer<Ftype, Btype>::Reshape(
   top[0]->Reshape(loss_shape);
 }
 
+template <typename Ftype, typename Btype>
+Ftype LossLayer<Ftype,Btype>::GetNormalizer(
+    const LossParameter_NormalizationMode normalization_mode,
+    const int outer_num, const int inner_num, const int valid_count) {
+  Dtype normalizer;
+  switch (normalization_mode) {
+    case LossParameter_NormalizationMode_FULL:
+      normalizer = Dtype(outer_num * inner_num);
+      break;
+    case LossParameter_NormalizationMode_VALID:
+      if (valid_count == -1) {
+        normalizer = Dtype(outer_num * inner_num);
+      } else {
+        normalizer = Dtype(valid_count);
+      }
+      break;
+    case LossParameter_NormalizationMode_BATCH_SIZE:
+      normalizer = Dtype(outer_num);
+      break;
+    case LossParameter_NormalizationMode_NONE:
+      normalizer = Dtype(1);
+      break;
+    default:
+      LOG(FATAL) << "Unknown normalization mode: "
+          << LossParameter_NormalizationMode_Name(normalization_mode);
+  }
+  // Some users will have no labels for some examples in order to 'turn off' a
+  // particular loss in a multi-task setup. The max prevents NaNs in that case.
+  return std::max(Dtype(1.0), normalizer);
+}
+
 INSTANTIATE_CLASS_FB(LossLayer);
 
 }  // namespace caffe

--- a/src/caffe/layers/multibox_loss_layer.cpp
+++ b/src/caffe/layers/multibox_loss_layer.cpp
@@ -1,0 +1,375 @@
+#include <algorithm>
+#include <map>
+#include <utility>
+#include <vector>
+
+#include "caffe/layers/multibox_loss_layer.hpp"
+#include "caffe/util/math_functions.hpp"
+
+namespace caffe {
+
+template <typename Ftype,typename Btype>
+void MultiBoxLossLayer<Ftype,Btype>::LayerSetUp(const vector<Blob*>& bottom,
+      const vector<Blob*>& top) {
+  LossLayer<Ftype,Btype>::LayerSetUp(bottom, top);
+  if (this->layer_param_.propagate_down_size() == 0) {
+    this->layer_param_.add_propagate_down(true);
+    this->layer_param_.add_propagate_down(true);
+    this->layer_param_.add_propagate_down(false);
+    this->layer_param_.add_propagate_down(false);
+  }
+  const MultiBoxLossParameter& multibox_loss_param =
+      this->layer_param_.multibox_loss_param();
+  multibox_loss_param_ = this->layer_param_.multibox_loss_param();
+
+  num_ = bottom[0]->num();
+  num_priors_ = bottom[2]->height() / 4;
+  // Get other parameters.
+  CHECK(multibox_loss_param.has_num_classes()) << "Must provide num_classes.";
+  num_classes_ = multibox_loss_param.num_classes();
+  CHECK_GE(num_classes_, 1) << "num_classes should not be less than 1.";
+  share_location_ = multibox_loss_param.share_location();
+  loc_classes_ = share_location_ ? 1 : num_classes_;
+  background_label_id_ = multibox_loss_param.background_label_id();
+  use_difficult_gt_ = multibox_loss_param.use_difficult_gt();
+  mining_type_ = multibox_loss_param.mining_type();
+  if (multibox_loss_param.has_do_neg_mining()) {
+    LOG(WARNING) << "do_neg_mining is deprecated, use mining_type instead.";
+    do_neg_mining_ = multibox_loss_param.do_neg_mining();
+    CHECK_EQ(do_neg_mining_,
+             mining_type_ != MultiBoxLossParameter_MiningType_NONE);
+  }
+  do_neg_mining_ = mining_type_ != MultiBoxLossParameter_MiningType_NONE;
+
+  if (!this->layer_param_.loss_param().has_normalization() &&
+      this->layer_param_.loss_param().has_normalize()) {
+    normalization_ = this->layer_param_.loss_param().normalize() ?
+                     LossParameter_NormalizationMode_VALID :
+                     LossParameter_NormalizationMode_BATCH_SIZE;
+  } else {
+    normalization_ = this->layer_param_.loss_param().normalization();
+  }
+
+  if (do_neg_mining_) {
+    CHECK(share_location_)
+        << "Currently only support negative mining if share_location is true.";
+  }
+
+  vector<int> loss_shape(1, 1);
+  // Set up localization loss layer.
+  loc_weight_ = multibox_loss_param.loc_weight();
+  loc_loss_type_ = multibox_loss_param.loc_loss_type();
+  // fake shape.
+  vector<int> loc_shape(1, 1);
+  loc_shape.push_back(4);
+  loc_pred_.Reshape(loc_shape);
+  loc_gt_.Reshape(loc_shape);
+  loc_bottom_vec_.push_back(&loc_pred_);
+  loc_bottom_vec_.push_back(&loc_gt_);
+  loc_loss_.Reshape(loss_shape);
+  loc_top_vec_.push_back(&loc_loss_);
+  if (loc_loss_type_ == MultiBoxLossParameter_LocLossType_L2) {
+    LayerParameter layer_param;
+    layer_param.set_name(this->layer_param_.name() + "_l2_loc");
+    layer_param.set_type("EuclideanLoss");
+    layer_param.add_loss_weight(loc_weight_);
+    loc_loss_layer_ = LayerRegistry::CreateLayer(layer_param);
+    loc_loss_layer_->SetUp(loc_bottom_vec_, loc_top_vec_);
+  } else if (loc_loss_type_ == MultiBoxLossParameter_LocLossType_SMOOTH_L1) {
+    LayerParameter layer_param;
+    layer_param.set_name(this->layer_param_.name() + "_smooth_L1_loc");
+    layer_param.set_type("SmoothL1Loss");
+    layer_param.add_loss_weight(loc_weight_);
+    loc_loss_layer_ = LayerRegistry::CreateLayer(layer_param);
+    loc_loss_layer_->SetUp(loc_bottom_vec_, loc_top_vec_);
+  } else {
+    LOG(FATAL) << "Unknown localization loss type.";
+  }
+  // Set up confidence loss layer.
+  conf_loss_type_ = multibox_loss_param.conf_loss_type();
+  conf_bottom_vec_.push_back(&conf_pred_);
+  conf_bottom_vec_.push_back(&conf_gt_);
+  conf_loss_.Reshape(loss_shape);
+  conf_top_vec_.push_back(&conf_loss_);
+  if (conf_loss_type_ == MultiBoxLossParameter_ConfLossType_SOFTMAX) {
+    CHECK_GE(background_label_id_, 0)
+        << "background_label_id should be within [0, num_classes) for Softmax.";
+    CHECK_LT(background_label_id_, num_classes_)
+        << "background_label_id should be within [0, num_classes) for Softmax.";
+    LayerParameter layer_param;
+    layer_param.set_name(this->layer_param_.name() + "_softmax_conf");
+    layer_param.set_type("SoftmaxWithLoss");
+    layer_param.add_loss_weight(Dtype(1.));
+    layer_param.mutable_loss_param()->set_normalization(
+        LossParameter_NormalizationMode_NONE);
+    SoftmaxParameter* softmax_param = layer_param.mutable_softmax_param();
+    softmax_param->set_axis(1);
+    // Fake reshape.
+    vector<int> conf_shape(1, 1);
+    conf_gt_.Reshape(conf_shape);
+    conf_shape.push_back(num_classes_);
+    conf_pred_.Reshape(conf_shape);
+    conf_loss_layer_ = LayerRegistry::CreateLayer(layer_param);
+    conf_loss_layer_->SetUp(conf_bottom_vec_, conf_top_vec_);
+  } else if (conf_loss_type_ == MultiBoxLossParameter_ConfLossType_LOGISTIC) {
+    LayerParameter layer_param;
+    layer_param.set_name(this->layer_param_.name() + "_logistic_conf");
+    layer_param.set_type("SigmoidCrossEntropyLoss");
+    layer_param.add_loss_weight(Dtype(1.));
+    // Fake reshape.
+    vector<int> conf_shape(1, 1);
+    conf_shape.push_back(num_classes_);
+    conf_gt_.Reshape(conf_shape);
+    conf_pred_.Reshape(conf_shape);
+    conf_loss_layer_ = LayerRegistry::CreateLayer(layer_param);
+    conf_loss_layer_->SetUp(conf_bottom_vec_, conf_top_vec_);
+  } else {
+    LOG(FATAL) << "Unknown confidence loss type.";
+  }
+}
+
+template <typename Ftype,typename Btype>
+void MultiBoxLossLayer<Ftype,Btype>::Reshape(const vector<Blob*>& bottom,
+      const vector<Blob*>& top) {
+  LossLayer<Ftype,Btype>::Reshape(bottom, top);
+  num_ = bottom[0]->num();
+  num_priors_ = bottom[2]->height() / 4;
+  num_gt_ = bottom[3]->height();
+  CHECK_EQ(bottom[0]->num(), bottom[1]->num());
+  CHECK_EQ(num_priors_ * loc_classes_ * 4, bottom[0]->channels())
+      << "Number of priors must match number of location predictions.";
+  CHECK_EQ(num_priors_ * num_classes_, bottom[1]->channels())
+      << "Number of priors must match number of confidence predictions.";
+}
+
+template <typename Ftype,typename Btype>
+void MultiBoxLossLayer<Ftype,Btype>::Forward_cpu(const vector<Blob*>& bottom,
+    const vector<Blob*>& top) {
+  const Dtype* loc_data = bottom[0]->cpu_data<Dtype>();
+  const Dtype* conf_data = bottom[1]->cpu_data<Dtype>();
+  const Dtype* prior_data = bottom[2]->cpu_data<Dtype>();
+  const Dtype* gt_data = bottom[3]->cpu_data<Dtype>();
+
+  // Retrieve all ground truth.
+  map<int, vector<NormalizedBBox> > all_gt_bboxes;
+  GetGroundTruth(gt_data, num_gt_, background_label_id_, use_difficult_gt_,
+                 &all_gt_bboxes);
+
+  // Retrieve all prior bboxes. It is same within a batch since we assume all
+  // images in a batch are of same dimension.
+  vector<NormalizedBBox> prior_bboxes;
+  vector<vector<float> > prior_variances;
+  GetPriorBBoxes(prior_data, num_priors_, &prior_bboxes, &prior_variances);
+
+  // Retrieve all predictions.
+  vector<LabelBBox> all_loc_preds;
+  GetLocPredictions(loc_data, num_, num_priors_, loc_classes_, share_location_,
+                    &all_loc_preds);
+
+  // Find matches between source bboxes and ground truth bboxes.
+  vector<map<int, vector<float> > > all_match_overlaps;
+  FindMatches(all_loc_preds, all_gt_bboxes, prior_bboxes, prior_variances,
+              multibox_loss_param_, &all_match_overlaps, &all_match_indices_);
+
+  num_matches_ = 0;
+  int num_negs = 0;
+  // Sample hard negative (and positive) examples based on mining type.
+  MineHardExamples(*static_cast<TBlob<Dtype>*>(bottom[1]), all_loc_preds, all_gt_bboxes, prior_bboxes,
+                   prior_variances, all_match_overlaps, multibox_loss_param_,
+                   &num_matches_, &num_negs, &all_match_indices_,
+                   &all_neg_indices_);
+
+  if (num_matches_ >= 1) {
+    // Form data to pass on to loc_loss_layer_.
+    vector<int> loc_shape(2);
+    loc_shape[0] = 1;
+    loc_shape[1] = num_matches_ * 4;
+    loc_pred_.Reshape(loc_shape);
+    loc_gt_.Reshape(loc_shape);
+    Dtype* loc_pred_data = loc_pred_.mutable_cpu_data();
+    Dtype* loc_gt_data = loc_gt_.mutable_cpu_data();
+    EncodeLocPrediction(all_loc_preds, all_gt_bboxes, all_match_indices_,
+                        prior_bboxes, prior_variances, multibox_loss_param_,
+                        loc_pred_data, loc_gt_data);
+    loc_loss_layer_->Reshape(loc_bottom_vec_, loc_top_vec_);
+    loc_loss_layer_->Forward(loc_bottom_vec_, loc_top_vec_);
+  } else {
+    loc_loss_.mutable_cpu_data()[0] = 0;
+  }
+
+  // Form data to pass on to conf_loss_layer_.
+  if (do_neg_mining_) {
+    num_conf_ = num_matches_ + num_negs;
+  } else {
+    num_conf_ = num_ * num_priors_;
+  }
+  if (num_conf_ >= 1) {
+    // Reshape the confidence data.
+    vector<int> conf_shape;
+    if (conf_loss_type_ == MultiBoxLossParameter_ConfLossType_SOFTMAX) {
+      conf_shape.push_back(num_conf_);
+      conf_gt_.Reshape(conf_shape);
+      conf_shape.push_back(num_classes_);
+      conf_pred_.Reshape(conf_shape);
+    } else if (conf_loss_type_ == MultiBoxLossParameter_ConfLossType_LOGISTIC) {
+      conf_shape.push_back(1);
+      conf_shape.push_back(num_conf_);
+      conf_shape.push_back(num_classes_);
+      conf_gt_.Reshape(conf_shape);
+      conf_pred_.Reshape(conf_shape);
+    } else {
+      LOG(FATAL) << "Unknown confidence loss type.";
+    }
+    if (!do_neg_mining_) {
+      // Consider all scores.
+      // Share data and diff with bottom[1].
+      CHECK_EQ(conf_pred_.count(), bottom[1]->count());
+      conf_pred_.ShareData(*(bottom[1]));
+    }
+    Dtype* conf_pred_data = conf_pred_.mutable_cpu_data();
+    Dtype* conf_gt_data = conf_gt_.mutable_cpu_data();
+    caffe_set(conf_gt_.count(), Dtype(background_label_id_), conf_gt_data);
+    EncodeConfPrediction(conf_data, num_, num_priors_, multibox_loss_param_,
+                         all_match_indices_, all_neg_indices_, all_gt_bboxes,
+                         conf_pred_data, conf_gt_data);
+    conf_loss_layer_->Reshape(conf_bottom_vec_, conf_top_vec_);
+    conf_loss_layer_->Forward(conf_bottom_vec_, conf_top_vec_);
+  } else {
+    conf_loss_.mutable_cpu_data()[0] = 0;
+  }
+
+  top[0]->mutable_cpu_data<Dtype>()[0] = 0;
+  if (this->layer_param_.propagate_down(0)) {
+    Dtype normalizer = LossLayer<Ftype,Btype>::GetNormalizer(
+        normalization_, num_, num_priors_, num_matches_);
+    top[0]->mutable_cpu_data<Dtype>()[0] +=
+        loc_weight_ * loc_loss_.cpu_data()[0] / normalizer;
+  }
+  if (this->layer_param_.propagate_down(1)) {
+    Dtype normalizer = LossLayer<Ftype,Btype>::GetNormalizer(
+        normalization_, num_, num_priors_, num_matches_);
+    top[0]->mutable_cpu_data<Dtype>()[0] += conf_loss_.cpu_data()[0] / normalizer;
+  }
+}
+
+template <typename Ftype,typename Btype>
+void MultiBoxLossLayer<Ftype,Btype>::Backward_cpu(const vector<Blob*>& top,
+    const vector<bool>& propagate_down,
+    const vector<Blob*>& bottom) {
+
+  if (propagate_down[2]) {
+    LOG(FATAL) << this->type()
+        << " Layer cannot backpropagate to prior inputs.";
+  }
+  if (propagate_down[3]) {
+    LOG(FATAL) << this->type()
+        << " Layer cannot backpropagate to label inputs.";
+  }
+
+  // Back propagate on location prediction.
+  if (propagate_down[0]) {
+    Dtype* loc_bottom_diff = bottom[0]->mutable_cpu_diff<Dtype>();
+    caffe_set(bottom[0]->count(), Dtype(0), loc_bottom_diff);
+    if (num_matches_ >= 1) {
+      vector<bool> loc_propagate_down;
+      // Only back propagate on prediction, not ground truth.
+      loc_propagate_down.push_back(true);
+      loc_propagate_down.push_back(false);
+      loc_loss_layer_->Backward(loc_top_vec_, loc_propagate_down,
+                                loc_bottom_vec_);
+      // Scale gradient.
+      Dtype normalizer = LossLayer<Ftype,Btype>::GetNormalizer(
+          normalization_, num_, num_priors_, num_matches_);
+      Dtype loss_weight = top[0]->cpu_diff<Dtype>()[0] / normalizer;
+      caffe_scal(loc_pred_.count(), loss_weight, loc_pred_.mutable_cpu_diff());
+      // Copy gradient back to bottom[0].
+      const Dtype* loc_pred_diff = loc_pred_.cpu_diff();
+      int count = 0;
+      for (int i = 0; i < num_; ++i) {
+        for (map<int, vector<int> >::iterator it =
+             all_match_indices_[i].begin();
+             it != all_match_indices_[i].end(); ++it) {
+          const int label = share_location_ ? 0 : it->first;
+          const vector<int>& match_index = it->second;
+          for (int j = 0; j < match_index.size(); ++j) {
+            if (match_index[j] <= -1) {
+              continue;
+            }
+            // Copy the diff to the right place.
+            int start_idx = loc_classes_ * 4 * j + label * 4;
+            caffe_copy(4, loc_pred_diff + count * 4,
+                              loc_bottom_diff + start_idx);
+            ++count;
+          }
+        }
+        loc_bottom_diff += bottom[0]->offset(1);
+      }
+    }
+  }
+
+  // Back propagate on confidence prediction.
+  if (propagate_down[1]) {
+    Dtype* conf_bottom_diff = bottom[1]->mutable_cpu_diff<Dtype>();
+    caffe_set(bottom[1]->count(), Dtype(0), conf_bottom_diff);
+    if (num_conf_ >= 1) {
+      vector<bool> conf_propagate_down;
+      // Only back propagate on prediction, not ground truth.
+      conf_propagate_down.push_back(true);
+      conf_propagate_down.push_back(false);
+      conf_loss_layer_->Backward(conf_top_vec_, conf_propagate_down,
+                                 conf_bottom_vec_);
+      // Scale gradient.
+      Dtype normalizer = LossLayer<Ftype,Btype>::GetNormalizer(
+          normalization_, num_, num_priors_, num_matches_);
+      Dtype loss_weight = top[0]->cpu_diff<Dtype>()[0] / normalizer;
+      caffe_scal(conf_pred_.count(), loss_weight,
+                 conf_pred_.mutable_cpu_diff());
+      // Copy gradient back to bottom[1].
+      const Dtype* conf_pred_diff = conf_pred_.cpu_diff();
+      if (do_neg_mining_) {
+        int count = 0;
+        for (int i = 0; i < num_; ++i) {
+          // Copy matched (positive) bboxes scores' diff.
+          const map<int, vector<int> >& match_indices = all_match_indices_[i];
+          for (map<int, vector<int> >::const_iterator it =
+               match_indices.begin(); it != match_indices.end(); ++it) {
+            const vector<int>& match_index = it->second;
+            CHECK_EQ(match_index.size(), num_priors_);
+            for (int j = 0; j < num_priors_; ++j) {
+              if (match_index[j] <= -1) {
+                continue;
+              }
+              // Copy the diff to the right place.
+              caffe_copy(num_classes_,
+                                conf_pred_diff + count * num_classes_,
+                                conf_bottom_diff + j * num_classes_);
+              ++count;
+            }
+          }
+          // Copy negative bboxes scores' diff.
+          for (int n = 0; n < all_neg_indices_[i].size(); ++n) {
+            int j = all_neg_indices_[i][n];
+            CHECK_LT(j, num_priors_);
+            caffe_copy(num_classes_,
+                              conf_pred_diff + count * num_classes_,
+                              conf_bottom_diff + j * num_classes_);
+            ++count;
+          }
+          conf_bottom_diff += bottom[1]->offset(1);
+        }
+      } else {
+        // The diff is already computed and stored.
+        bottom[1]->ShareDiff(conf_pred_);
+      }
+    }
+  }
+
+  // After backward, remove match statistics.
+  all_match_indices_.clear();
+  all_neg_indices_.clear();
+}
+
+INSTANTIATE_CLASS_FB(MultiBoxLossLayer);
+REGISTER_LAYER_CLASS(MultiBoxLoss);
+
+}  // namespace caffe

--- a/src/caffe/layers/normalize_layer.cpp
+++ b/src/caffe/layers/normalize_layer.cpp
@@ -1,0 +1,234 @@
+#include <vector>
+
+#include "caffe/filler.hpp"
+#include "caffe/layers/normalize_layer.hpp"
+
+namespace caffe {
+
+template <typename Ftype, typename Btype>
+void NormalizeLayer<Ftype,Btype>::LayerSetUp(const vector<Blob*>& bottom,
+      const vector<Blob*>& top) {
+  CHECK_GE(bottom[0]->num_axes(), 2)
+      << "Number of axes of bottom blob must be >=2.";
+  buffer_.Reshape(1, bottom[0]->channels(),
+                   bottom[0]->height(), bottom[0]->width());
+  buffer_channel_.Reshape(1, bottom[0]->channels(), 1, 1);
+  buffer_spatial_.Reshape(1, 1, bottom[0]->height(), bottom[0]->width());
+  NormalizeParameter norm_param = this->layer_param().norm_param();
+  across_spatial_ = norm_param.across_spatial();
+  if (across_spatial_) {
+    norm_.Reshape(bottom[0]->num(), 1, 1, 1);
+  } else {
+    norm_.Reshape(bottom[0]->num(), 1, bottom[0]->height(), bottom[0]->width());
+  }
+  eps_ = norm_param.eps();
+  int channels = bottom[0]->channels();
+  int spatial_dim = bottom[0]->width() * bottom[0]->height();
+  sum_channel_multiplier_.Reshape(1, channels, 1, 1);
+  caffe_set(channels, Dtype(1), sum_channel_multiplier_.mutable_cpu_data());
+  sum_spatial_multiplier_.Reshape(
+      1, 1, bottom[0]->height(), bottom[0]->width());
+  caffe_set(spatial_dim, Dtype(1), sum_spatial_multiplier_.mutable_cpu_data());
+  channel_shared_ = norm_param.channel_shared();
+  if (this->blobs_.size() > 0) {
+    LOG(INFO) << "Skipping parameter initialization";
+  } else {
+    this->blobs_.resize(1);
+    if (channel_shared_) {
+      this->blobs_[0] = Blob::create<Ftype,Btype>(vector<int>(0));
+    } else {
+      this->blobs_[0] = Blob::create<Ftype,Btype>(vector<int>(1, channels));
+    }
+    shared_ptr<Filler<Dtype> > scale_filler;
+    if (norm_param.has_scale_filler()) {
+      scale_filler.reset(GetFiller<Dtype>(norm_param.scale_filler()));
+    } else {
+      FillerParameter filler_param;
+      filler_param.set_type("constant");
+      filler_param.set_value(1.0);
+      scale_filler.reset(GetFiller<Dtype>(filler_param));
+    }
+    scale_filler->Fill(this->blobs_[0].get());
+  }
+  if (channel_shared_) {
+    CHECK_EQ(this->blobs_[0]->count(), 1)
+        << "Scale size is inconsistent with prototxt config";
+  } else {
+    CHECK_EQ(this->blobs_[0]->count(), channels)
+        << "Scale size is inconsistent with prototxt config";
+  }
+  this->param_propagate_down_.resize(this->blobs_.size(), true);
+}
+
+template <typename Ftype, typename Btype>
+void NormalizeLayer<Ftype,Btype>::Reshape(const vector<Blob*>& bottom,
+      const vector<Blob*>& top) {
+  CHECK_GE(bottom[0]->num_axes(), 2)
+      << "Number of axes of bottom blob must be >=2.";
+  top[0]->ReshapeLike(*bottom[0]);
+  buffer_.Reshape(1, bottom[0]->channels(),
+                   bottom[0]->height(), bottom[0]->width());
+  if (!across_spatial_) {
+    norm_.Reshape(bottom[0]->num(), 1, bottom[0]->height(), bottom[0]->width());
+  }
+  int spatial_dim = bottom[0]->height() * bottom[0]->width();
+  if (spatial_dim != sum_spatial_multiplier_.count()) {
+    sum_spatial_multiplier_.Reshape(
+        1, 1, bottom[0]->height(), bottom[0]->width());
+    caffe_set(spatial_dim, Dtype(1),
+              sum_spatial_multiplier_.mutable_cpu_data());
+    buffer_spatial_.Reshape(1, 1, bottom[0]->height(), bottom[0]->width());
+  }
+}
+
+template <typename Ftype, typename Btype>
+void NormalizeLayer<Ftype,Btype>::Forward_cpu(const vector<Blob*>& bottom,
+    const vector<Blob*>& top) {
+  const Dtype* bottom_data = bottom[0]->cpu_data<Dtype>();
+  Dtype* top_data = top[0]->mutable_cpu_data<Dtype>();
+  const Dtype* scale = this->blobs_[0]->template cpu_data<Dtype>();
+  Dtype* buffer_data = buffer_.mutable_cpu_data();
+  Dtype* norm_data = norm_.mutable_cpu_data();
+  // add eps to avoid overflow
+  caffe_set(norm_.count(), Dtype(eps_), norm_data);
+  const Dtype* sum_channel_multiplier = sum_channel_multiplier_.cpu_data();
+  const Dtype* sum_spatial_multiplier = sum_spatial_multiplier_.cpu_data();
+  int num = bottom[0]->num();
+  int dim = bottom[0]->count() / num;
+  int spatial_dim = bottom[0]->height() * bottom[0]->width();
+  int channels = bottom[0]->channels();
+  for (int n = 0; n < num; ++n) {
+    caffe_sqr<Dtype>(dim, bottom_data, buffer_data);
+    if (across_spatial_) {
+      // add eps to avoid overflow
+      norm_data[n] = pow(Dtype(caffe_cpu_asum(dim, buffer_data)+eps_),
+                         Dtype(0.5));
+      caffe_cpu_scale<Dtype>(dim, Dtype(1.0 / norm_data[n]), bottom_data,
+                             top_data);
+    } else {
+      caffe_cpu_gemv<Dtype>(CblasTrans, channels, spatial_dim, Dtype(1),
+                            buffer_data, sum_channel_multiplier, Dtype(1),
+                            norm_data);
+      // compute norm
+      caffe_powx(spatial_dim, norm_data, Dtype(0.5), norm_data);
+      // scale the layer
+      caffe_cpu_gemm(CblasNoTrans, CblasNoTrans, channels, spatial_dim,
+                            1, Dtype(1), sum_channel_multiplier, norm_data,
+                            Dtype(0), buffer_data);
+      caffe_div(dim, bottom_data, buffer_data, top_data);
+      norm_data += spatial_dim;
+    }
+    // scale the output
+    if (channel_shared_) {
+      caffe_scal(dim, scale[0], top_data);
+    } else {
+      caffe_cpu_gemm(CblasNoTrans, CblasNoTrans, channels, spatial_dim,
+                            1, Dtype(1), scale, sum_spatial_multiplier,
+                            Dtype(0),
+                            buffer_data);
+      caffe_mul<Dtype>(dim, top_data, buffer_data, top_data);
+    }
+    bottom_data += dim;
+    top_data += dim;
+  }
+}
+
+template <typename Ftype, typename Btype>
+void NormalizeLayer<Ftype,Btype>::Backward_cpu(const vector<Blob*>& top,
+    const vector<bool>& propagate_down, const vector<Blob*>& bottom) {
+  const Dtype* top_diff = top[0]->cpu_diff<Dtype>();
+  const Dtype* top_data = top[0]->cpu_data<Dtype>();
+  const Dtype* bottom_data = bottom[0]->cpu_data<Dtype>();
+  Dtype* bottom_diff = bottom[0]->mutable_cpu_diff<Dtype>();
+  const Dtype* scale = this->blobs_[0]->template cpu_data<Dtype>();
+  const Dtype* norm_data = norm_.cpu_data();
+  Dtype* buffer_data = buffer_.mutable_cpu_data();
+  Dtype* buffer_channel = buffer_channel_.mutable_cpu_data();
+  Dtype* buffer_spatial = buffer_spatial_.mutable_cpu_data();
+  const Dtype* sum_channel_multiplier = sum_channel_multiplier_.cpu_data();
+  const Dtype* sum_spatial_multiplier = sum_spatial_multiplier_.cpu_data();
+  int count = top[0]->count();
+  int num = top[0]->num();
+  int dim = count / num;
+  int spatial_dim = top[0]->height() * top[0]->width();
+  int channels = top[0]->channels();
+
+  // Propagate to param
+  if (this->param_propagate_down_[0]) {
+    Dtype* scale_diff = this->blobs_[0]->template mutable_cpu_diff<Dtype>();
+    if (channel_shared_) {
+      scale_diff[0] +=
+          caffe_cpu_dot(count, top_data, top_diff) / scale[0];
+    } else {
+      for (int n = 0; n < num; ++n) {
+        caffe_mul(dim, top_data+n*dim, top_diff+n*dim, buffer_data);
+        caffe_cpu_gemv(CblasNoTrans, channels, spatial_dim, Dtype(1),
+                              buffer_data, sum_spatial_multiplier, Dtype(0),
+                              buffer_channel);
+        // store a / scale[i] in buffer_data temporary
+        caffe_div(channels, buffer_channel, scale, buffer_channel);
+        caffe_add(channels, buffer_channel, scale_diff, scale_diff);
+      }
+    }
+  }
+
+  // Propagate to bottom
+  if (propagate_down[0]) {
+    for (int n = 0; n < num; ++n) {
+      if (across_spatial_) {
+        Dtype a = caffe_cpu_dot(dim, bottom_data, top_diff);
+        caffe_cpu_scale(dim, Dtype(a / norm_data[n] / norm_data[n]),
+                               bottom_data, bottom_diff);
+        caffe_sub(dim, top_diff, bottom_diff, bottom_diff);
+        caffe_scal(dim, Dtype(1.0 / norm_data[n]), bottom_diff);
+      } else {
+        // dot product between bottom_data and top_diff
+        caffe_mul(dim, bottom_data, top_diff, buffer_data);
+        caffe_cpu_gemv(CblasTrans, channels, spatial_dim, Dtype(1),
+                              buffer_data, sum_channel_multiplier, Dtype(0),
+                              buffer_spatial);
+        // scale bottom_diff
+        caffe_cpu_gemm(CblasNoTrans, CblasNoTrans, channels, spatial_dim,
+                              1, Dtype(1), sum_channel_multiplier,
+                              buffer_spatial, Dtype(0), buffer_data);
+        caffe_mul(dim, bottom_data, buffer_data, bottom_diff);
+        // divide by square of norm
+        caffe_powx(spatial_dim, norm_data, Dtype(2), buffer_spatial);
+        caffe_cpu_gemm(CblasNoTrans, CblasNoTrans, channels, spatial_dim,
+                              1, Dtype(1), sum_channel_multiplier,
+                              buffer_spatial, Dtype(0), buffer_data);
+        caffe_div(dim, bottom_diff, buffer_data, bottom_diff);
+        // subtract
+        caffe_sub(dim, top_diff, bottom_diff, bottom_diff);
+        // divide by norm
+        caffe_cpu_gemm(CblasNoTrans, CblasNoTrans, channels, spatial_dim,
+                              1, Dtype(1), sum_channel_multiplier, norm_data,
+                              Dtype(0), buffer_data);
+        caffe_div(dim, bottom_diff, buffer_data, bottom_diff);
+        norm_data += spatial_dim;
+      }
+      // scale the diff
+      if (channel_shared_) {
+        caffe_scal(dim, scale[0], bottom_diff);
+      } else {
+        caffe_cpu_gemm(CblasNoTrans, CblasNoTrans, channels, spatial_dim,
+                              1, Dtype(1), scale, sum_spatial_multiplier,
+                              Dtype(0), buffer_data);
+        caffe_mul(dim, bottom_diff, buffer_data, bottom_diff);
+      }
+      bottom_data += dim;
+      top_diff += dim;
+      bottom_diff += dim;
+    }
+  }
+}
+
+
+#ifdef CPU_ONLY
+STUB_GPU(NormalizeLayer);
+#endif
+
+INSTANTIATE_CLASS_FB(NormalizeLayer);
+REGISTER_LAYER_CLASS(Normalize);
+
+}  // namespace caffe

--- a/src/caffe/layers/normalize_layer.cu
+++ b/src/caffe/layers/normalize_layer.cu
@@ -1,0 +1,220 @@
+#include <algorithm>
+#include <cfloat>
+#include <vector>
+
+#include "thrust/device_vector.h"
+
+#include "caffe/filler.hpp"
+#include "caffe/layers/normalize_layer.hpp"
+#include "caffe/util/math_functions.hpp"
+
+namespace caffe {
+
+// divid a matrix with vector
+template <typename Dtype>
+__global__ void DivBsx(const int nthreads, const Dtype* A,
+    const Dtype* v, const int rows, const int cols, const CBLAS_TRANSPOSE trans,
+    Dtype* B) {
+  CUDA_KERNEL_LOOP(index, nthreads) {
+    int c = index % cols;
+    int r = (index / cols) % rows;
+    if (trans == CblasNoTrans) {
+      B[index] = A[index] / v[c];
+    } else {
+      B[index] = A[index] / v[r];
+    }
+  }
+}
+
+template <typename Dtype>
+__global__ void MulBsx(const int nthreads, const Dtype* A,
+    const Dtype* v, const int rows, const int cols, const CBLAS_TRANSPOSE trans,
+    Dtype* B) {
+  CUDA_KERNEL_LOOP(index, nthreads) {
+    int c = index % cols;
+    int r = (index / cols) % rows;
+    if (trans == CblasNoTrans) {
+      B[index] = A[index] * v[c];
+    } else {
+      B[index] = A[index] * v[r];
+    }
+  }
+}
+
+template <typename Ftype, typename Btype>
+void NormalizeLayer<Ftype,Btype>::Forward_gpu(const vector<Blob*>& bottom,
+    const vector<Blob*>& top) {
+  const Dtype* bottom_data = bottom[0]->gpu_data<Dtype>();
+  Dtype* top_data = top[0]->mutable_gpu_data<Dtype>();
+  Dtype* buffer_data = buffer_.mutable_gpu_data();
+  Dtype* norm_data;
+  if (across_spatial_) {
+    // need to index it
+    norm_data = norm_.mutable_cpu_data();
+  } else {
+    norm_data = norm_.mutable_gpu_data();
+    // add eps to avoid overflow
+    caffe_gpu_set<Dtype>(norm_.count(), Dtype(eps_), norm_data);
+  }
+  const Dtype* scale;
+  if (channel_shared_) {
+    scale = this->blobs_[0]->template cpu_data<Dtype>();
+  } else {
+    scale = this->blobs_[0]->template gpu_data<Dtype>();
+  }
+  const Dtype* sum_channel_multiplier = sum_channel_multiplier_.gpu_data();
+  int num = bottom[0]->num();
+  int dim = bottom[0]->count() / num;
+  int spatial_dim = bottom[0]->height() * bottom[0]->width();
+  int channels = bottom[0]->channels();
+  for (int n = 0; n < num; ++n) {
+    caffe_gpu_powx<Dtype>(dim, bottom_data, Dtype(2), buffer_data);
+    if (across_spatial_) {
+      Dtype normsqr;
+      caffe_gpu_asum<Dtype>(dim, buffer_data, &normsqr);
+      // add eps to avoid overflow
+      norm_data[n] = pow(normsqr+eps_, Dtype(0.5));
+      caffe_gpu_scale<Dtype>(dim, Dtype(1.0 / norm_data[n]), bottom_data,
+                             top_data);
+    } else {
+      // compute norm
+      caffe_gpu_gemv<Dtype>(CblasTrans, channels, spatial_dim, Dtype(1),
+                            buffer_data, sum_channel_multiplier, Dtype(1),
+                            norm_data);
+      caffe_gpu_powx<Dtype>(spatial_dim, norm_data, Dtype(0.5), norm_data);
+      // scale the layer
+      // NOLINT_NEXT_LINE(whitespace/operators)
+      DivBsx<Dtype> <<<CAFFE_GET_BLOCKS(dim), CAFFE_CUDA_NUM_THREADS>>>(
+          dim, bottom_data, norm_data, channels, spatial_dim, CblasNoTrans,
+          top_data);
+      CUDA_POST_KERNEL_CHECK;
+      norm_data += spatial_dim;
+    }
+    // scale the output
+    if (channel_shared_) {
+      caffe_gpu_scal<Dtype>(dim, scale[0], top_data);
+    } else {
+      // NOLINT_NEXT_LINE(whitespace/operators)
+      MulBsx<Dtype> <<<CAFFE_GET_BLOCKS(dim), CAFFE_CUDA_NUM_THREADS>>>(
+          dim, top_data, scale, channels, spatial_dim, CblasTrans,
+          top_data);
+      CUDA_POST_KERNEL_CHECK;
+    }
+    bottom_data += dim;
+    top_data += dim;
+  }
+}
+
+template <typename Ftype, typename Btype>
+void NormalizeLayer<Ftype,Btype>::Backward_gpu(const vector<Blob*>& top,
+    const vector<bool>& propagate_down, const vector<Blob*>& bottom) {
+  const Dtype* top_diff = top[0]->gpu_diff<Dtype>();
+  const Dtype* top_data = top[0]->gpu_data<Dtype>();
+  const Dtype* bottom_data = bottom[0]->mutable_gpu_data<Dtype>();
+  Dtype* bottom_diff = bottom[0]->mutable_gpu_diff<Dtype>();
+  const Dtype* norm_data;
+  if (across_spatial_) {
+    // need to index it
+    norm_data = norm_.cpu_data();
+  } else {
+    norm_data = norm_.gpu_data();
+  }
+  const Dtype* scale;
+  if (channel_shared_) {
+    scale = this->blobs_[0]->template cpu_data<Dtype>();
+  } else {
+    scale = this->blobs_[0]->template gpu_data<Dtype>();
+  }
+  Dtype* buffer_data = buffer_.mutable_gpu_data();
+  Dtype* buffer_channel = buffer_channel_.mutable_gpu_data();
+  Dtype* buffer_spatial = buffer_spatial_.mutable_gpu_data();
+  const Dtype* sum_channel_multiplier = sum_channel_multiplier_.gpu_data();
+  const Dtype* sum_spatial_multiplier = sum_spatial_multiplier_.gpu_data();
+  int count = top[0]->count();
+  int num = top[0]->num();
+  int dim = count / num;
+  int spatial_dim = top[0]->height() * top[0]->width();
+  int channels = top[0]->channels();
+
+  // Propagate to param
+  if (this->param_propagate_down_[0]) {
+    if (channel_shared_) {
+      Dtype* scale_diff = this->blobs_[0]->template mutable_cpu_diff<Dtype>();
+      Dtype a;
+      caffe_gpu_dot<Dtype>(count, top_data, top_diff, &a);
+      scale_diff[0] += a / scale[0];
+    } else {
+      Dtype* scale_diff = this->blobs_[0]->template mutable_gpu_diff<Dtype>();
+      for (int n = 0; n < num; ++n) {
+        // compute a
+        caffe_gpu_mul<Dtype>(dim, top_data+n*dim, top_diff+n*dim, buffer_data);
+        caffe_gpu_gemv<Dtype>(CblasNoTrans, channels, spatial_dim, Dtype(1),
+                              buffer_data, sum_spatial_multiplier, Dtype(0),
+                              buffer_channel);
+        // store a / scale[i] in buffer_data temporary
+        caffe_gpu_div<Dtype>(channels, buffer_channel, scale, buffer_channel);
+        caffe_gpu_add<Dtype>(channels, buffer_channel, scale_diff, scale_diff);
+      }
+    }
+  }
+
+  // Propagate to bottom
+  if (propagate_down[0]) {
+    for (int n = 0; n < num; ++n) {
+      if (across_spatial_) {
+        Dtype a;
+        caffe_gpu_dot(dim, bottom_data, top_diff, &a);
+        caffe_gpu_scale(dim, Dtype(a / norm_data[n] / norm_data[n]),
+                               bottom_data, bottom_diff);
+        caffe_gpu_sub(dim, top_diff, bottom_diff, bottom_diff);
+        caffe_gpu_scale(dim, Dtype(1.0 / norm_data[n]), bottom_diff,
+                               bottom_diff);
+      } else {
+        // dot product between bottom_data and top_diff
+        caffe_gpu_mul(dim, bottom_data, top_diff, buffer_data);
+        caffe_gpu_gemv(CblasTrans, channels, spatial_dim, Dtype(1),
+                              buffer_data, sum_channel_multiplier, Dtype(0),
+                              buffer_spatial);
+        // scale botom_diff
+        // NOLINT_NEXT_LINE(whitespace/operators)
+        MulBsx<Dtype> <<<CAFFE_GET_BLOCKS(dim), CAFFE_CUDA_NUM_THREADS>>>(
+            dim, bottom_data, buffer_spatial, channels, spatial_dim,
+            CblasNoTrans, bottom_diff);
+        CUDA_POST_KERNEL_CHECK;
+        // divide by square of norm
+        caffe_gpu_powx(spatial_dim, norm_data, Dtype(2), buffer_spatial);
+        // NOLINT_NEXT_LINE(whitespace/operators)
+        DivBsx<Dtype> <<<CAFFE_GET_BLOCKS(dim), CAFFE_CUDA_NUM_THREADS>>>(
+            dim, bottom_diff, buffer_spatial, channels, spatial_dim,
+            CblasNoTrans, bottom_diff);
+        CUDA_POST_KERNEL_CHECK;
+        caffe_gpu_sub(dim, top_diff, bottom_diff, bottom_diff);
+        // divide by norm
+        // NOLINT_NEXT_LINE(whitespace/operators)
+        DivBsx<Dtype> <<<CAFFE_GET_BLOCKS(dim), CAFFE_CUDA_NUM_THREADS>>>(
+            dim, bottom_diff, norm_data, channels, spatial_dim, CblasNoTrans,
+            bottom_diff);
+        CUDA_POST_KERNEL_CHECK;
+        norm_data += spatial_dim;
+      }
+      // scale the diff
+      if (channel_shared_) {
+        caffe_gpu_scal(dim, scale[0], bottom_diff);
+      } else {
+        // NOLINT_NEXT_LINE(whitespace/operators)
+        MulBsx<Dtype> <<<CAFFE_GET_BLOCKS(dim), CAFFE_CUDA_NUM_THREADS>>>(
+            dim, bottom_diff, scale, channels, spatial_dim, CblasTrans,
+            bottom_diff);
+        CUDA_POST_KERNEL_CHECK;
+      }
+      bottom_data += dim;
+      top_diff += dim;
+      bottom_diff += dim;
+    }
+  }
+}
+
+INSTANTIATE_LAYER_GPU_FUNCS_FB(NormalizeLayer);
+
+
+}  // namespace caffe

--- a/src/caffe/layers/permute_layer.cpp
+++ b/src/caffe/layers/permute_layer.cpp
@@ -1,0 +1,143 @@
+#include <vector>
+
+#include "caffe/layers/permute_layer.hpp"
+#include "caffe/util/math_functions.hpp"
+
+namespace caffe {
+
+template <typename Dtype>
+void Permute(const int count, Dtype* bottom_data, const bool forward,
+    const int* permute_order, const int* old_steps, const int* new_steps,
+    const int num_axes, Dtype* top_data) {
+    for (int i = 0; i < count; ++i) {
+      int old_idx = 0;
+      int idx = i;
+      for (int j = 0; j < num_axes; ++j) {
+        int order = permute_order[j];
+        old_idx += (idx / new_steps[j]) * old_steps[order];
+        idx %= new_steps[j];
+      }
+      if (forward) {
+        top_data[i] = bottom_data[old_idx];
+      } else {
+        bottom_data[old_idx] = top_data[i];
+      }
+    }
+}
+
+
+template <typename Ftype, typename Btype>
+void PermuteLayer<Ftype,Btype>::LayerSetUp(const vector<Blob*>& bottom,
+      const vector<Blob*>& top) {
+  PermuteParameter permute_param = this->layer_param_.permute_param();
+  CHECK_EQ(bottom.size(), 1);
+  num_axes_ = bottom[0]->num_axes();
+  vector<int> orders;
+  // Push the specified new orders.
+  for (int i = 0; i < permute_param.order_size(); ++i) {
+    int order = permute_param.order(i);
+    CHECK_LT(order, num_axes_)
+        << "order should be less than the input dimension.";
+    if (std::find(orders.begin(), orders.end(), order) != orders.end()) {
+      LOG(FATAL) << "there are duplicate orders";
+    }
+    orders.push_back(order);
+  }
+  // Push the rest orders. And save original step sizes for each axis.
+  for (int i = 0; i < num_axes_; ++i) {
+    if (std::find(orders.begin(), orders.end(), i) == orders.end()) {
+      orders.push_back(i);
+    }
+  }
+  CHECK_EQ(num_axes_, orders.size());
+  // Check if we need to reorder the data or keep it.
+  need_permute_ = false;
+  for (int i = 0; i < num_axes_; ++i) {
+    if (orders[i] != i) {
+      // As long as there is one order which is different from the natural order
+      // of the data, we need to permute. Otherwise, we share the data and diff.
+      need_permute_ = true;
+      break;
+    }
+  }
+
+  vector<int> top_shape(num_axes_, 1);
+  permute_order_.Reshape(num_axes_, 1, 1, 1);
+  old_steps_.Reshape(num_axes_, 1, 1, 1);
+  new_steps_.Reshape(num_axes_, 1, 1, 1);
+  for (int i = 0; i < num_axes_; ++i) {
+    permute_order_.mutable_cpu_data()[i] = orders[i];
+    top_shape[i] = bottom[0]->shape(orders[i]);
+  }
+  top[0]->Reshape(top_shape);
+}
+
+template <typename Ftype, typename Btype>
+void PermuteLayer<Ftype,Btype>::Reshape(const vector<Blob*>& bottom,
+      const vector<Blob*>& top) {
+  vector<int> top_shape;
+  for (int i = 0; i < num_axes_; ++i) {
+    if (i == num_axes_ - 1) {
+      old_steps_.mutable_cpu_data()[i] = 1;
+    } else {
+      old_steps_.mutable_cpu_data()[i] = bottom[0]->count(i + 1);
+    }
+    top_shape.push_back(bottom[0]->shape(permute_order_.cpu_data()[i]));
+  }
+  top[0]->Reshape(top_shape);
+
+  for (int i = 0; i < num_axes_; ++i) {
+    if (i == num_axes_ - 1) {
+      new_steps_.mutable_cpu_data()[i] = 1;
+    } else {
+      new_steps_.mutable_cpu_data()[i] = top[0]->count(i + 1);
+    }
+  }
+}
+
+template <typename Ftype, typename Btype>
+void PermuteLayer<Ftype,Btype>::Forward_cpu(const vector<Blob*>& bottom,
+      const vector<Blob*>& top) {
+  if (need_permute_) {
+    Dtype* bottom_data = bottom[0]->mutable_cpu_data<Dtype>();
+    Dtype* top_data = top[0]->mutable_cpu_data<Dtype>();
+    const int top_count = top[0]->count();
+    const int* permute_order = permute_order_.cpu_data();
+    const int* old_steps = old_steps_.cpu_data();
+    const int* new_steps = new_steps_.cpu_data();
+    bool forward = true;
+    Permute(top_count, bottom_data, forward, permute_order, old_steps,
+            new_steps, num_axes_, top_data);
+  } else {
+    // If there is no need to permute, we share data to save memory.
+    top[0]->ShareData(*bottom[0]);
+  }
+}
+
+template <typename Ftype, typename Btype>
+void PermuteLayer<Ftype,Btype>::Backward_cpu(const vector<Blob*>& top,
+      const vector<bool>& propagate_down, const vector<Blob*>& bottom) {
+  if (need_permute_) {
+    Dtype* top_diff = top[0]->mutable_cpu_diff<Dtype>();
+    Dtype* bottom_diff = bottom[0]->mutable_cpu_diff<Dtype>();
+    const int top_count = top[0]->count();
+    const int* permute_order = permute_order_.cpu_data();
+    const int* old_steps = old_steps_.cpu_data();
+    const int* new_steps = new_steps_.cpu_data();
+    bool forward = false;
+    Permute(top_count, bottom_diff, forward, permute_order, old_steps,
+            new_steps, num_axes_, top_diff);
+  } else {
+    // If there is no need to permute, we share diff to save memory.
+    bottom[0]->ShareDiff(*top[0]);
+  }
+}
+
+#ifdef CPU_ONLY
+STUB_GPU(PermuteLayer);
+#endif
+
+INSTANTIATE_CLASS_FB(PermuteLayer);
+REGISTER_LAYER_CLASS(Permute);
+
+}  // namespace caffe

--- a/src/caffe/layers/permute_layer.cu
+++ b/src/caffe/layers/permute_layer.cu
@@ -1,0 +1,78 @@
+#include <algorithm>
+#include <cfloat>
+#include <vector>
+
+#include "caffe/layers/permute_layer.hpp"
+#include "caffe/util/math_functions.hpp"
+
+namespace caffe {
+
+template <typename Dtype>
+__global__ void PermuteKernel(const int nthreads,
+    Dtype* const bottom_data, const bool forward, const int* permute_order,
+    const int* old_steps, const int* new_steps, const int num_axes,
+    Dtype* const top_data) {
+  CUDA_KERNEL_LOOP(index, nthreads) {
+    int temp_idx = index;
+    int old_idx = 0;
+    for (int i = 0; i < num_axes; ++i) {
+      int order = permute_order[i];
+      old_idx += (temp_idx / new_steps[i]) * old_steps[order];
+      temp_idx %= new_steps[i];
+    }
+    if (forward) {
+      top_data[index] = bottom_data[old_idx];
+    } else {
+      bottom_data[old_idx] = top_data[index];
+    }
+  }
+}
+
+template <typename Ftype, typename Btype>
+void PermuteLayer<Ftype,Btype>::Forward_gpu(const vector<Blob*>& bottom,
+      const vector<Blob*>& top) {
+  if (need_permute_) {
+    Dtype* bottom_data = bottom[0]->mutable_gpu_data<Dtype>();
+    Dtype* top_data = top[0]->mutable_gpu_data<Dtype>();
+    int count = top[0]->count();
+    const int* permute_order = permute_order_.gpu_data();
+    const int* new_steps = new_steps_.gpu_data();
+    const int* old_steps = old_steps_.gpu_data();
+    bool foward = true;
+    // NOLINT_NEXT_LINE(whitespace/operators)
+    PermuteKernel<Dtype><<<CAFFE_GET_BLOCKS(count), CAFFE_CUDA_NUM_THREADS>>>(
+        count, bottom_data, foward, permute_order, old_steps, new_steps,
+        num_axes_, top_data);
+    CUDA_POST_KERNEL_CHECK;
+  } else {
+    // If there is no need to permute, we share data to save memory.
+    top[0]->ShareData(*bottom[0]);
+  }
+}
+
+
+template <typename Ftype, typename Btype>
+void PermuteLayer<Ftype,Btype>::Backward_gpu(const vector<Blob*>& top,
+      const vector<bool>& propagate_down, const vector<Blob*>& bottom) {
+  if (need_permute_) {
+    Dtype* top_diff = top[0]->mutable_gpu_diff<Dtype>();
+    Dtype* bottom_diff = bottom[0]->mutable_gpu_diff<Dtype>();
+    const int count = bottom[0]->count();
+    const int* permute_order = permute_order_.gpu_data();
+    const int* new_steps = new_steps_.gpu_data();
+    const int* old_steps = old_steps_.gpu_data();
+    bool foward = false;
+    // NOLINT_NEXT_LINE(whitespace/operators)
+    PermuteKernel<Dtype><<<CAFFE_GET_BLOCKS(count), CAFFE_CUDA_NUM_THREADS>>>(
+        count, bottom_diff, foward, permute_order, old_steps, new_steps,
+        num_axes_, top_diff);
+    CUDA_POST_KERNEL_CHECK;
+  } else {
+    // If there is no need to permute, we share diff to save memory.
+    bottom[0]->ShareDiff(*top[0]);
+  }
+}
+
+INSTANTIATE_LAYER_GPU_FUNCS_FB(PermuteLayer);
+
+}  // namespace caffe

--- a/src/caffe/layers/prior_box_layer.cpp
+++ b/src/caffe/layers/prior_box_layer.cpp
@@ -1,0 +1,224 @@
+#include <algorithm>
+#include <functional>
+#include <utility>
+#include <vector>
+
+#include "caffe/layers/prior_box_layer.hpp"
+
+namespace caffe {
+
+template <typename Ftype, typename Btype>
+void PriorBoxLayer<Ftype,Btype>::LayerSetUp(const vector<Blob*>& bottom,
+      const vector<Blob*>& top) {
+  const PriorBoxParameter& prior_box_param =
+      this->layer_param_.prior_box_param();
+  CHECK_GT(prior_box_param.min_size_size(), 0) << "must provide min_size.";
+  for (int i = 0; i < prior_box_param.min_size_size(); ++i) {
+    min_sizes_.push_back(prior_box_param.min_size(i));
+    CHECK_GT(min_sizes_.back(), 0) << "min_size must be positive.";
+  }
+  aspect_ratios_.clear();
+  aspect_ratios_.push_back(1.);
+  flip_ = prior_box_param.flip();
+  for (int i = 0; i < prior_box_param.aspect_ratio_size(); ++i) {
+    float ar = prior_box_param.aspect_ratio(i);
+    bool already_exist = false;
+    for (int j = 0; j < aspect_ratios_.size(); ++j) {
+      if (fabs(ar - aspect_ratios_[j]) < 1e-6) {
+        already_exist = true;
+        break;
+      }
+    }
+    if (!already_exist) {
+      aspect_ratios_.push_back(ar);
+      if (flip_) {
+        aspect_ratios_.push_back(1./ar);
+      }
+    }
+  }
+  num_priors_ = aspect_ratios_.size() * min_sizes_.size();
+  if (prior_box_param.max_size_size() > 0) {
+    CHECK_EQ(prior_box_param.min_size_size(), prior_box_param.max_size_size());
+    for (int i = 0; i < prior_box_param.max_size_size(); ++i) {
+      max_sizes_.push_back(prior_box_param.max_size(i));
+      CHECK_GT(max_sizes_[i], min_sizes_[i])
+          << "max_size must be greater than min_size.";
+      num_priors_ += 1;
+    }
+  }
+  clip_ = prior_box_param.clip();
+  if (prior_box_param.variance_size() > 1) {
+    // Must and only provide 4 variance.
+    CHECK_EQ(prior_box_param.variance_size(), 4);
+    for (int i = 0; i < prior_box_param.variance_size(); ++i) {
+      CHECK_GT(prior_box_param.variance(i), 0);
+      variance_.push_back(prior_box_param.variance(i));
+    }
+  } else if (prior_box_param.variance_size() == 1) {
+    CHECK_GT(prior_box_param.variance(0), 0);
+    variance_.push_back(prior_box_param.variance(0));
+  } else {
+    // Set default to 0.1.
+    variance_.push_back(0.1);
+  }
+
+  if (prior_box_param.has_img_h() || prior_box_param.has_img_w()) {
+    CHECK(!prior_box_param.has_img_size())
+        << "Either img_size or img_h/img_w should be specified; not both.";
+    img_h_ = prior_box_param.img_h();
+    CHECK_GT(img_h_, 0) << "img_h should be larger than 0.";
+    img_w_ = prior_box_param.img_w();
+    CHECK_GT(img_w_, 0) << "img_w should be larger than 0.";
+  } else if (prior_box_param.has_img_size()) {
+    const int img_size = prior_box_param.img_size();
+    CHECK_GT(img_size, 0) << "img_size should be larger than 0.";
+    img_h_ = img_size;
+    img_w_ = img_size;
+  } else {
+    img_h_ = 0;
+    img_w_ = 0;
+  }
+
+  if (prior_box_param.has_step_h() || prior_box_param.has_step_w()) {
+    CHECK(!prior_box_param.has_step())
+        << "Either step or step_h/step_w should be specified; not both.";
+    step_h_ = prior_box_param.step_h();
+    CHECK_GT(step_h_, 0.) << "step_h should be larger than 0.";
+    step_w_ = prior_box_param.step_w();
+    CHECK_GT(step_w_, 0.) << "step_w should be larger than 0.";
+  } else if (prior_box_param.has_step()) {
+    const float step = prior_box_param.step();
+    CHECK_GT(step, 0) << "step should be larger than 0.";
+    step_h_ = step;
+    step_w_ = step;
+  } else {
+    step_h_ = 0;
+    step_w_ = 0;
+  }
+
+  offset_ = prior_box_param.offset();
+}
+
+template <typename Ftype, typename Btype>
+void PriorBoxLayer<Ftype,Btype>::Reshape(const vector<Blob*>& bottom,
+      const vector<Blob*>& top) {
+  const int layer_width = bottom[0]->width();
+  const int layer_height = bottom[0]->height();
+  vector<int> top_shape(3, 1);
+  // Since all images in a batch has same height and width, we only need to
+  // generate one set of priors which can be shared across all images.
+  top_shape[0] = 1;
+  // 2 channels. First channel stores the mean of each prior coordinate.
+  // Second channel stores the variance of each prior coordinate.
+  top_shape[1] = 2;
+  top_shape[2] = layer_width * layer_height * num_priors_ * 4;
+  CHECK_GT(top_shape[2], 0);
+  top[0]->Reshape(top_shape);
+}
+
+template <typename Ftype, typename Btype>
+void PriorBoxLayer<Ftype,Btype>::Forward_cpu(const vector<Blob*>& bottom,
+    const vector<Blob*>& top) {
+  const int layer_width = bottom[0]->width();
+  const int layer_height = bottom[0]->height();
+  int img_width, img_height;
+  if (img_h_ == 0 || img_w_ == 0) {
+    img_width = bottom[1]->width();
+    img_height = bottom[1]->height();
+  } else {
+    img_width = img_w_;
+    img_height = img_h_;
+  }
+  float step_w, step_h;
+  if (step_w_ == 0 || step_h_ == 0) {
+    step_w = static_cast<float>(img_width) / layer_width;
+    step_h = static_cast<float>(img_height) / layer_height;
+  } else {
+    step_w = step_w_;
+    step_h = step_h_;
+  }
+  Ftype* top_data = top[0]->mutable_cpu_data<Dtype>();
+  int dim = layer_height * layer_width * num_priors_ * 4;
+  int idx = 0;
+  for (int h = 0; h < layer_height; ++h) {
+    for (int w = 0; w < layer_width; ++w) {
+      float center_x = (w + offset_) * step_w;
+      float center_y = (h + offset_) * step_h;
+      float box_width, box_height;
+      for (int s = 0; s < min_sizes_.size(); ++s) {
+        int min_size_ = min_sizes_[s];
+        // first prior: aspect_ratio = 1, size = min_size
+        box_width = box_height = min_size_;
+        // xmin
+        top_data[idx++] = (center_x - box_width / 2.) / img_width;
+        // ymin
+        top_data[idx++] = (center_y - box_height / 2.) / img_height;
+        // xmax
+        top_data[idx++] = (center_x + box_width / 2.) / img_width;
+        // ymax
+        top_data[idx++] = (center_y + box_height / 2.) / img_height;
+
+        if (max_sizes_.size() > 0) {
+          CHECK_EQ(min_sizes_.size(), max_sizes_.size());
+          int max_size_ = max_sizes_[s];
+          // second prior: aspect_ratio = 1, size = sqrt(min_size * max_size)
+          box_width = box_height = sqrt(min_size_ * max_size_);
+          // xmin
+          top_data[idx++] = (center_x - box_width / 2.) / img_width;
+          // ymin
+          top_data[idx++] = (center_y - box_height / 2.) / img_height;
+          // xmax
+          top_data[idx++] = (center_x + box_width / 2.) / img_width;
+          // ymax
+          top_data[idx++] = (center_y + box_height / 2.) / img_height;
+        }
+
+        // rest of priors
+        for (int r = 0; r < aspect_ratios_.size(); ++r) {
+          float ar = aspect_ratios_[r];
+          if (fabs(ar - 1.) < 1e-6) {
+            continue;
+          }
+          box_width = min_size_ * sqrt(ar);
+          box_height = min_size_ / sqrt(ar);
+          // xmin
+          top_data[idx++] = (center_x - box_width / 2.) / img_width;
+          // ymin
+          top_data[idx++] = (center_y - box_height / 2.) / img_height;
+          // xmax
+          top_data[idx++] = (center_x + box_width / 2.) / img_width;
+          // ymax
+          top_data[idx++] = (center_y + box_height / 2.) / img_height;
+        }
+      }
+    }
+  }
+  // clip the prior's coordidate such that it is within [0, 1]
+  if (clip_) {
+    for (int d = 0; d < dim; ++d) {
+      top_data[d] = std::min<Dtype>(std::max<Dtype>(top_data[d], 0.), 1.);
+    }
+  }
+  // set the variance.
+  top_data += top[0]->offset(0, 1);
+  if (variance_.size() == 1) {
+    caffe_set(dim, Dtype(variance_[0]), top_data);
+  } else {
+    int count = 0;
+    for (int h = 0; h < layer_height; ++h) {
+      for (int w = 0; w < layer_width; ++w) {
+        for (int i = 0; i < num_priors_; ++i) {
+          for (int j = 0; j < 4; ++j) {
+            top_data[count] = variance_[j];
+            ++count;
+          }
+        }
+      }
+    }
+  }
+}
+
+INSTANTIATE_CLASS_FB(PriorBoxLayer);
+REGISTER_LAYER_CLASS(PriorBox);
+
+}  // namespace caffe

--- a/src/caffe/layers/smooth_L1_loss_layer.cpp
+++ b/src/caffe/layers/smooth_L1_loss_layer.cpp
@@ -1,0 +1,108 @@
+// ------------------------------------------------------------------
+// Fast R-CNN
+// copyright (c) 2015 Microsoft
+// Licensed under The MIT License [see fast-rcnn/LICENSE for details]
+// Written by Ross Girshick
+// Modified by Wei Liu
+// ------------------------------------------------------------------
+
+#include <vector>
+
+#include "caffe/layers/smooth_L1_loss_layer.hpp"
+#include "caffe/util/math_functions.hpp"
+
+namespace caffe {
+
+template <typename Ftype, typename Btype>
+void SmoothL1LossLayer<Ftype,Btype>::LayerSetUp(
+  const vector<Blob*>& bottom, const vector<Blob*>& top) {
+  LossLayer<Ftype,Btype>::LayerSetUp(bottom, top);
+  has_weights_ = (bottom.size() == 3);
+}
+
+template <typename Ftype, typename Btype>
+void SmoothL1LossLayer<Ftype,Btype>::Reshape(
+  const vector<Blob*>& bottom, const vector<Blob*>& top) {
+  LossLayer<Ftype,Btype>::Reshape(bottom, top);
+  CHECK_EQ(bottom[0]->channels(), bottom[1]->channels());
+  CHECK_EQ(bottom[0]->height(), bottom[1]->height());
+  CHECK_EQ(bottom[0]->width(), bottom[1]->width());
+  if (has_weights_) {
+    CHECK_EQ(bottom[0]->channels(), bottom[2]->channels());
+    CHECK_EQ(bottom[0]->height(), bottom[2]->height());
+    CHECK_EQ(bottom[0]->width(), bottom[2]->width());
+  }
+  diff_.Reshape(bottom[0]->num(), bottom[0]->channels(),
+      bottom[0]->height(), bottom[0]->width());
+  errors_.Reshape(bottom[0]->num(), bottom[0]->channels(),
+      bottom[0]->height(), bottom[0]->width());
+}
+
+template <typename Ftype, typename Btype>
+void SmoothL1LossLayer<Ftype,Btype>::Forward_cpu(const vector<Blob*>& bottom,
+    const vector<Blob*>& top) {
+  int count = bottom[0]->count();
+  caffe_sub(
+      count,
+      bottom[0]->cpu_data<Dtype>(),
+      bottom[1]->cpu_data<Dtype>(),
+      diff_.mutable_cpu_data());
+  if (has_weights_) {
+    caffe_mul(
+        count,
+        bottom[2]->cpu_data<Dtype>(),
+        diff_.cpu_data(),
+        diff_.mutable_cpu_data());  // d := w * (b0 - b1)
+  }
+  const Dtype* diff_data = diff_.cpu_data();
+  Dtype* error_data = errors_.mutable_cpu_data();
+  for (int i = 0; i < count; ++i) {
+    Dtype val = diff_data[i];
+    Dtype abs_val = fabs(val);
+    if (abs_val < 1.) {
+      error_data[i] = 0.5 * val * val;
+    } else {
+      error_data[i] = abs_val - 0.5;
+    }
+  }
+  top[0]->mutable_cpu_data<Dtype>()[0] =
+      caffe_cpu_asum(count, errors_.cpu_data()) / bottom[0]->num();
+}
+
+template <typename Ftype, typename Btype>
+void SmoothL1LossLayer<Ftype,Btype>::Backward_cpu(const vector<Blob*>& top,
+    const vector<bool>& propagate_down, const vector<Blob*>& bottom) {
+  int count = diff_.count();
+  Dtype* diff_data = diff_.mutable_cpu_data();
+  for (int i = 0; i < count; ++i) {
+    Dtype val = diff_data[i];
+    // f'(x) = x         if |x| < 1
+    //       = sign(x)   otherwise
+    if (fabs(val) < 1.) {
+      diff_data[i] = val;
+    } else {
+      diff_data[i] = (Dtype(0) < val) - (val < Dtype(0));
+    }
+  }
+  for (int i = 0; i < 2; ++i) {
+    if (propagate_down[i]) {
+      const Dtype sign = (i == 0) ? 1 : -1;
+      const Dtype alpha = sign * top[0]->cpu_diff<Dtype>()[0] / bottom[i]->num();
+      caffe_cpu_axpby(
+          bottom[i]->count(),               // count
+          alpha,                            // alpha
+          diff_.cpu_data(),                 // a
+          Dtype(0),                         // beta
+          bottom[i]->mutable_cpu_diff<Dtype>());   // b
+    }
+  }
+}
+
+#ifdef CPU_ONLY
+STUB_GPU(SmoothL1LossLayer);
+#endif
+
+INSTANTIATE_CLASS_FB(SmoothL1LossLayer);
+REGISTER_LAYER_CLASS(SmoothL1Loss);
+
+}  // namespace caffe

--- a/src/caffe/layers/smooth_L1_loss_layer.cu
+++ b/src/caffe/layers/smooth_L1_loss_layer.cu
@@ -1,0 +1,96 @@
+// ------------------------------------------------------------------
+// Fast R-CNN
+// copyright (c) 2015 Microsoft
+// Licensed under The MIT License [see fast-rcnn/LICENSE for details]
+// Written by Ross Girshick
+// Modified by Wei Liu
+// ------------------------------------------------------------------
+
+#include <vector>
+
+#include "caffe/layers/smooth_L1_loss_layer.hpp"
+#include "caffe/util/math_functions.hpp"
+
+namespace caffe {
+
+template <typename Dtype>
+__global__ void SmoothL1Forward(const int n, const Dtype* in, Dtype* out) {
+  // f(x) = 0.5 * x^2    if |x| < 1
+  //        |x| - 0.5    otherwise
+  CUDA_KERNEL_LOOP(index, n) {
+    Dtype val = in[index];
+    Dtype abs_val = abs(val);
+    if (abs_val < 1) {
+      out[index] = 0.5 * val * val;
+    } else {
+      out[index] = abs_val - 0.5;
+    }
+  }
+}
+
+template <typename Ftype, typename Btype>
+void SmoothL1LossLayer<Ftype,Btype>::Forward_gpu(const vector<Blob*>& bottom,
+    const vector<Blob*>& top) {
+  int count = bottom[0]->count();
+  caffe_gpu_sub(
+      count,
+      bottom[0]->gpu_data<Dtype>(),
+      bottom[1]->gpu_data<Dtype>(),
+      diff_.mutable_gpu_data());    // d := b0 - b1
+  if (has_weights_) {
+    caffe_gpu_mul(
+        count,
+        bottom[2]->gpu_data<Dtype>(),
+        diff_.gpu_data(),
+        diff_.mutable_gpu_data());  // d := w * (b0 - b1)
+  }
+  // NOLINT_NEXT_LINE(whitespace/operators)
+  SmoothL1Forward<Dtype><<<CAFFE_GET_BLOCKS(count), CAFFE_CUDA_NUM_THREADS>>>(
+      count, diff_.gpu_data(), errors_.mutable_gpu_data());
+  CUDA_POST_KERNEL_CHECK;
+
+  Dtype loss;
+  caffe_gpu_asum(count, errors_.gpu_data(), &loss);
+  top[0]->mutable_cpu_data<Dtype>()[0] = loss / bottom[0]->num();
+}
+
+template <typename Dtype>
+__global__ void SmoothL1Backward(const int n, const Dtype* in, Dtype* out) {
+  // f'(x) = x         if |x| < 1
+  //       = sign(x)   otherwise
+  CUDA_KERNEL_LOOP(index, n) {
+    Dtype val = in[index];
+    Dtype abs_val = abs(val);
+    if (abs_val < 1) {
+      out[index] = val;
+    } else {
+      out[index] = (Dtype(0) < val) - (val < Dtype(0));
+    }
+  }
+}
+
+template <typename Ftype, typename Btype>
+void SmoothL1LossLayer<Ftype,Btype>::Backward_gpu(const vector<Blob*>& top,
+    const vector<bool>& propagate_down, const vector<Blob*>& bottom) {
+  int count = diff_.count();
+  // NOLINT_NEXT_LINE(whitespace/operators)
+  SmoothL1Backward<Dtype><<<CAFFE_GET_BLOCKS(count), CAFFE_CUDA_NUM_THREADS>>>(
+      count, diff_.gpu_data(), diff_.mutable_gpu_data());
+  CUDA_POST_KERNEL_CHECK;
+  for (int i = 0; i < 2; ++i) {
+    if (propagate_down[i]) {
+      const Dtype sign = (i == 0) ? 1 : -1;
+      const Dtype alpha = sign * top[0]->cpu_diff<Dtype>()[0] / bottom[i]->num();
+      caffe_gpu_axpby(
+          bottom[i]->count(),              // count
+          alpha,                           // alpha
+          diff_.gpu_data(),                // x
+          Dtype(0),                        // beta
+          bottom[i]->mutable_gpu_diff<Dtype>());  // y
+    }
+  }
+}
+
+INSTANTIATE_LAYER_GPU_FUNCS_FB(SmoothL1LossLayer);
+
+}  // namespace caffe

--- a/src/caffe/layers/video_data_layer.cpp
+++ b/src/caffe/layers/video_data_layer.cpp
@@ -1,0 +1,165 @@
+#ifdef USE_OPENCV
+#include <opencv2/core/core.hpp>
+#include <opencv2/highgui/highgui.hpp>
+
+#include <stdint.h>
+#include <algorithm>
+#include <csignal>
+#include <map>
+#include <string>
+#include <vector>
+
+#include "caffe/data_transformer.hpp"
+#include "caffe/layers/video_data_layer.hpp"
+#include "caffe/util/benchmark.hpp"
+
+namespace caffe {
+
+template <typename Ftype, typename Btype>
+VideoDataLayer<Ftype,Btype>::VideoDataLayer(const LayerParameter& param)
+  : BasePrefetchingDataLayer<Ftype,Btype>(param) {
+}
+
+template <typename Ftype, typename Btype>
+VideoDataLayer<Ftype,Btype>::~VideoDataLayer() {
+  this->StopInternalThread();
+  if (cap_.isOpened()) {
+    cap_.release();
+  }
+}
+
+template <typename Ftype, typename Btype>
+void VideoDataLayer<Ftype,Btype>::DataLayerSetUp(
+    const vector<Blob*>& bottom, const vector<Blob*>& top) {
+  const int batch_size = this->layer_param_.data_param().batch_size();
+  const VideoDataParameter& video_data_param =
+      this->layer_param_.video_data_param();
+  video_type_ = video_data_param.video_type();
+  skip_frames_ = video_data_param.skip_frames();
+  CHECK_GE(skip_frames_, 0);
+  TBlob<Dtype> transformed_datum;  
+  // Read an image, and use it to initialize the top blob.
+  cv::Mat cv_img;
+  if (video_type_ == VideoDataParameter_VideoType_WEBCAM) {
+    const int device_id = video_data_param.device_id();
+    if (!cap_.open(device_id)) {
+      LOG(FATAL) << "Failed to open webcam: " << device_id;
+    }
+    cap_ >> cv_img;
+  } else if (video_type_ == VideoDataParameter_VideoType_VIDEO) {
+    CHECK(video_data_param.has_video_file()) << "Must provide video file!";
+    const string& video_file = video_data_param.video_file();
+    if (!cap_.open(video_file)) {
+      LOG(FATAL) << "Failed to open video: " << video_file;
+    }
+    total_frames_ = cap_.get(CV_CAP_PROP_FRAME_COUNT);
+    processed_frames_ = 0;
+    // Read image to infer shape.
+    cap_ >> cv_img;
+    // Set index back to the first frame.
+    cap_.set(CV_CAP_PROP_POS_FRAMES, 0);
+  } else {
+    LOG(FATAL) << "Unknow video type!";
+  }
+  CHECK(cv_img.data) << "Could not load image!";
+  // Use data_transformer to infer the expected blob shape from a cv_image.
+  top_shape_ = this->data_transformers_[0]->InferBlobShape(cv_img);
+  transformed_datum.Reshape(top_shape_);
+  top_shape_[0] = batch_size;
+  top[0]->Reshape(top_shape_);
+  for (int i = 0; i < this->prefetch_.size(); ++i) {
+    this->prefetch_[i]->data_.Reshape(top_shape_);
+  }
+  LOG(INFO) << "output data size: " << top[0]->num() << ","
+      << top[0]->channels() << "," << top[0]->height() << ","
+      << top[0]->width();
+  // label
+  if (this->output_labels_) {
+    vector<int> label_shape(1, batch_size);
+    top[1]->Reshape(label_shape);
+    for (int i = 0; i < this->prefetch_.size(); ++i) {
+      this->prefetch_[i]->label_.Reshape(label_shape);
+    }
+  }
+}
+
+// This function is called on prefetch thread
+template <typename Ftype, typename Btype>
+void VideoDataLayer<Ftype,Btype>::load_batch(Batch<Ftype>* batch, int thread_id, size_t queue_id) {
+  CPUTimer batch_timer;
+  batch_timer.Start();
+  double read_time = 0;
+  double trans_time = 0;
+  CPUTimer timer;
+  CHECK(batch->data_.count());
+  TBlob<Dtype> transformed_datum;  
+
+  // Reshape according to the first anno_datum of each batch
+  // on single input batches allows for inputs of varying dimension.
+  const int batch_size = this->layer_param_.data_param().batch_size();
+  top_shape_[0] = 1;
+  transformed_datum.Reshape(top_shape_);
+  // Reshape batch according to the batch_size.
+  top_shape_[0] = batch_size;
+  batch->data_.Reshape(top_shape_);
+
+  Dtype* top_data = batch->data_.mutable_cpu_data();
+  Dtype* top_label = NULL;  // suppress warnings about uninitialized variables
+  if (this->output_labels_) {
+    top_label = batch->label_.mutable_cpu_data();
+  }
+
+  int skip_frames = skip_frames_;
+  for (int item_id = 0; item_id < batch_size; ++item_id) {
+    timer.Start();
+    cv::Mat cv_img;
+    if (video_type_ == VideoDataParameter_VideoType_WEBCAM) {
+      cap_ >> cv_img;
+    } else if (video_type_ == VideoDataParameter_VideoType_VIDEO) {
+      if (processed_frames_ >= total_frames_) {
+        LOG(INFO) << "Finished processing video.";
+        raise(SIGINT);
+      }
+      ++processed_frames_;
+      cap_ >> cv_img;
+    } else {
+      LOG(FATAL) << "Unknown video type.";
+    }
+    CHECK(cv_img.data) << "Could not load image!";
+    read_time += timer.MicroSeconds();
+    if (skip_frames > 0) {
+      --skip_frames;
+      --item_id;
+    } else {
+      skip_frames = skip_frames_;
+      timer.Start();
+      // Apply transformations (mirror, crop...) to the image
+      int offset = batch->data_.offset(item_id);
+      transformed_datum.set_cpu_data(top_data + offset);
+      this->data_transformers_[0]->Transform(cv_img, &(transformed_datum));
+      trans_time += timer.MicroSeconds();
+    }
+    CHECK(cv_img.data) << "Could not load image!";
+    read_time += timer.MicroSeconds();
+    timer.Start();
+    // Apply transformations (mirror, crop...) to the image
+    int offset = batch->data_.offset(item_id);
+    transformed_datum.set_cpu_data(top_data + offset);
+    this->data_transformers_[0]->Transform(cv_img, &(transformed_datum));
+    trans_time += timer.MicroSeconds();
+    if (this->output_labels_) {
+      top_label[item_id] = 0;
+    }
+  }
+  timer.Stop();
+  batch_timer.Stop();
+  DLOG(INFO) << "Prefetch batch: " << batch_timer.MilliSeconds() << " ms.";
+  DLOG(INFO) << "     Read time: " << read_time / 1000 << " ms.";
+  DLOG(INFO) << "Transform time: " << trans_time / 1000 << " ms.";
+}
+
+INSTANTIATE_CLASS_FB(VideoDataLayer);
+REGISTER_LAYER_CLASS(VideoData);
+
+}  // namespace caffe
+#endif  // USE_OPENCV

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -9,6 +9,7 @@ enum Type {
   FLOAT16 = 2;
   INT = 3;  // math not supported
   UINT = 4;  // math not supported
+  BOOL = 5; //math not supported
 }
 
 // Specifies the shape (dimensions) of a Blob.
@@ -53,6 +54,127 @@ message Datum {
   optional bool encoded = 7 [default = false];
   // Unique record index assigned by Reader
   optional uint32 record_id = 8 [default = 0];
+}
+
+// The label (display) name and label id.
+message LabelMapItem {
+  // Both name and label are required.
+  optional string name = 1;
+  optional int32 label = 2;
+  // display_name is optional.
+  optional string display_name = 3;
+}
+
+message LabelMap {
+  repeated LabelMapItem item = 1;
+}
+
+// Sample a bbox in the normalized space [0, 1] with provided constraints.
+message Sampler {
+  // Minimum scale of the sampled bbox.
+  optional float min_scale = 1 [default = 1.];
+  // Maximum scale of the sampled bbox.
+  optional float max_scale = 2 [default = 1.];
+
+  // Minimum aspect ratio of the sampled bbox.
+  optional float min_aspect_ratio = 3 [default = 1.];
+  // Maximum aspect ratio of the sampled bbox.
+  optional float max_aspect_ratio = 4 [default = 1.];
+}
+
+// Constraints for selecting sampled bbox.
+message SampleConstraint {
+  // Minimum Jaccard overlap between sampled bbox and all bboxes in
+  // AnnotationGroup.
+  optional float min_jaccard_overlap = 1;
+  // Maximum Jaccard overlap between sampled bbox and all bboxes in
+  // AnnotationGroup.
+  optional float max_jaccard_overlap = 2;
+
+  // Minimum coverage of sampled bbox by all bboxes in AnnotationGroup.
+  optional float min_sample_coverage = 3;
+  // Maximum coverage of sampled bbox by all bboxes in AnnotationGroup.
+  optional float max_sample_coverage = 4;
+
+  // Minimum coverage of all bboxes in AnnotationGroup by sampled bbox.
+  optional float min_object_coverage = 5;
+  // Maximum coverage of all bboxes in AnnotationGroup by sampled bbox.
+  optional float max_object_coverage = 6;
+}
+
+// Sample a batch of bboxes with provided constraints.
+message BatchSampler {
+  // Use original image as the source for sampling.
+  optional bool use_original_image = 1 [default = true];
+
+  // Constraints for sampling bbox.
+  optional Sampler sampler = 2;
+
+  // Constraints for determining if a sampled bbox is positive or negative.
+  optional SampleConstraint sample_constraint = 3;
+
+  // If provided, break when found certain number of samples satisfing the
+  // sample_constraint.
+  optional uint32 max_sample = 4;
+
+  // Maximum number of trials for sampling to avoid infinite loop.
+  optional uint32 max_trials = 5 [default = 100];
+}
+
+// Condition for emitting annotations.
+message EmitConstraint {
+  enum EmitType {
+    CENTER = 0;
+    MIN_OVERLAP = 1;
+  }
+  optional EmitType emit_type = 1 [default = CENTER];
+  // If emit_type is MIN_OVERLAP, provide the emit_overlap.
+  optional float emit_overlap = 2;
+}
+
+// The normalized bounding box [0, 1] w.r.t. the input image size.
+message NormalizedBBox {
+  optional float xmin = 1;
+  optional float ymin = 2;
+  optional float xmax = 3;
+  optional float ymax = 4;
+  optional int32 label = 5;
+  optional bool difficult = 6;
+  optional float score = 7;
+  optional float size = 8;
+}
+
+// Annotation for each object instance.
+message Annotation {
+  optional int32 instance_id = 1 [default = 0];
+  optional NormalizedBBox bbox = 2;
+}
+
+// Group of annotations for a particular label.
+message AnnotationGroup {
+  optional int32 group_label = 1;
+  repeated Annotation annotation = 2;
+}
+
+// An extension of Datum which contains "rich" annotations.
+message AnnotatedDatum {
+  enum AnnotationType {
+    BBOX = 0;
+  }
+  optional Datum datum = 1;
+  // If there are "rich" annotations, specify the type of annotation.
+  // Currently it only supports bounding box.
+  // If there are no "rich" annotations, use label in datum instead.
+  optional AnnotationType type = 2;
+  // Each group contains annotation for a particular class.
+  repeated AnnotationGroup annotation_group = 3;
+  // Unique record index assigned by Reader
+  optional uint32 record_id = 4 [default = 0];  
+}
+
+enum DatumTypeInfo {
+  DatumTypeInfo_DATUM = 0;
+  DatumTypeInfo_ANNOTATED_DATUM = 1;
 }
 
 message FillerParameter {
@@ -182,6 +304,17 @@ message SolverParameter {
   optional NetState train_state = 26;
   repeated NetState test_state = 27;
 
+  // Evaluation type.
+  optional string eval_type = 241 [default = "classification"];
+  // ap_version: different ways of computing Average Precision.
+  //    Check https://sanchom.wordpress.com/tag/average-precision/ for details.
+  //    11point: the 11-point interpolated average precision. Used in VOC2007.
+  //    MaxIntegral: maximally interpolated AP. Used in VOC2012/ILSVRC.
+  //    Integral: the natural integral of the precision-recall curve.
+  optional string ap_version = 242 [default = "Integral"];
+  // If true, display per class result.
+  optional bool show_per_class_result = 244 [default = false];
+
   // The number of iterations for each test net.
   repeated int32 test_iter = 3;
 
@@ -219,6 +352,8 @@ message SolverParameter {
   //      zero by the max_iter. return base_lr (1 - iter/max_iter) ^ (power)
   //    - sigmoid: the effective learning rate follows a sigmod decay
   //      return base_lr ( 1/(1 + exp(-gamma * (iter - stepsize))))
+  //    - plateau: decreases lr
+  //              if the minimum loss isn't updated for 'plateau_winsize' iters
   //
   // where base_lr, max_iter, gamma, step, stepvalue and power are defined
   // in the solver parameter protocol buffer, and iter is the current iteration.
@@ -242,6 +377,8 @@ message SolverParameter {
   optional int32 stepsize = 13;
   // the stepsize for learning rate policy "multistep"
   repeated int32 stepvalue = 34;
+  // the stepsize for learning rate policy "plateau"
+  repeated int32 plateau_winsize = 243;
 
   // Set clip_gradients to >= 0 to clip parameter gradients to that L2 norm,
   // whenever their actual L2 norm is larger.
@@ -316,6 +453,8 @@ message SolverState {
   optional string learned_net = 2; // The file that stores the learned net.
   repeated BlobProto history = 3; // The history for sgd solvers
   optional int32 current_step = 4 [default = 0]; // The current step for learning rate
+  optional float minimum_loss = 5 [default = 1E38]; // Historical minimum loss
+  optional int32 iter_last_event = 6 [default = 0]; // The iteration when last lr-update or min_loss-update happend
 }
 
 enum Phase {
@@ -448,6 +587,7 @@ message LayerParameter {
   // engine parameter for selecting the implementation.
   // The default for the engine is set by the ENGINE switch at compile-time.
   optional AccuracyParameter accuracy_param = 102;
+  optional AnnotatedDataParameter annotated_data_param = 200;
   optional ArgMaxParameter argmax_param = 103;
   optional BatchNormParameter batch_norm_param = 139;
   optional BiasParameter bias_param = 141;
@@ -456,6 +596,8 @@ message LayerParameter {
   optional ConvolutionParameter convolution_param = 106;
   optional CropParameter crop_param = 144;
   optional DataParameter data_param = 107;
+  optional DetectionEvaluateParameter detection_evaluate_param = 205;
+  optional DetectionOutputParameter detection_output_param = 204;
   optional DropoutParameter dropout_param = 108;
   optional DummyDataParameter dummy_data_param = 109;
   optional EltwiseParameter eltwise_param = 110;
@@ -473,10 +615,14 @@ message LayerParameter {
   optional LogParameter log_param = 134;
   optional LRNParameter lrn_param = 118;
   optional MemoryDataParameter memory_data_param = 119;
+  optional MultiBoxLossParameter multibox_loss_param = 201;
   optional MVNParameter mvn_param = 120;
+  optional NormalizeParameter norm_param = 206;
+  optional PermuteParameter permute_param = 202;
   optional PoolingParameter pooling_param = 121;
   optional PowerParameter power_param = 122;
   optional PReLUParameter prelu_param = 131;
+  optional PriorBoxParameter prior_box_param = 203;
   optional PythonParameter python_param = 130;
   optional ReductionParameter reduction_param = 136;
   optional ReLUParameter relu_param = 123;
@@ -489,6 +635,7 @@ message LayerParameter {
   optional TanHParameter tanh_param = 127;
   optional ThresholdParameter threshold_param = 128;
   optional TileParameter tile_param = 138;
+  optional VideoDataParameter video_data_param = 207;
   optional WindowDataParameter window_data_param = 129;
 
   // NVIDIA PARAMETERS (Start with 68 because NV is 68 on an old-style phone)
@@ -536,6 +683,9 @@ message TransformationParameter {
   optional bool mirror = 2 [default = false];
   // Specify if we would like to randomly crop an image.
   optional uint32 crop_size = 3 [default = 0];
+  optional uint32 crop_h = 211 [default = 0];
+  optional uint32 crop_w = 212 [default = 0];
+
   // mean_file and mean_value cannot be specified at the same time
   optional string mean_file = 4;
   // if specified can be repeated once (would substract it from all the channels)
@@ -554,6 +704,20 @@ message TransformationParameter {
   // random number generator would be initialized -- useful for reproducible results.
   // Otherwise, (and by default) initialize using a seed derived from the system clock.
   optional int64 random_seed = 9 [default = -1];
+
+  optional bool display = 20 [default = false]; 
+  optional int32 num_labels = 21 [default = 0];  
+  
+  // Resize policy
+  optional ResizeParameter resize_param = 208;
+  // Noise policy
+  optional NoiseParameter noise_param = 209;
+  // Distortion policy
+  optional DistortionParameter distort_param = 213;
+  // Expand policy
+  optional ExpansionParameter expand_param = 214;
+  // Constraint for emitting the annotation after transformation.
+  optional EmitConstraint emit_constraint = 210;  
 }
 // Message that stores parameters used to create gridbox ground truth
 message DetectNetGroundTruthParameter {
@@ -627,6 +791,142 @@ message DetectNetAugmentationParameter {
   //  desaturation augmentation off.
   optional float desaturation_prob = 12 [default = 0.33];
   optional float desaturation_max = 13 [default = 0.5];
+  
+  // Resize policy
+  optional ResizeParameter resize_param = 208;
+  // Noise policy
+  optional NoiseParameter noise_param = 209;
+  // Distortion policy
+  optional DistortionParameter distort_param = 213;
+  // Expand policy
+  optional ExpansionParameter expand_param = 214;
+  // Constraint for emitting the annotation after transformation.
+  optional EmitConstraint emit_constraint = 210;  
+}
+
+// Message that stores parameters used by data transformer for resize policy
+message ResizeParameter {
+  //Probability of using this resize policy
+  optional float prob = 1 [default = 1];
+
+  enum Resize_mode {
+    WARP = 1;
+    FIT_SMALL_SIZE = 2;
+    FIT_LARGE_SIZE_AND_PAD = 3;
+  }
+  optional Resize_mode resize_mode = 2 [default = WARP];
+  optional uint32 height = 3 [default = 0];
+  optional uint32 width = 4 [default = 0];
+  // A parameter used to update bbox in FIT_SMALL_SIZE mode.
+  optional uint32 height_scale = 8 [default = 0];
+  optional uint32 width_scale = 9 [default = 0];
+
+  enum Pad_mode {
+    CONSTANT = 1;
+    MIRRORED = 2;
+    REPEAT_NEAREST = 3;
+  }
+  // Padding mode for BE_SMALL_SIZE_AND_PAD mode and object centering
+  optional Pad_mode pad_mode = 5 [default = CONSTANT];
+  // if specified can be repeated once (would fill all the channels)
+  // or can be repeated the same number of times as channels
+  // (would use it them to the corresponding channel)
+  repeated float pad_value = 6;
+
+  enum Interp_mode { //Same as in OpenCV
+    LINEAR = 1;
+    AREA = 2;
+    NEAREST = 3;
+    CUBIC = 4;
+    LANCZOS4 = 5;
+  }
+  //interpolation for for resizing
+  repeated Interp_mode interp_mode = 7;
+}
+
+message SaltPepperParameter {
+  //Percentage of pixels
+  optional float fraction = 1 [default = 0];
+  repeated float value = 2;
+}
+
+// Message that stores parameters used by data transformer for transformation
+// policy
+message NoiseParameter {
+  //Probability of using this resize policy
+  optional float prob = 1 [default = 0];
+  // Histogram equalized
+  optional bool hist_eq = 2 [default = false];
+  // Color inversion
+  optional bool inverse = 3 [default = false];
+  // Grayscale
+  optional bool decolorize = 4 [default = false];
+  // Gaussian blur
+  optional bool gauss_blur = 5 [default = false];
+
+  // JPEG compression quality (-1 = no compression)
+  optional float jpeg = 6 [default = -1];
+
+  // Posterization
+  optional bool posterize = 7 [default = false];
+
+  // Erosion
+  optional bool erode = 8 [default = false];
+
+  // Salt-and-pepper noise
+  optional bool saltpepper = 9 [default = false];
+
+  optional SaltPepperParameter saltpepper_param = 10;
+
+  // Local histogram equalization
+  optional bool clahe = 11 [default = false];
+
+  // Color space conversion
+  optional bool convert_to_hsv = 12 [default = false];
+
+  // Color space conversion
+  optional bool convert_to_lab = 13 [default = false];
+}
+
+// Message that stores parameters used by data transformer for distortion policy
+message DistortionParameter {
+  // The probability of adjusting brightness.
+  optional float brightness_prob = 1 [default = 0.0];
+  // Amount to add to the pixel values within [-delta, delta].
+  // The possible value is within [0, 255]. Recommend 32.
+  optional float brightness_delta = 2 [default = 0.0];
+
+  // The probability of adjusting contrast.
+  optional float contrast_prob = 3 [default = 0.0];
+  // Lower bound for random contrast factor. Recommend 0.5.
+  optional float contrast_lower = 4 [default = 0.0];
+  // Upper bound for random contrast factor. Recommend 1.5.
+  optional float contrast_upper = 5 [default = 0.0];
+
+  // The probability of adjusting hue.
+  optional float hue_prob = 6 [default = 0.0];
+  // Amount to add to the hue channel within [-delta, delta].
+  // The possible value is within [0, 180]. Recommend 36.
+  optional float hue_delta = 7 [default = 0.0];
+
+  // The probability of adjusting saturation.
+  optional float saturation_prob = 8 [default = 0.0];
+  // Lower bound for the random saturation factor. Recommend 0.5.
+  optional float saturation_lower = 9 [default = 0.0];
+  // Upper bound for the random saturation factor. Recommend 1.5.
+  optional float saturation_upper = 10 [default = 0.0];
+
+  // The probability of randomly order the image channels.
+  optional float random_order_prob = 11 [default = 0.0];
+}
+
+// Message that stores parameters used by data transformer for expansion policy
+message ExpansionParameter {
+  //Probability of using this expansion policy
+  optional float prob = 1 [default = 1];
+
+  // The ratio to expand the image.
+  optional float max_expand_ratio = 2 [default = 1.];
 }
 
 // Message that stores parameters shared by loss layers
@@ -674,6 +974,16 @@ message AccuracyParameter {
 
   // If specified, ignore instances with the given label.
   optional int32 ignore_label = 3;
+}
+
+message AnnotatedDataParameter {
+  // Define the sampler.
+  repeated BatchSampler batch_sampler = 1;
+  // Store label name and label id in LabelMap format.
+  optional string label_map_file = 2;
+  // If provided, it will replace the AnnotationType stored in each
+  // AnnotatedDatum.
+  optional AnnotatedDatum.AnnotationType anno_type = 3;
 }
 
 message ArgMaxParameter {
@@ -894,6 +1204,95 @@ message DataParameter {
   optional bool shuffle = 14 [default = false];
 }
 
+// Message that store parameters used by DetectionEvaluateLayer
+message DetectionEvaluateParameter {
+  // Number of classes that are actually predicted. Required!
+  optional uint32 num_classes = 1;
+  // Label id for background class. Needed for sanity check so that
+  // background class is neither in the ground truth nor the detections.
+  optional uint32 background_label_id = 2 [default = 0];
+  // Threshold for deciding true/false positive.
+  optional float overlap_threshold = 3 [default = 0.5];
+  // If true, also consider difficult ground truth for evaluation.
+  optional bool evaluate_difficult_gt = 4 [default = true];
+  // A file which contains a list of names and sizes with same order
+  // of the input DB. The file is in the following format:
+  //    name height width
+  //    ...
+  // If provided, we will scale the prediction and ground truth NormalizedBBox
+  // for evaluation.
+  optional string name_size_file = 5;
+  // The resize parameter used in converting NormalizedBBox to original image.
+  optional ResizeParameter resize_param = 6;
+}
+
+message NonMaximumSuppressionParameter {
+  // Threshold to be used in nms.
+  optional float nms_threshold = 1 [default = 0.3];
+  // Maximum number of results to be kept.
+  optional int32 top_k = 2;
+  // Parameter for adaptive nms.
+  optional float eta = 3 [default = 1.0];
+}
+
+message SaveOutputParameter {
+  // Output directory. If not empty, we will save the results.
+  optional string output_directory = 1;
+  // Output name prefix.
+  optional string output_name_prefix = 2;
+  // Output format.
+  //    VOC - PASCAL VOC output format.
+  //    COCO - MS COCO output format.
+  optional string output_format = 3;
+  // If you want to output results, must also provide the following two files.
+  // Otherwise, we will ignore saving results.
+  // label map file.
+  optional string label_map_file = 4;
+  // A file which contains a list of names and sizes with same order
+  // of the input DB. The file is in the following format:
+  //    name height width
+  //    ...
+  optional string name_size_file = 5;
+  // Number of test images. It can be less than the lines specified in
+  // name_size_file. For example, when we only want to evaluate on part
+  // of the test images.
+  optional uint32 num_test_image = 6;
+  // The resize parameter used in saving the data.
+  optional ResizeParameter resize_param = 7;
+}
+
+// Message that store parameters used by DetectionOutputLayer
+message DetectionOutputParameter {
+  // Number of classes to be predicted. Required!
+  optional uint32 num_classes = 1;
+  // If true, bounding box are shared among different classes.
+  optional bool share_location = 2 [default = true];
+  // Background label id. If there is no background class,
+  // set it as -1.
+  optional int32 background_label_id = 3 [default = 0];
+  // Parameters used for non maximum suppression.
+  optional NonMaximumSuppressionParameter nms_param = 4;
+  // Parameters used for saving detection results.
+  optional SaveOutputParameter save_output_param = 5;
+  // Type of coding method for bbox.
+  optional PriorBoxParameter.CodeType code_type = 6 [default = CORNER];
+  // If true, variance is encoded in target; otherwise we need to adjust the
+  // predicted offset accordingly.
+  optional bool variance_encoded_in_target = 8 [default = false];
+  // Number of total bboxes to be kept per image after nms step.
+  // -1 means keeping all bboxes after nms step.
+  optional int32 keep_top_k = 7 [default = -1];
+  // Only consider detections whose confidences are larger than a threshold.
+  // If not provided, consider all boxes.
+  optional float confidence_threshold = 9;
+  // If true, visualize the detection results.
+  optional bool visualize = 10 [default = false];
+  // The threshold used to visualize the detection results.
+  optional float visualize_threshold = 11;
+  // If provided, save outputs to video file.
+  optional string save_file = 12;
+}
+
 message DropoutParameter {
   optional float dropout_ratio = 1 [default = 0.5]; // dropout ratio
   enum Engine {
@@ -1108,6 +1507,78 @@ message MemoryDataParameter {
   optional uint32 width = 4;
 }
 
+// Message that store parameters used by MultiBoxLossLayer
+message MultiBoxLossParameter {
+  // Localization loss type.
+  enum LocLossType {
+    L2 = 0;
+    SMOOTH_L1 = 1;
+  }
+  optional LocLossType loc_loss_type = 1 [default = SMOOTH_L1];
+  // Confidence loss type.
+  enum ConfLossType {
+    SOFTMAX = 0;
+    LOGISTIC = 1;
+  }
+  optional ConfLossType conf_loss_type = 2 [default = SOFTMAX];
+  // Weight for localization loss.
+  optional float loc_weight = 3 [default = 1.0];
+  // Number of classes to be predicted. Required!
+  optional uint32 num_classes = 4;
+  // If true, bounding box are shared among different classes.
+  optional bool share_location = 5 [default = true];
+  // Matching method during training.
+  enum MatchType {
+    BIPARTITE = 0;
+    PER_PREDICTION = 1;
+  }
+  optional MatchType match_type = 6 [default = PER_PREDICTION];
+  // If match_type is PER_PREDICTION, use overlap_threshold to
+  // determine the extra matching bboxes.
+  optional float overlap_threshold = 7 [default = 0.5];
+  // Use prior for matching.
+  optional bool use_prior_for_matching = 8 [default = true];
+  // Background label id.
+  optional uint32 background_label_id = 9 [default = 0];
+  // If true, also consider difficult ground truth.
+  optional bool use_difficult_gt = 10 [default = true];
+  // If true, perform negative mining.
+  // DEPRECATED: use mining_type instead.
+  optional bool do_neg_mining = 11;
+  // The negative/positive ratio.
+  optional float neg_pos_ratio = 12 [default = 3.0];
+  // The negative overlap upperbound for the unmatched predictions.
+  optional float neg_overlap = 13 [default = 0.5];
+  // Type of coding method for bbox.
+  optional PriorBoxParameter.CodeType code_type = 14 [default = CORNER];
+  // If true, encode the variance of prior box in the loc loss target instead of
+  // in bbox.
+  optional bool encode_variance_in_target = 16 [default = false];
+  // If true, map all object classes to agnostic class. It is useful for learning
+  // objectness detector.
+  optional bool map_object_to_agnostic = 17 [default = false];
+  // If true, ignore cross boundary bbox during matching.
+  // Cross boundary bbox is a bbox who is outside of the image region.
+  optional bool ignore_cross_boundary_bbox = 18 [default = false];
+  // If true, only backpropagate on corners which are inside of the image
+  // region when encode_type is CORNER or CORNER_SIZE.
+  optional bool bp_inside = 19 [default = false];
+  // Mining type during training.
+  //   NONE : use all negatives.
+  //   MAX_NEGATIVE : select negatives based on the score.
+  //   HARD_EXAMPLE : select hard examples based on "Training Region-based Object Detectors with Online Hard Example Mining", Shrivastava et.al.
+  enum MiningType {
+    NONE = 0;
+    MAX_NEGATIVE = 1;
+    HARD_EXAMPLE = 2;
+  }
+  optional MiningType mining_type = 20 [default = MAX_NEGATIVE];
+  // Parameters used for non maximum suppression durig hard example mining.
+  optional NonMaximumSuppressionParameter nms_param = 21;
+  optional int32 sample_size = 22 [default = 64];
+  optional bool use_prior_for_nms = 23 [default = false];
+}
+
 message MVNParameter {
   // This parameter can be set to false to normalize mean only
   optional bool normalize_variance = 1 [default = true];
@@ -1117,6 +1588,24 @@ message MVNParameter {
 
   // Epsilon for not dividing by zero while normalizing variance
   optional float eps = 3 [default = 1e-9];
+}
+
+// Message that stores parameters used by NormalizeLayer
+message NormalizeParameter {
+  optional bool across_spatial = 1 [default = true];
+  // Initial value of scale. Default is 1.0 for all
+  optional FillerParameter scale_filler = 2;
+  // Whether or not scale parameters are shared across channels.
+  optional bool channel_shared = 3 [default = true];
+  // Epsilon for not dividing by zero while normalizing variance
+  optional float eps = 4 [default = 1e-10];
+}
+
+message PermuteParameter {
+  // The new orders of the axes of data. Notice it should be with
+  // in the same range as the input data, and it starts from 0.
+  // Do not provide repeated order.
+  repeated uint32 order = 1;
 }
 
 message PoolingParameter {
@@ -1153,6 +1642,48 @@ message PowerParameter {
   optional float power = 1 [default = 1.0];
   optional float scale = 2 [default = 1.0];
   optional float shift = 3 [default = 0.0];
+}
+
+// Message that store parameters used by PriorBoxLayer
+message PriorBoxParameter {
+  // Encode/decode type.
+  enum CodeType {
+    CORNER = 1;
+    CENTER_SIZE = 2;
+    CORNER_SIZE = 3;
+  }
+  // Minimum box size (in pixels). Required!
+  repeated float min_size = 1;
+  // Maximum box size (in pixels). Required!
+  repeated float max_size = 2;
+  // Various of aspect ratios. Duplicate ratios will be ignored.
+  // If none is provided, we use default ratio 1.
+  repeated float aspect_ratio = 3;
+  // If true, will flip each aspect ratio.
+  // For example, if there is aspect ratio "r",
+  // we will generate aspect ratio "1.0/r" as well.
+  optional bool flip = 4 [default = true];
+  // If true, will clip the prior so that it is within [0, 1]
+  optional bool clip = 5 [default = false];
+  // Variance for adjusting the prior bboxes.
+  repeated float variance = 6;
+  // By default, we calculate img_height, img_width, step_x, step_y based on
+  // bottom[0] (feat) and bottom[1] (img). Unless these values are explicitely
+  // provided.
+  // Explicitly provide the img_size.
+  optional uint32 img_size = 7;
+  // Either img_size or img_h/img_w should be specified; not both.
+  optional uint32 img_h = 8;
+  optional uint32 img_w = 9;
+
+  // Explicitly provide the step size.
+  optional float step = 10;
+  // Either step or step_h/step_w should be specified; not both.
+  optional float step_h = 11;
+  optional float step_w = 12;
+
+  // Offset to the top left corner of each cell.
+  optional float offset = 13 [default = 0.5];
 }
 
 message PythonParameter {
@@ -1371,6 +1902,18 @@ message TileParameter {
 // Message that stores parameters used by ThresholdLayer
 message ThresholdParameter {
   optional float threshold = 1 [default = 0]; // Strictly positive values
+}
+
+message VideoDataParameter{
+  enum VideoType {
+    WEBCAM = 0;
+    VIDEO = 1;
+  }
+  optional VideoType video_type = 1 [default = WEBCAM];
+  optional int32 device_id = 2 [default = 0];
+  optional string video_file = 3;
+  // Number of frames to be skipped before processing a frame.
+  optional uint32 skip_frames = 4 [default = 0];
 }
 
 message WindowDataParameter {

--- a/src/caffe/solver.cpp
+++ b/src/caffe/solver.cpp
@@ -10,6 +10,7 @@
 #include "caffe/util/hdf5.hpp"
 #include "caffe/util/io.hpp"
 #include "caffe/util/upgrade_proto.hpp"
+#include "caffe/util/bbox_util.hpp"
 
 namespace caffe {
 
@@ -446,7 +447,9 @@ bool Solver::TestAll(const int iters, bool use_multi_gpu) {
   for (int test_net_id = 0;
        test_net_id < test_nets_.size() && !requested_early_exit_;
        ++test_net_id) {
-    if (Test(test_net_id, iters, use_multi_gpu)) {
+    if (param_.eval_type() == "detection") {
+      TestDetection(test_net_id);
+    } else if (Test(test_net_id, iters, use_multi_gpu)) {
       return true;
     }
   }
@@ -529,20 +532,152 @@ bool Solver::Test(const int test_net_id, const int iters, bool use_multi_gpu) {
     LOG(INFO) << "Test loss: " << loss;
   }
   for (int i = 0; i < test_score.size(); ++i) {
-    const int output_blob_index =
-        test_net->output_blob_indices()[test_score_output_id[i]];
-    const string& output_name = test_net->blob_names()[output_blob_index];
-    const float loss_weight = test_net->blob_loss_weights()[output_blob_index];
-    ostringstream loss_msg_stream;
-    const float mean_score = test_score[i] / test_iterations / Caffe::solver_count();
-    if (loss_weight) {
-      loss_msg_stream << " (* " << loss_weight
-          << " = " << (loss_weight * mean_score) << " loss)";
+    if(i < test_score_output_id.size()) {
+      int test_score_output_id_value = test_score_output_id[i];
+      const vector<int>& output_blob_indices = test_net->output_blob_indices();
+      if(test_score_output_id_value < output_blob_indices.size()) {
+        const int output_blob_index = output_blob_indices[test_score_output_id_value];
+        const vector<string>& blob_names = test_net->blob_names();
+        if(output_blob_index < blob_names.size()) {
+          const string& output_name = blob_names[output_blob_index];
+          const vector<float>& blob_loss_weights = test_net->blob_loss_weights();
+          if(output_blob_index < blob_loss_weights.size()) {
+            const float loss_weight = blob_loss_weights[output_blob_index];
+            ostringstream loss_msg_stream;
+            const float mean_score = test_score[i] / test_iterations / Caffe::solver_count();
+            if (loss_weight) {
+              loss_msg_stream << " (* " << loss_weight
+                  << " = " << (loss_weight * mean_score) << " loss)";
+            }
+            LOG_IF(INFO, Caffe::root_solver()) << "    Test net output #" << i <<
+                ": " << output_name << " = " << mean_score << loss_msg_stream.str();
+          }
+        }
+      }
     }
-    LOG_IF(INFO, Caffe::root_solver()) << "    Test net output #" << i <<
-        ": " << output_name << " = " << mean_score << loss_msg_stream.str();
   }
   return false;
+}
+
+void Solver::TestDetection(const int test_net_id) {
+  typedef float Dtype;
+  LOG_IF(INFO, Caffe::root_solver()) << "Iteration " << iter_
+            << ", Testing net (#" << test_net_id << ")";
+  if (!test_nets_[test_net_id]->trained_layers_shared()) {
+    CHECK_NOTNULL(test_nets_[test_net_id].get())->ShareTrainedLayersWith(net_.get());
+  }
+  map<int, map<int, vector<pair<float, int> > > > all_true_pos;
+  map<int, map<int, vector<pair<float, int> > > > all_false_pos;
+  map<int, map<int, int> > all_num_pos;
+  const shared_ptr<Net >& test_net = test_nets_[test_net_id];
+  Dtype loss = 0;
+  for (int i = 0; i < param_.test_iter(test_net_id); ++i) {
+    SolverAction::Enum request = GetRequestedAction();
+    // Check to see if stoppage of testing/training has been requested.
+    while (request != SolverAction::NONE) {
+        if (SolverAction::SNAPSHOT == request) {
+          Snapshot();
+        } else if (SolverAction::STOP == request) {
+          requested_early_exit_ = true;
+        }
+        request = GetRequestedAction();
+    }
+    if (requested_early_exit_) {
+      // break out of test loop.
+      break;
+    }
+
+    Dtype iter_loss;
+    const vector<Blob*>& result = test_net->Forward(&iter_loss);
+    if (param_.test_compute_loss()) {
+      loss += iter_loss;
+    }
+    for (int j = 0; j < result.size(); ++j) {
+      CHECK_EQ(result[j]->width(), 5);
+      const Dtype* result_vec = result[j]->cpu_data<Dtype>();
+      int num_det = result[j]->height();
+      for (int k = 0; k < num_det; ++k) {
+        int item_id = static_cast<int>(result_vec[k * 5]);
+        int label = static_cast<int>(result_vec[k * 5 + 1]);
+        if (item_id == -1) {
+          // Special row of storing number of positives for a label.
+          if (all_num_pos[j].find(label) == all_num_pos[j].end()) {
+            all_num_pos[j][label] = static_cast<int>(result_vec[k * 5 + 2]);
+          } else {
+            all_num_pos[j][label] += static_cast<int>(result_vec[k * 5 + 2]);
+          }
+        } else {
+          // Normal row storing detection status.
+          float score = result_vec[k * 5 + 2];
+          int tp = static_cast<int>(result_vec[k * 5 + 3]);
+          int fp = static_cast<int>(result_vec[k * 5 + 4]);
+          if (tp == 0 && fp == 0) {
+            // Ignore such case. It happens when a detection bbox is matched to
+            // a difficult gt bbox and we don't evaluate on difficult gt bbox.
+            continue;
+          }
+          all_true_pos[j][label].push_back(std::make_pair(score, tp));
+          all_false_pos[j][label].push_back(std::make_pair(score, fp));
+        }
+      }
+    }
+  }
+  if (requested_early_exit_) {
+    LOG(INFO)     << "Test interrupted.";
+    return;
+  }
+  if (param_.test_compute_loss()) {
+    loss /= param_.test_iter(test_net_id);
+    LOG(INFO) << "Test loss: " << loss;
+  }
+  for (int i = 0; i < all_true_pos.size(); ++i) {
+    if (all_true_pos.find(i) == all_true_pos.end()) {
+      LOG(FATAL) << "Missing output_blob true_pos: " << i;
+    }
+    const map<int, vector<pair<float, int> > >& true_pos =
+        all_true_pos.find(i)->second;
+    if (all_false_pos.find(i) == all_false_pos.end()) {
+      LOG(FATAL) << "Missing output_blob false_pos: " << i;
+    }
+    const map<int, vector<pair<float, int> > >& false_pos =
+        all_false_pos.find(i)->second;
+    if (all_num_pos.find(i) == all_num_pos.end()) {
+      LOG(FATAL) << "Missing output_blob num_pos: " << i;
+    }
+    const map<int, int>& num_pos = all_num_pos.find(i)->second;
+    map<int, float> APs;
+    float mAP = 0.;
+    // Sort true_pos and false_pos with descend scores.
+    for (map<int, int>::const_iterator it = num_pos.begin();
+         it != num_pos.end(); ++it) {
+      int label = it->first;
+      int label_num_pos = it->second;
+      if (true_pos.find(label) == true_pos.end()) {
+        LOG(WARNING) << "Missing true_pos for label: " << label;
+        continue;
+      }
+      const vector<pair<float, int> >& label_true_pos =
+          true_pos.find(label)->second;
+      if (false_pos.find(label) == false_pos.end()) {
+        LOG(WARNING) << "Missing false_pos for label: " << label;
+        continue;
+      }
+      const vector<pair<float, int> >& label_false_pos =
+          false_pos.find(label)->second;
+      vector<float> prec, rec;
+      ComputeAP(label_true_pos, label_num_pos, label_false_pos,
+                param_.ap_version(), &prec, &rec, &(APs[label]));
+      mAP += APs[label];
+      if (param_.show_per_class_result()) {
+        LOG(INFO) << "class AP " << label << ": " << APs[label];
+      }
+    }
+    mAP /= num_pos.size();
+    const int output_blob_index = test_net->output_blob_indices()[i];
+    const string& output_name = test_net->blob_names()[output_blob_index];
+    LOG(INFO) << "Test net output mAP #" << i << ": " << output_name << " = "
+              << mAP;
+  }
 }
 
 void Solver::Snapshot() {

--- a/src/caffe/util/bbox_util.cpp
+++ b/src/caffe/util/bbox_util.cpp
@@ -317,7 +317,9 @@ Dtype JaccardOverlap(const Dtype* bbox1, const Dtype* bbox2) {
 
 template float JaccardOverlap(const float* bbox1, const float* bbox2);
 template double JaccardOverlap(const double* bbox1, const double* bbox2);
+#ifndef CPU_ONLY
 template float16 JaccardOverlap(const float16* bbox1, const float16* bbox2);
+#endif
 
 float BBoxCoverage(const NormalizedBBox& bbox1, const NormalizedBBox& bbox2) {
   NormalizedBBox intersect_bbox;
@@ -1051,6 +1053,7 @@ template void MineHardExamples(const TBlob<double>& conf_blob,
     int* num_matches, int* num_negs,
     vector<map<int, vector<int> > >* all_match_indices,
     vector<vector<int> >* all_neg_indices);
+#ifndef CPU_ONLY
 template void MineHardExamples(const TBlob<float16>& conf_blob,
     const vector<LabelBBox>& all_loc_preds,
     const map<int, vector<NormalizedBBox> >& all_gt_bboxes,
@@ -1061,7 +1064,7 @@ template void MineHardExamples(const TBlob<float16>& conf_blob,
     int* num_matches, int* num_negs,
     vector<map<int, vector<int> > >* all_match_indices,
     vector<vector<int> >* all_neg_indices);
-
+#endif
 template <typename Dtype>
 void GetGroundTruth(const Dtype* gt_data, const int num_gt,
       const int background_label_id, const bool use_difficult_gt,
@@ -1101,9 +1104,11 @@ template void GetGroundTruth(const float* gt_data, const int num_gt,
 template void GetGroundTruth(const double* gt_data, const int num_gt,
       const int background_label_id, const bool use_difficult_gt,
       map<int, vector<NormalizedBBox> >* all_gt_bboxes);
+#ifndef CPU_ONLY
 template void GetGroundTruth(const float16* gt_data, const int num_gt,
       const int background_label_id, const bool use_difficult_gt,
       map<int, vector<NormalizedBBox> >* all_gt_bboxes);
+#endif
 
 template <typename Dtype>
 void GetGroundTruth(const Dtype* gt_data, const int num_gt,
@@ -1143,10 +1148,11 @@ template void GetGroundTruth(const float* gt_data, const int num_gt,
 template void GetGroundTruth(const double* gt_data, const int num_gt,
       const int background_label_id, const bool use_difficult_gt,
       map<int, LabelBBox>* all_gt_bboxes);
+#ifndef CPU_ONLY
 template void GetGroundTruth(const float16* gt_data, const int num_gt,
       const int background_label_id, const bool use_difficult_gt,
       map<int, LabelBBox>* all_gt_bboxes);
-
+#endif
 template <typename Dtype>
 void GetLocPredictions(const Dtype* loc_data, const int num,
       const int num_preds_per_class, const int num_loc_classes,
@@ -1182,10 +1188,11 @@ template void GetLocPredictions(const float* loc_data, const int num,
 template void GetLocPredictions(const double* loc_data, const int num,
       const int num_preds_per_class, const int num_loc_classes,
       const bool share_location, vector<LabelBBox>* loc_preds);
+#ifndef CPU_ONLY
 template void GetLocPredictions(const float16* loc_data, const int num,
       const int num_preds_per_class, const int num_loc_classes,
       const bool share_location, vector<LabelBBox>* loc_preds);
-
+#endif
 template <typename Dtype>
 void EncodeLocPrediction(const vector<LabelBBox>& all_loc_preds,
       const map<int, vector<NormalizedBBox> >& all_gt_bboxes,
@@ -1288,6 +1295,7 @@ template void EncodeLocPrediction(const vector<LabelBBox>& all_loc_preds,
       const vector<vector<float> >& prior_variances,
       const MultiBoxLossParameter& multibox_loss_param,
       double* loc_pred_data, double* loc_gt_data);
+#ifndef CPU_ONLY
 template void EncodeLocPrediction(const vector<LabelBBox>& all_loc_preds,
       const map<int, vector<NormalizedBBox> >& all_gt_bboxes,
       const vector<map<int, vector<int> > >& all_match_indices,
@@ -1295,7 +1303,7 @@ template void EncodeLocPrediction(const vector<LabelBBox>& all_loc_preds,
       const vector<vector<float> >& prior_variances,
       const MultiBoxLossParameter& multibox_loss_param,
       float16* loc_pred_data, float16* loc_gt_data);
-
+#endif
 template <typename Dtype>
 void ComputeLocLoss(const TBlob<Dtype>& loc_pred, const TBlob<Dtype>& loc_gt,
       const vector<map<int, vector<int> > >& all_match_indices,
@@ -1358,12 +1366,13 @@ template void ComputeLocLoss(const TBlob<double>& loc_pred,
       const vector<map<int, vector<int> > >& all_match_indices,
       const int num, const int num_priors, const LocLossType loc_loss_type,
       vector<vector<float> >* all_loc_loss);
+#ifndef CPU_ONLY
 template void ComputeLocLoss(const TBlob<float16>& loc_pred,
       const TBlob<float16>& loc_gt,
       const vector<map<int, vector<int> > >& all_match_indices,
       const int num, const int num_priors, const LocLossType loc_loss_type,
       vector<vector<float> >* all_loc_loss);
-
+#endif
 template <typename Dtype>
 void GetConfidenceScores(const Dtype* conf_data, const int num,
       const int num_preds_per_class, const int num_classes,
@@ -1389,10 +1398,11 @@ template void GetConfidenceScores(const float* conf_data, const int num,
 template void GetConfidenceScores(const double* conf_data, const int num,
       const int num_preds_per_class, const int num_classes,
       vector<map<int, vector<float> > >* conf_preds);
+#ifndef CPU_ONLY
 template void GetConfidenceScores(const float16* conf_data, const int num,
       const int num_preds_per_class, const int num_classes,
       vector<map<int, vector<float> > >* conf_preds);
-
+#endif
 template <typename Dtype>
 void GetConfidenceScores(const Dtype* conf_data, const int num,
       const int num_preds_per_class, const int num_classes,
@@ -1425,10 +1435,11 @@ template void GetConfidenceScores(const float* conf_data, const int num,
 template void GetConfidenceScores(const double* conf_data, const int num,
       const int num_preds_per_class, const int num_classes,
       const bool class_major, vector<map<int, vector<float> > >* conf_preds);
+#ifndef CPU_ONLY
 template void GetConfidenceScores(const float16* conf_data, const int num,
       const int num_preds_per_class, const int num_classes,
       const bool class_major, vector<map<int, vector<float> > >* conf_preds);
-
+#endif
 template <typename Dtype>
 void ComputeConfLoss(const Dtype* conf_data, const int num,
       const int num_preds_per_class, const int num_classes,
@@ -1487,11 +1498,12 @@ template void ComputeConfLoss(const double* conf_data, const int num,
       const int num_preds_per_class, const int num_classes,
       const int background_label_id, const ConfLossType loss_type,
       vector<vector<float> >* all_conf_loss);
+#ifndef CPU_ONLY
 template void ComputeConfLoss(const float16* conf_data, const int num,
       const int num_preds_per_class, const int num_classes,
       const int background_label_id, const ConfLossType loss_type,
       vector<vector<float> >* all_conf_loss);
-
+#endif
 template <typename Dtype>
 void ComputeConfLoss(const Dtype* conf_data, const int num,
       const int num_preds_per_class, const int num_classes,
@@ -1577,13 +1589,14 @@ template void ComputeConfLoss(const double* conf_data, const int num,
       const vector<map<int, vector<int> > >& all_match_indices,
       const map<int, vector<NormalizedBBox> >& all_gt_bboxes,
       vector<vector<float> >* all_conf_loss);
+#ifndef CPU_ONLY
 template void ComputeConfLoss(const float16* conf_data, const int num,
       const int num_preds_per_class, const int num_classes,
       const int background_label_id, const ConfLossType loss_type,
       const vector<map<int, vector<int> > >& all_match_indices,
       const map<int, vector<NormalizedBBox> >& all_gt_bboxes,
       vector<vector<float> >* all_conf_loss);
-
+#endif
 template <typename Dtype>
 void EncodeConfPrediction(const Dtype* conf_data, const int num,
       const int num_priors, const MultiBoxLossParameter& multibox_loss_param,
@@ -1698,13 +1711,14 @@ template void EncodeConfPrediction(const double* conf_data, const int num,
       const vector<vector<int> >& all_neg_indices,
       const map<int, vector<NormalizedBBox> >& all_gt_bboxes,
       double* conf_pred_data, double* conf_gt_data);
+#ifndef CPU_ONLY
 template void EncodeConfPrediction(const float16* conf_data, const int num,
       const int num_priors, const MultiBoxLossParameter& multibox_loss_param,
       const vector<map<int, vector<int> > >& all_match_indices,
       const vector<vector<int> >& all_neg_indices,
       const map<int, vector<NormalizedBBox> >& all_gt_bboxes,
       float16* conf_pred_data, float16* conf_gt_data);
-
+#endif
 template <typename Dtype>
 void GetPriorBBoxes(const Dtype* prior_data, const int num_priors,
       vector<NormalizedBBox>* prior_bboxes,
@@ -1740,10 +1754,11 @@ template void GetPriorBBoxes(const float* prior_data, const int num_priors,
 template void GetPriorBBoxes(const double* prior_data, const int num_priors,
       vector<NormalizedBBox>* prior_bboxes,
       vector<vector<float> >* prior_variances);
+#ifndef CPU_ONLY
 template void GetPriorBBoxes(const float16* prior_data, const int num_priors,
       vector<NormalizedBBox>* prior_bboxes,
       vector<vector<float> >* prior_variances);
-
+#endif
 template <typename Dtype>
 void GetDetectionResults(const Dtype* det_data, const int num_det,
       const int background_label_id,
@@ -1777,10 +1792,11 @@ template void GetDetectionResults(const float* det_data, const int num_det,
 template void GetDetectionResults(const double* det_data, const int num_det,
       const int background_label_id,
       map<int, map<int, vector<NormalizedBBox> > >* all_detections);
+#ifndef CPU_ONLY
 template void GetDetectionResults(const float16* det_data, const int num_det,
       const int background_label_id,
       map<int, map<int, vector<NormalizedBBox> > >* all_detections);
-
+#endif
 void GetTopKScoreIndex(const vector<float>& scores, const vector<int>& indices,
       const int top_k, vector<pair<float, int> >* score_index_vec) {
   CHECK_EQ(scores.size(), indices.size());
@@ -1846,11 +1862,12 @@ template
 void GetMaxScoreIndex(const double* scores, const int num,
       const float threshold, const int top_k,
       vector<pair<double, int> >* score_index_vec);
+#ifndef CPU_ONLY
 template
 void GetMaxScoreIndex(const float16* scores, const int num,
       const float threshold, const int top_k,
       vector<pair<float16, int> >* score_index_vec);
-
+#endif
 void ApplyNMS(const vector<NormalizedBBox>& bboxes, const vector<float>& scores,
       const float threshold, const int top_k, const bool reuse_overlaps,
       map<int, map<int, float> >* overlaps, vector<int>* indices) {
@@ -2040,11 +2057,12 @@ template
 void ApplyNMSFast(const double* bboxes, const double* scores, const int num,
       const float score_threshold, const float nms_threshold,
       const float eta, const int top_k, vector<int>* indices);
+#ifndef CPU_ONLY
 template
 void ApplyNMSFast(const float16* bboxes, const float16* scores, const int num,
       const float score_threshold, const float nms_threshold,
       const float eta, const int top_k, vector<int>* indices);
-
+#endif
 void CumSum(const vector<pair<float, int> >& pairs, vector<int>* cumsum) {
   // Sort the pairs based on first item of the pair.
   vector<pair<float, int> > sort_pairs = pairs;
@@ -2312,13 +2330,14 @@ void VisualizeBBox(const vector<cv::Mat>& images,
                    const float threshold, const vector<cv::Scalar>& colors,
                    const map<int, string>& label_to_display_name,
                    const string& save_file);
+#ifndef CPU_ONLY
 template
 void VisualizeBBox(const vector<cv::Mat>& images,
                    const TBlob<float16>* detections,
                    const float threshold, const vector<cv::Scalar>& colors,
                    const map<int, string>& label_to_display_name,
                    const string& save_file);
-
+#endif
 #endif  // USE_OPENCV
 
 }  // namespace caffe

--- a/src/caffe/util/bbox_util.cpp
+++ b/src/caffe/util/bbox_util.cpp
@@ -1,0 +1,2324 @@
+#include <algorithm>
+#include <csignal>
+#include <ctime>
+#include <functional>
+#include <map>
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "boost/iterator/counting_iterator.hpp"
+
+#include "caffe/util/bbox_util.hpp"
+
+namespace caffe {
+
+bool SortBBoxAscend(const NormalizedBBox& bbox1, const NormalizedBBox& bbox2) {
+  return bbox1.score() < bbox2.score();
+}
+
+bool SortBBoxDescend(const NormalizedBBox& bbox1, const NormalizedBBox& bbox2) {
+  return bbox1.score() > bbox2.score();
+}
+
+template <typename T>
+bool SortScorePairAscend(const pair<float, T>& pair1,
+                         const pair<float, T>& pair2) {
+  return pair1.first < pair2.first;
+}
+
+// Explicit initialization.
+template bool SortScorePairAscend(const pair<float, int>& pair1,
+                                  const pair<float, int>& pair2);
+template bool SortScorePairAscend(const pair<float, pair<int, int> >& pair1,
+                                  const pair<float, pair<int, int> >& pair2);
+
+template <typename T>
+bool SortScorePairDescend(const pair<float, T>& pair1,
+                          const pair<float, T>& pair2) {
+  return pair1.first > pair2.first;
+}
+
+// Explicit initialization.
+template bool SortScorePairDescend(const pair<float, int>& pair1,
+                                   const pair<float, int>& pair2);
+template bool SortScorePairDescend(const pair<float, pair<int, int> >& pair1,
+                                   const pair<float, pair<int, int> >& pair2);
+
+NormalizedBBox UnitBBox() {
+  NormalizedBBox unit_bbox;
+  unit_bbox.set_xmin(0.);
+  unit_bbox.set_ymin(0.);
+  unit_bbox.set_xmax(1.);
+  unit_bbox.set_ymax(1.);
+  return unit_bbox;
+}
+
+bool IsCrossBoundaryBBox(const NormalizedBBox& bbox) {
+  return bbox.xmin() < 0 || bbox.xmin() > 1 ||
+      bbox.ymin() < 0 || bbox.ymin() > 1 ||
+      bbox.xmax() < 0 || bbox.xmax() > 1 ||
+      bbox.ymax() < 0 || bbox.ymax() > 1;
+}
+
+void IntersectBBox(const NormalizedBBox& bbox1, const NormalizedBBox& bbox2,
+                   NormalizedBBox* intersect_bbox) {
+  if (bbox2.xmin() > bbox1.xmax() || bbox2.xmax() < bbox1.xmin() ||
+      bbox2.ymin() > bbox1.ymax() || bbox2.ymax() < bbox1.ymin()) {
+    // Return [0, 0, 0, 0] if there is no intersection.
+    intersect_bbox->set_xmin(0);
+    intersect_bbox->set_ymin(0);
+    intersect_bbox->set_xmax(0);
+    intersect_bbox->set_ymax(0);
+  } else {
+    intersect_bbox->set_xmin(std::max(bbox1.xmin(), bbox2.xmin()));
+    intersect_bbox->set_ymin(std::max(bbox1.ymin(), bbox2.ymin()));
+    intersect_bbox->set_xmax(std::min(bbox1.xmax(), bbox2.xmax()));
+    intersect_bbox->set_ymax(std::min(bbox1.ymax(), bbox2.ymax()));
+  }
+}
+
+float BBoxSize(const NormalizedBBox& bbox, const bool normalized) {
+  if (bbox.xmax() < bbox.xmin() || bbox.ymax() < bbox.ymin()) {
+    // If bbox is invalid (e.g. xmax < xmin or ymax < ymin), return 0.
+    return 0;
+  } else {
+    if (bbox.has_size()) {
+      return bbox.size();
+    } else {
+      float width = bbox.xmax() - bbox.xmin();
+      float height = bbox.ymax() - bbox.ymin();
+      if (normalized) {
+        return width * height;
+      } else {
+        // If bbox is not within range [0, 1].
+        return (width + 1) * (height + 1);
+      }
+    }
+  }
+}
+
+template <typename Dtype>
+Dtype BBoxSize(const Dtype* bbox, const bool normalized) {
+  if (bbox[2] < bbox[0] || bbox[3] < bbox[1]) {
+    // If bbox is invalid (e.g. xmax < xmin or ymax < ymin), return 0.
+    return Dtype(0.);
+  } else {
+    const Dtype width = bbox[2] - bbox[0];
+    const Dtype height = bbox[3] - bbox[1];
+    if (normalized) {
+      return width * height;
+    } else {
+      // If bbox is not within range [0, 1].
+      return (width + 1) * (height + 1);
+    }
+  }
+}
+
+template float BBoxSize(const float* bbox, const bool normalized);
+template double BBoxSize(const double* bbox, const bool normalized);
+
+void ClipBBox(const NormalizedBBox& bbox, NormalizedBBox* clip_bbox) {
+  clip_bbox->set_xmin(std::max(std::min(bbox.xmin(), 1.f), 0.f));
+  clip_bbox->set_ymin(std::max(std::min(bbox.ymin(), 1.f), 0.f));
+  clip_bbox->set_xmax(std::max(std::min(bbox.xmax(), 1.f), 0.f));
+  clip_bbox->set_ymax(std::max(std::min(bbox.ymax(), 1.f), 0.f));
+  clip_bbox->clear_size();
+  clip_bbox->set_size(BBoxSize(*clip_bbox));
+  clip_bbox->set_difficult(bbox.difficult());
+}
+
+void ClipBBox(const NormalizedBBox& bbox, const float height, const float width,
+              NormalizedBBox* clip_bbox) {
+  clip_bbox->set_xmin(std::max(std::min(bbox.xmin(), width), 0.f));
+  clip_bbox->set_ymin(std::max(std::min(bbox.ymin(), height), 0.f));
+  clip_bbox->set_xmax(std::max(std::min(bbox.xmax(), width), 0.f));
+  clip_bbox->set_ymax(std::max(std::min(bbox.ymax(), height), 0.f));
+  clip_bbox->clear_size();
+  clip_bbox->set_size(BBoxSize(*clip_bbox));
+  clip_bbox->set_difficult(bbox.difficult());
+}
+
+void ScaleBBox(const NormalizedBBox& bbox, const int height, const int width,
+               NormalizedBBox* scale_bbox) {
+  scale_bbox->set_xmin(bbox.xmin() * width);
+  scale_bbox->set_ymin(bbox.ymin() * height);
+  scale_bbox->set_xmax(bbox.xmax() * width);
+  scale_bbox->set_ymax(bbox.ymax() * height);
+  scale_bbox->clear_size();
+  bool normalized = !(width > 1 || height > 1);
+  scale_bbox->set_size(BBoxSize(*scale_bbox, normalized));
+  scale_bbox->set_difficult(bbox.difficult());
+}
+
+void OutputBBox(const NormalizedBBox& bbox, const pair<int, int>& img_size,
+                const bool has_resize, const ResizeParameter& resize_param,
+                NormalizedBBox* out_bbox) {
+  const int height = img_size.first;
+  const int width = img_size.second;
+  NormalizedBBox temp_bbox = bbox;
+  if (has_resize && resize_param.resize_mode()) {
+    float resize_height = resize_param.height();
+    CHECK_GT(resize_height, 0);
+    float resize_width = resize_param.width();
+    CHECK_GT(resize_width, 0);
+    float resize_aspect = resize_width / resize_height;
+    int height_scale = resize_param.height_scale();
+    int width_scale = resize_param.width_scale();
+    float aspect = static_cast<float>(width) / height;
+
+    float padding;
+    NormalizedBBox source_bbox;
+    switch (resize_param.resize_mode()) {
+      case ResizeParameter_Resize_mode_WARP:
+        ClipBBox(temp_bbox, &temp_bbox);
+        ScaleBBox(temp_bbox, height, width, out_bbox);
+        break;
+      case ResizeParameter_Resize_mode_FIT_LARGE_SIZE_AND_PAD:
+        if (aspect > resize_aspect) {
+          padding = (resize_height - resize_width / aspect) / 2;
+          source_bbox.set_xmin(0.);
+          source_bbox.set_ymin(padding / resize_height);
+          source_bbox.set_xmax(1.);
+          source_bbox.set_ymax(1. - padding / resize_height);
+        } else {
+          padding = (resize_width - resize_height * aspect) / 2;
+          source_bbox.set_xmin(padding / resize_width);
+          source_bbox.set_ymin(0.);
+          source_bbox.set_xmax(1. - padding / resize_width);
+          source_bbox.set_ymax(1.);
+        }
+        ProjectBBox(source_bbox, bbox, &temp_bbox);
+        ClipBBox(temp_bbox, &temp_bbox);
+        ScaleBBox(temp_bbox, height, width, out_bbox);
+        break;
+      case ResizeParameter_Resize_mode_FIT_SMALL_SIZE:
+        if (height_scale == 0 || width_scale == 0) {
+          ClipBBox(temp_bbox, &temp_bbox);
+          ScaleBBox(temp_bbox, height, width, out_bbox);
+        } else {
+          ScaleBBox(temp_bbox, height_scale, width_scale, out_bbox);
+          ClipBBox(*out_bbox, height, width, out_bbox);
+        }
+        break;
+      default:
+        LOG(FATAL) << "Unknown resize mode.";
+    }
+  } else {
+    // Clip the normalized bbox first.
+    ClipBBox(temp_bbox, &temp_bbox);
+    // Scale the bbox according to the original image size.
+    ScaleBBox(temp_bbox, height, width, out_bbox);
+  }
+}
+
+void LocateBBox(const NormalizedBBox& src_bbox, const NormalizedBBox& bbox,
+                NormalizedBBox* loc_bbox) {
+  float src_width = src_bbox.xmax() - src_bbox.xmin();
+  float src_height = src_bbox.ymax() - src_bbox.ymin();
+  loc_bbox->set_xmin(src_bbox.xmin() + bbox.xmin() * src_width);
+  loc_bbox->set_ymin(src_bbox.ymin() + bbox.ymin() * src_height);
+  loc_bbox->set_xmax(src_bbox.xmin() + bbox.xmax() * src_width);
+  loc_bbox->set_ymax(src_bbox.ymin() + bbox.ymax() * src_height);
+  loc_bbox->set_difficult(bbox.difficult());
+}
+
+bool ProjectBBox(const NormalizedBBox& src_bbox, const NormalizedBBox& bbox,
+                 NormalizedBBox* proj_bbox) {
+  if (bbox.xmin() >= src_bbox.xmax() || bbox.xmax() <= src_bbox.xmin() ||
+      bbox.ymin() >= src_bbox.ymax() || bbox.ymax() <= src_bbox.ymin()) {
+    return false;
+  }
+  float src_width = src_bbox.xmax() - src_bbox.xmin();
+  float src_height = src_bbox.ymax() - src_bbox.ymin();
+  proj_bbox->set_xmin((bbox.xmin() - src_bbox.xmin()) / src_width);
+  proj_bbox->set_ymin((bbox.ymin() - src_bbox.ymin()) / src_height);
+  proj_bbox->set_xmax((bbox.xmax() - src_bbox.xmin()) / src_width);
+  proj_bbox->set_ymax((bbox.ymax() - src_bbox.ymin()) / src_height);
+  proj_bbox->set_difficult(bbox.difficult());
+  ClipBBox(*proj_bbox, proj_bbox);
+  if (BBoxSize(*proj_bbox) > 0) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+void ExtrapolateBBox(const ResizeParameter& param, const int height,
+    const int width, const NormalizedBBox& crop_bbox, NormalizedBBox* bbox) {
+  float height_scale = param.height_scale();
+  float width_scale = param.width_scale();
+  if (height_scale > 0 && width_scale > 0 &&
+      param.resize_mode() == ResizeParameter_Resize_mode_FIT_SMALL_SIZE) {
+    float orig_aspect = static_cast<float>(width) / height;
+    float resize_height = param.height();
+    float resize_width = param.width();
+    float resize_aspect = resize_width / resize_height;
+    if (orig_aspect < resize_aspect) {
+      resize_height = resize_width / orig_aspect;
+    } else {
+      resize_width = resize_height * orig_aspect;
+    }
+    float crop_height = resize_height * (crop_bbox.ymax() - crop_bbox.ymin());
+    float crop_width = resize_width * (crop_bbox.xmax() - crop_bbox.xmin());
+    CHECK_GE(crop_width, width_scale);
+    CHECK_GE(crop_height, height_scale);
+    bbox->set_xmin(bbox->xmin() * crop_width / width_scale);
+    bbox->set_xmax(bbox->xmax() * crop_width / width_scale);
+    bbox->set_ymin(bbox->ymin() * crop_height / height_scale);
+    bbox->set_ymax(bbox->ymax() * crop_height / height_scale);
+  }
+}
+
+float JaccardOverlap(const NormalizedBBox& bbox1, const NormalizedBBox& bbox2,
+                     const bool normalized) {
+  NormalizedBBox intersect_bbox;
+  IntersectBBox(bbox1, bbox2, &intersect_bbox);
+  float intersect_width, intersect_height;
+  if (normalized) {
+    intersect_width = intersect_bbox.xmax() - intersect_bbox.xmin();
+    intersect_height = intersect_bbox.ymax() - intersect_bbox.ymin();
+  } else {
+    intersect_width = intersect_bbox.xmax() - intersect_bbox.xmin() + 1;
+    intersect_height = intersect_bbox.ymax() - intersect_bbox.ymin() + 1;
+  }
+  if (intersect_width > 0 && intersect_height > 0) {
+    float intersect_size = intersect_width * intersect_height;
+    float bbox1_size = BBoxSize(bbox1);
+    float bbox2_size = BBoxSize(bbox2);
+    return intersect_size / (bbox1_size + bbox2_size - intersect_size);
+  } else {
+    return 0.;
+  }
+}
+
+template <typename Dtype>
+Dtype JaccardOverlap(const Dtype* bbox1, const Dtype* bbox2) {
+  if (bbox2[0] > bbox1[2] || bbox2[2] < bbox1[0] ||
+      bbox2[1] > bbox1[3] || bbox2[3] < bbox1[1]) {
+    return Dtype(0.);
+  } else {
+    const Dtype inter_xmin = std::max(bbox1[0], bbox2[0]);
+    const Dtype inter_ymin = std::max(bbox1[1], bbox2[1]);
+    const Dtype inter_xmax = std::min(bbox1[2], bbox2[2]);
+    const Dtype inter_ymax = std::min(bbox1[3], bbox2[3]);
+
+    const Dtype inter_width = inter_xmax - inter_xmin;
+    const Dtype inter_height = inter_ymax - inter_ymin;
+    const Dtype inter_size = inter_width * inter_height;
+
+    const Dtype bbox1_size = BBoxSize(bbox1);
+    const Dtype bbox2_size = BBoxSize(bbox2);
+
+    return inter_size / (bbox1_size + bbox2_size - inter_size);
+  }
+}
+
+template float JaccardOverlap(const float* bbox1, const float* bbox2);
+template double JaccardOverlap(const double* bbox1, const double* bbox2);
+template float16 JaccardOverlap(const float16* bbox1, const float16* bbox2);
+
+float BBoxCoverage(const NormalizedBBox& bbox1, const NormalizedBBox& bbox2) {
+  NormalizedBBox intersect_bbox;
+  IntersectBBox(bbox1, bbox2, &intersect_bbox);
+  float intersect_size = BBoxSize(intersect_bbox);
+  if (intersect_size > 0) {
+    float bbox1_size = BBoxSize(bbox1);
+    return intersect_size / bbox1_size;
+  } else {
+    return 0.;
+  }
+}
+
+bool MeetEmitConstraint(const NormalizedBBox& src_bbox,
+                        const NormalizedBBox& bbox,
+                        const EmitConstraint& emit_constraint) {
+  EmitType emit_type = emit_constraint.emit_type();
+  if (emit_type == EmitConstraint_EmitType_CENTER) {
+    float x_center = (bbox.xmin() + bbox.xmax()) / 2;
+    float y_center = (bbox.ymin() + bbox.ymax()) / 2;
+    if (x_center >= src_bbox.xmin() && x_center <= src_bbox.xmax() &&
+        y_center >= src_bbox.ymin() && y_center <= src_bbox.ymax()) {
+      return true;
+    } else {
+      return false;
+    }
+  } else if (emit_type == EmitConstraint_EmitType_MIN_OVERLAP) {
+    float bbox_coverage = BBoxCoverage(bbox, src_bbox);
+    return bbox_coverage > emit_constraint.emit_overlap();
+  } else {
+    LOG(FATAL) << "Unknown emit type.";
+    return false;
+  }
+}
+
+void EncodeBBox(
+    const NormalizedBBox& prior_bbox, const vector<float>& prior_variance,
+    const CodeType code_type, const bool encode_variance_in_target,
+    const NormalizedBBox& bbox, NormalizedBBox* encode_bbox) {
+  if (code_type == PriorBoxParameter_CodeType_CORNER) {
+    if (encode_variance_in_target) {
+      encode_bbox->set_xmin(bbox.xmin() - prior_bbox.xmin());
+      encode_bbox->set_ymin(bbox.ymin() - prior_bbox.ymin());
+      encode_bbox->set_xmax(bbox.xmax() - prior_bbox.xmax());
+      encode_bbox->set_ymax(bbox.ymax() - prior_bbox.ymax());
+    } else {
+      // Encode variance in bbox.
+      CHECK_EQ(prior_variance.size(), 4);
+      for (int i = 0; i < prior_variance.size(); ++i) {
+        CHECK_GT(prior_variance[i], 0);
+      }
+      encode_bbox->set_xmin(
+          (bbox.xmin() - prior_bbox.xmin()) / prior_variance[0]);
+      encode_bbox->set_ymin(
+          (bbox.ymin() - prior_bbox.ymin()) / prior_variance[1]);
+      encode_bbox->set_xmax(
+          (bbox.xmax() - prior_bbox.xmax()) / prior_variance[2]);
+      encode_bbox->set_ymax(
+          (bbox.ymax() - prior_bbox.ymax()) / prior_variance[3]);
+    }
+  } else if (code_type == PriorBoxParameter_CodeType_CENTER_SIZE) {
+    float prior_width = prior_bbox.xmax() - prior_bbox.xmin();
+    CHECK_GT(prior_width, 0);
+    float prior_height = prior_bbox.ymax() - prior_bbox.ymin();
+    CHECK_GT(prior_height, 0);
+    float prior_center_x = (prior_bbox.xmin() + prior_bbox.xmax()) / 2.;
+    float prior_center_y = (prior_bbox.ymin() + prior_bbox.ymax()) / 2.;
+
+    float bbox_width = bbox.xmax() - bbox.xmin();
+    CHECK_GT(bbox_width, 0);
+    float bbox_height = bbox.ymax() - bbox.ymin();
+    CHECK_GT(bbox_height, 0);
+    float bbox_center_x = (bbox.xmin() + bbox.xmax()) / 2.;
+    float bbox_center_y = (bbox.ymin() + bbox.ymax()) / 2.;
+
+    if (encode_variance_in_target) {
+      encode_bbox->set_xmin((bbox_center_x - prior_center_x) / prior_width);
+      encode_bbox->set_ymin((bbox_center_y - prior_center_y) / prior_height);
+      encode_bbox->set_xmax(log(bbox_width / prior_width));
+      encode_bbox->set_ymax(log(bbox_height / prior_height));
+    } else {
+      // Encode variance in bbox.
+      encode_bbox->set_xmin(
+          (bbox_center_x - prior_center_x) / prior_width / prior_variance[0]);
+      encode_bbox->set_ymin(
+          (bbox_center_y - prior_center_y) / prior_height / prior_variance[1]);
+      encode_bbox->set_xmax(
+          log(bbox_width / prior_width) / prior_variance[2]);
+      encode_bbox->set_ymax(
+          log(bbox_height / prior_height) / prior_variance[3]);
+    }
+  } else if (code_type == PriorBoxParameter_CodeType_CORNER_SIZE) {
+    float prior_width = prior_bbox.xmax() - prior_bbox.xmin();
+    CHECK_GT(prior_width, 0);
+    float prior_height = prior_bbox.ymax() - prior_bbox.ymin();
+    CHECK_GT(prior_height, 0);
+    if (encode_variance_in_target) {
+      encode_bbox->set_xmin((bbox.xmin() - prior_bbox.xmin()) / prior_width);
+      encode_bbox->set_ymin((bbox.ymin() - prior_bbox.ymin()) / prior_height);
+      encode_bbox->set_xmax((bbox.xmax() - prior_bbox.xmax()) / prior_width);
+      encode_bbox->set_ymax((bbox.ymax() - prior_bbox.ymax()) / prior_height);
+    } else {
+      // Encode variance in bbox.
+      CHECK_EQ(prior_variance.size(), 4);
+      for (int i = 0; i < prior_variance.size(); ++i) {
+        CHECK_GT(prior_variance[i], 0);
+      }
+      encode_bbox->set_xmin(
+          (bbox.xmin() - prior_bbox.xmin()) / prior_width / prior_variance[0]);
+      encode_bbox->set_ymin(
+          (bbox.ymin() - prior_bbox.ymin()) / prior_height / prior_variance[1]);
+      encode_bbox->set_xmax(
+          (bbox.xmax() - prior_bbox.xmax()) / prior_width / prior_variance[2]);
+      encode_bbox->set_ymax(
+          (bbox.ymax() - prior_bbox.ymax()) / prior_height / prior_variance[3]);
+    }
+  } else {
+    LOG(FATAL) << "Unknown LocLossType.";
+  }
+}
+
+void DecodeBBox(
+    const NormalizedBBox& prior_bbox, const vector<float>& prior_variance,
+    const CodeType code_type, const bool variance_encoded_in_target,
+    const bool clip_bbox, const NormalizedBBox& bbox,
+    NormalizedBBox* decode_bbox) {
+  if (code_type == PriorBoxParameter_CodeType_CORNER) {
+    if (variance_encoded_in_target) {
+      // variance is encoded in target, we simply need to add the offset
+      // predictions.
+      decode_bbox->set_xmin(prior_bbox.xmin() + bbox.xmin());
+      decode_bbox->set_ymin(prior_bbox.ymin() + bbox.ymin());
+      decode_bbox->set_xmax(prior_bbox.xmax() + bbox.xmax());
+      decode_bbox->set_ymax(prior_bbox.ymax() + bbox.ymax());
+    } else {
+      // variance is encoded in bbox, we need to scale the offset accordingly.
+      decode_bbox->set_xmin(
+          prior_bbox.xmin() + prior_variance[0] * bbox.xmin());
+      decode_bbox->set_ymin(
+          prior_bbox.ymin() + prior_variance[1] * bbox.ymin());
+      decode_bbox->set_xmax(
+          prior_bbox.xmax() + prior_variance[2] * bbox.xmax());
+      decode_bbox->set_ymax(
+          prior_bbox.ymax() + prior_variance[3] * bbox.ymax());
+    }
+  } else if (code_type == PriorBoxParameter_CodeType_CENTER_SIZE) {
+    float prior_width = prior_bbox.xmax() - prior_bbox.xmin();
+    CHECK_GT(prior_width, 0);
+    float prior_height = prior_bbox.ymax() - prior_bbox.ymin();
+    CHECK_GT(prior_height, 0);
+    float prior_center_x = (prior_bbox.xmin() + prior_bbox.xmax()) / 2.;
+    float prior_center_y = (prior_bbox.ymin() + prior_bbox.ymax()) / 2.;
+
+    float decode_bbox_center_x, decode_bbox_center_y;
+    float decode_bbox_width, decode_bbox_height;
+    if (variance_encoded_in_target) {
+      // variance is encoded in target, we simply need to retore the offset
+      // predictions.
+      decode_bbox_center_x = bbox.xmin() * prior_width + prior_center_x;
+      decode_bbox_center_y = bbox.ymin() * prior_height + prior_center_y;
+      decode_bbox_width = exp(bbox.xmax()) * prior_width;
+      decode_bbox_height = exp(bbox.ymax()) * prior_height;
+    } else {
+      // variance is encoded in bbox, we need to scale the offset accordingly.
+      decode_bbox_center_x =
+          prior_variance[0] * bbox.xmin() * prior_width + prior_center_x;
+      decode_bbox_center_y =
+          prior_variance[1] * bbox.ymin() * prior_height + prior_center_y;
+      decode_bbox_width =
+          exp(prior_variance[2] * bbox.xmax()) * prior_width;
+      decode_bbox_height =
+          exp(prior_variance[3] * bbox.ymax()) * prior_height;
+    }
+
+    decode_bbox->set_xmin(decode_bbox_center_x - decode_bbox_width / 2.);
+    decode_bbox->set_ymin(decode_bbox_center_y - decode_bbox_height / 2.);
+    decode_bbox->set_xmax(decode_bbox_center_x + decode_bbox_width / 2.);
+    decode_bbox->set_ymax(decode_bbox_center_y + decode_bbox_height / 2.);
+  } else if (code_type == PriorBoxParameter_CodeType_CORNER_SIZE) {
+    float prior_width = prior_bbox.xmax() - prior_bbox.xmin();
+    CHECK_GT(prior_width, 0);
+    float prior_height = prior_bbox.ymax() - prior_bbox.ymin();
+    CHECK_GT(prior_height, 0);
+    if (variance_encoded_in_target) {
+      // variance is encoded in target, we simply need to add the offset
+      // predictions.
+      decode_bbox->set_xmin(prior_bbox.xmin() + bbox.xmin() * prior_width);
+      decode_bbox->set_ymin(prior_bbox.ymin() + bbox.ymin() * prior_height);
+      decode_bbox->set_xmax(prior_bbox.xmax() + bbox.xmax() * prior_width);
+      decode_bbox->set_ymax(prior_bbox.ymax() + bbox.ymax() * prior_height);
+    } else {
+      // variance is encoded in bbox, we need to scale the offset accordingly.
+      decode_bbox->set_xmin(
+          prior_bbox.xmin() + prior_variance[0] * bbox.xmin() * prior_width);
+      decode_bbox->set_ymin(
+          prior_bbox.ymin() + prior_variance[1] * bbox.ymin() * prior_height);
+      decode_bbox->set_xmax(
+          prior_bbox.xmax() + prior_variance[2] * bbox.xmax() * prior_width);
+      decode_bbox->set_ymax(
+          prior_bbox.ymax() + prior_variance[3] * bbox.ymax() * prior_height);
+    }
+  } else {
+    LOG(FATAL) << "Unknown LocLossType.";
+  }
+  float bbox_size = BBoxSize(*decode_bbox);
+  decode_bbox->set_size(bbox_size);
+  if (clip_bbox) {
+    ClipBBox(*decode_bbox, decode_bbox);
+  }
+}
+
+void DecodeBBoxes(
+    const vector<NormalizedBBox>& prior_bboxes,
+    const vector<vector<float> >& prior_variances,
+    const CodeType code_type, const bool variance_encoded_in_target,
+    const bool clip_bbox, const vector<NormalizedBBox>& bboxes,
+    vector<NormalizedBBox>* decode_bboxes) {
+  CHECK_EQ(prior_bboxes.size(), prior_variances.size());
+  CHECK_EQ(prior_bboxes.size(), bboxes.size());
+  int num_bboxes = prior_bboxes.size();
+  if (num_bboxes >= 1) {
+    CHECK_EQ(prior_variances[0].size(), 4);
+  }
+  decode_bboxes->clear();
+  for (int i = 0; i < num_bboxes; ++i) {
+    NormalizedBBox decode_bbox;
+    DecodeBBox(prior_bboxes[i], prior_variances[i], code_type,
+               variance_encoded_in_target, clip_bbox, bboxes[i], &decode_bbox);
+    decode_bboxes->push_back(decode_bbox);
+  }
+}
+
+void DecodeBBoxesAll(const vector<LabelBBox>& all_loc_preds,
+    const vector<NormalizedBBox>& prior_bboxes,
+    const vector<vector<float> >& prior_variances,
+    const int num, const bool share_location,
+    const int num_loc_classes, const int background_label_id,
+    const CodeType code_type, const bool variance_encoded_in_target,
+    const bool clip, vector<LabelBBox>* all_decode_bboxes) {
+  CHECK_EQ(all_loc_preds.size(), num);
+  all_decode_bboxes->clear();
+  all_decode_bboxes->resize(num);
+  for (int i = 0; i < num; ++i) {
+    // Decode predictions into bboxes.
+    LabelBBox& decode_bboxes = (*all_decode_bboxes)[i];
+    for (int c = 0; c < num_loc_classes; ++c) {
+      int label = share_location ? -1 : c;
+      if (label == background_label_id) {
+        // Ignore background class.
+        continue;
+      }
+      if (all_loc_preds[i].find(label) == all_loc_preds[i].end()) {
+        // Something bad happened if there are no predictions for current label.
+        LOG(FATAL) << "Could not find location predictions for label " << label;
+      }
+      const vector<NormalizedBBox>& label_loc_preds =
+          all_loc_preds[i].find(label)->second;
+      DecodeBBoxes(prior_bboxes, prior_variances,
+                   code_type, variance_encoded_in_target, clip,
+                   label_loc_preds, &(decode_bboxes[label]));
+    }
+  }
+}
+
+void MatchBBox(const vector<NormalizedBBox>& gt_bboxes,
+    const vector<NormalizedBBox>& pred_bboxes, const int label,
+    const MatchType match_type, const float overlap_threshold,
+    const bool ignore_cross_boundary_bbox,
+    vector<int>* match_indices, vector<float>* match_overlaps) {
+  int num_pred = pred_bboxes.size();
+  match_indices->clear();
+  match_indices->resize(num_pred, -1);
+  match_overlaps->clear();
+  match_overlaps->resize(num_pred, 0.);
+
+  int num_gt = 0;
+  vector<int> gt_indices;
+  if (label == -1) {
+    // label -1 means comparing against all ground truth.
+    num_gt = gt_bboxes.size();
+    for (int i = 0; i < num_gt; ++i) {
+      gt_indices.push_back(i);
+    }
+  } else {
+    // Count number of ground truth boxes which has the desired label.
+    for (int i = 0; i < gt_bboxes.size(); ++i) {
+      if (gt_bboxes[i].label() == label) {
+        num_gt++;
+        gt_indices.push_back(i);
+      }
+    }
+  }
+  if (num_gt == 0) {
+    return;
+  }
+
+  // Store the positive overlap between predictions and ground truth.
+  map<int, map<int, float> > overlaps;
+  for (int i = 0; i < num_pred; ++i) {
+    if (ignore_cross_boundary_bbox && IsCrossBoundaryBBox(pred_bboxes[i])) {
+      (*match_indices)[i] = -2;
+      continue;
+    }
+    for (int j = 0; j < num_gt; ++j) {
+      float overlap = JaccardOverlap(pred_bboxes[i], gt_bboxes[gt_indices[j]]);
+      if (overlap > 1e-6) {
+        (*match_overlaps)[i] = std::max((*match_overlaps)[i], overlap);
+        overlaps[i][j] = overlap;
+      }
+    }
+  }
+
+  // Bipartite matching.
+  vector<int> gt_pool;
+  for (int i = 0; i < num_gt; ++i) {
+    gt_pool.push_back(i);
+  }
+  while (gt_pool.size() > 0) {
+    // Find the most overlapped gt and cooresponding predictions.
+    int max_idx = -1;
+    int max_gt_idx = -1;
+    float max_overlap = -1;
+    for (map<int, map<int, float> >::iterator it = overlaps.begin();
+         it != overlaps.end(); ++it) {
+      int i = it->first;
+      if ((*match_indices)[i] != -1) {
+        // The prediction already has matched ground truth or is ignored.
+        continue;
+      }
+      for (int p = 0; p < gt_pool.size(); ++p) {
+        int j = gt_pool[p];
+        if (it->second.find(j) == it->second.end()) {
+          // No overlap between the i-th prediction and j-th ground truth.
+          continue;
+        }
+        // Find the maximum overlapped pair.
+        if (it->second[j] > max_overlap) {
+          // If the prediction has not been matched to any ground truth,
+          // and the overlap is larger than maximum overlap, update.
+          max_idx = i;
+          max_gt_idx = j;
+          max_overlap = it->second[j];
+        }
+      }
+    }
+    if (max_idx == -1) {
+      // Cannot find good match.
+      break;
+    } else {
+      CHECK_EQ((*match_indices)[max_idx], -1);
+      (*match_indices)[max_idx] = gt_indices[max_gt_idx];
+      (*match_overlaps)[max_idx] = max_overlap;
+      // Erase the ground truth.
+      gt_pool.erase(std::find(gt_pool.begin(), gt_pool.end(), max_gt_idx));
+    }
+  }
+
+  switch (match_type) {
+    case MultiBoxLossParameter_MatchType_BIPARTITE:
+      // Already done.
+      break;
+    case MultiBoxLossParameter_MatchType_PER_PREDICTION:
+      // Get most overlaped for the rest prediction bboxes.
+      for (map<int, map<int, float> >::iterator it = overlaps.begin();
+           it != overlaps.end(); ++it) {
+        int i = it->first;
+        if ((*match_indices)[i] != -1) {
+          // The prediction already has matched ground truth or is ignored.
+          continue;
+        }
+        int max_gt_idx = -1;
+        float max_overlap = -1;
+        for (int j = 0; j < num_gt; ++j) {
+          if (it->second.find(j) == it->second.end()) {
+            // No overlap between the i-th prediction and j-th ground truth.
+            continue;
+          }
+          // Find the maximum overlapped pair.
+          float overlap = it->second[j];
+          if (overlap >= overlap_threshold && overlap > max_overlap) {
+            // If the prediction has not been matched to any ground truth,
+            // and the overlap is larger than maximum overlap, update.
+            max_gt_idx = j;
+            max_overlap = overlap;
+          }
+        }
+        if (max_gt_idx != -1) {
+          // Found a matched ground truth.
+          CHECK_EQ((*match_indices)[i], -1);
+          (*match_indices)[i] = gt_indices[max_gt_idx];
+          (*match_overlaps)[i] = max_overlap;
+        }
+      }
+      break;
+    default:
+      LOG(FATAL) << "Unknown matching type.";
+      break;
+  }
+
+  return;
+}
+
+void FindMatches(const vector<LabelBBox>& all_loc_preds,
+      const map<int, vector<NormalizedBBox> >& all_gt_bboxes,
+      const vector<NormalizedBBox>& prior_bboxes,
+      const vector<vector<float> >& prior_variances,
+      const MultiBoxLossParameter& multibox_loss_param,
+      vector<map<int, vector<float> > >* all_match_overlaps,
+      vector<map<int, vector<int> > >* all_match_indices) {
+  // all_match_overlaps->clear();
+  // all_match_indices->clear();
+  // Get parameters.
+  CHECK(multibox_loss_param.has_num_classes()) << "Must provide num_classes.";
+  const int num_classes = multibox_loss_param.num_classes();
+  CHECK_GE(num_classes, 1) << "num_classes should not be less than 1.";
+  const bool share_location = multibox_loss_param.share_location();
+  const int loc_classes = share_location ? 1 : num_classes;
+  const MatchType match_type = multibox_loss_param.match_type();
+  const float overlap_threshold = multibox_loss_param.overlap_threshold();
+  const bool use_prior_for_matching =
+      multibox_loss_param.use_prior_for_matching();
+  const int background_label_id = multibox_loss_param.background_label_id();
+  const CodeType code_type = multibox_loss_param.code_type();
+  const bool encode_variance_in_target =
+      multibox_loss_param.encode_variance_in_target();
+  const bool ignore_cross_boundary_bbox =
+      multibox_loss_param.ignore_cross_boundary_bbox();
+  // Find the matches.
+  int num = all_loc_preds.size();
+  for (int i = 0; i < num; ++i) {
+    map<int, vector<int> > match_indices;
+    map<int, vector<float> > match_overlaps;
+    // Check if there is ground truth for current image.
+    if (all_gt_bboxes.find(i) == all_gt_bboxes.end()) {
+      // There is no gt for current image. All predictions are negative.
+      all_match_indices->push_back(match_indices);
+      all_match_overlaps->push_back(match_overlaps);
+      continue;
+    }
+    // Find match between predictions and ground truth.
+    const vector<NormalizedBBox>& gt_bboxes = all_gt_bboxes.find(i)->second;
+    if (!use_prior_for_matching) {
+      for (int c = 0; c < loc_classes; ++c) {
+        int label = share_location ? -1 : c;
+        if (!share_location && label == background_label_id) {
+          // Ignore background loc predictions.
+          continue;
+        }
+        // Decode the prediction into bbox first.
+        vector<NormalizedBBox> loc_bboxes;
+        bool clip_bbox = false;
+        DecodeBBoxes(prior_bboxes, prior_variances,
+                     code_type, encode_variance_in_target, clip_bbox,
+                     all_loc_preds[i].find(label)->second, &loc_bboxes);
+        MatchBBox(gt_bboxes, loc_bboxes, label, match_type,
+                  overlap_threshold, ignore_cross_boundary_bbox,
+                  &match_indices[label], &match_overlaps[label]);
+      }
+    } else {
+      // Use prior bboxes to match against all ground truth.
+      vector<int> temp_match_indices;
+      vector<float> temp_match_overlaps;
+      const int label = -1;
+      MatchBBox(gt_bboxes, prior_bboxes, label, match_type, overlap_threshold,
+                ignore_cross_boundary_bbox, &temp_match_indices,
+                &temp_match_overlaps);
+      if (share_location) {
+        match_indices[label] = temp_match_indices;
+        match_overlaps[label] = temp_match_overlaps;
+      } else {
+        // Get ground truth label for each ground truth bbox.
+        vector<int> gt_labels;
+        for (int g = 0; g < gt_bboxes.size(); ++g) {
+          gt_labels.push_back(gt_bboxes[g].label());
+        }
+        // Distribute the matching results to different loc_class.
+        for (int c = 0; c < loc_classes; ++c) {
+          if (c == background_label_id) {
+            // Ignore background loc predictions.
+            continue;
+          }
+          match_indices[c].resize(temp_match_indices.size(), -1);
+          match_overlaps[c] = temp_match_overlaps;
+          for (int m = 0; m < temp_match_indices.size(); ++m) {
+            if (temp_match_indices[m] > -1) {
+              const int gt_idx = temp_match_indices[m];
+              CHECK_LT(gt_idx, gt_labels.size());
+              if (c == gt_labels[gt_idx]) {
+                match_indices[c][m] = gt_idx;
+              }
+            }
+          }
+        }
+      }
+    }
+    all_match_indices->push_back(match_indices);
+    all_match_overlaps->push_back(match_overlaps);
+  }
+}
+
+int CountNumMatches(const vector<map<int, vector<int> > >& all_match_indices,
+                    const int num) {
+  int num_matches = 0;
+  for (int i = 0; i < num; ++i) {
+    const map<int, vector<int> >& match_indices = all_match_indices[i];
+    for (map<int, vector<int> >::const_iterator it = match_indices.begin();
+         it != match_indices.end(); ++it) {
+      const vector<int>& match_index = it->second;
+      for (int m = 0; m < match_index.size(); ++m) {
+        if (match_index[m] > -1) {
+          ++num_matches;
+        }
+      }
+    }
+  }
+  return num_matches;
+}
+
+inline bool IsEligibleMining(const MiningType mining_type, const int match_idx,
+    const float match_overlap, const float neg_overlap) {
+  if (mining_type == MultiBoxLossParameter_MiningType_MAX_NEGATIVE) {
+    return match_idx == -1 && match_overlap < neg_overlap;
+  } else if (mining_type == MultiBoxLossParameter_MiningType_HARD_EXAMPLE) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+template <typename Dtype>
+void MineHardExamples(const TBlob<Dtype>& conf_blob,
+    const vector<LabelBBox>& all_loc_preds,
+    const map<int, vector<NormalizedBBox> >& all_gt_bboxes,
+    const vector<NormalizedBBox>& prior_bboxes,
+    const vector<vector<float> >& prior_variances,
+    const vector<map<int, vector<float> > >& all_match_overlaps,
+    const MultiBoxLossParameter& multibox_loss_param,
+    int* num_matches, int* num_negs,
+    vector<map<int, vector<int> > >* all_match_indices,
+    vector<vector<int> >* all_neg_indices) {
+  int num = all_loc_preds.size();
+  // CHECK_EQ(num, all_match_overlaps.size());
+  // CHECK_EQ(num, all_match_indices->size());
+  // all_neg_indices->clear();
+  *num_matches = CountNumMatches(*all_match_indices, num);
+  *num_negs = 0;
+  int num_priors = prior_bboxes.size();
+  CHECK_EQ(num_priors, prior_variances.size());
+  // Get parameters.
+  CHECK(multibox_loss_param.has_num_classes()) << "Must provide num_classes.";
+  const int num_classes = multibox_loss_param.num_classes();
+  CHECK_GE(num_classes, 1) << "num_classes should not be less than 1.";
+  const int background_label_id = multibox_loss_param.background_label_id();
+  const bool use_prior_for_nms = multibox_loss_param.use_prior_for_nms();
+  const ConfLossType conf_loss_type = multibox_loss_param.conf_loss_type();
+  const MiningType mining_type = multibox_loss_param.mining_type();
+  if (mining_type == MultiBoxLossParameter_MiningType_NONE) {
+    return;
+  }
+  const LocLossType loc_loss_type = multibox_loss_param.loc_loss_type();
+  const float neg_pos_ratio = multibox_loss_param.neg_pos_ratio();
+  const float neg_overlap = multibox_loss_param.neg_overlap();
+  const CodeType code_type = multibox_loss_param.code_type();
+  const bool encode_variance_in_target =
+      multibox_loss_param.encode_variance_in_target();
+  const bool has_nms_param = multibox_loss_param.has_nms_param();
+  float nms_threshold = 0;
+  int top_k = -1;
+  if (has_nms_param) {
+    nms_threshold = multibox_loss_param.nms_param().nms_threshold();
+    top_k = multibox_loss_param.nms_param().top_k();
+  }
+  const int sample_size = multibox_loss_param.sample_size();
+  // Compute confidence losses based on matching results.
+  vector<vector<float> > all_conf_loss;
+#ifdef CPU_ONLY
+  ComputeConfLoss(conf_blob.cpu_data(), num, num_priors, num_classes,
+      background_label_id, conf_loss_type, *all_match_indices, all_gt_bboxes,
+      &all_conf_loss);
+#else
+  ComputeConfLossGPU(conf_blob, num, num_priors, num_classes,
+      background_label_id, conf_loss_type, *all_match_indices, all_gt_bboxes,
+      &all_conf_loss);
+#endif
+  vector<vector<float> > all_loc_loss;
+  if (mining_type == MultiBoxLossParameter_MiningType_HARD_EXAMPLE) {
+    // Compute localization losses based on matching results.
+    TBlob<Dtype> loc_pred, loc_gt;
+    if (*num_matches != 0) {
+      vector<int> loc_shape(2, 1);
+      loc_shape[1] = *num_matches * 4;
+      loc_pred.Reshape(loc_shape);
+      loc_gt.Reshape(loc_shape);
+      Dtype* loc_pred_data = loc_pred.mutable_cpu_data();
+      Dtype* loc_gt_data = loc_gt.mutable_cpu_data();
+      EncodeLocPrediction(all_loc_preds, all_gt_bboxes, *all_match_indices,
+                          prior_bboxes, prior_variances, multibox_loss_param,
+                          loc_pred_data, loc_gt_data);
+    }
+    ComputeLocLoss(loc_pred, loc_gt, *all_match_indices, num,
+                   num_priors, loc_loss_type, &all_loc_loss);
+  } else {
+    // No localization loss.
+    for (int i = 0; i < num; ++i) {
+      vector<float> loc_loss(num_priors, 0.f);
+      all_loc_loss.push_back(loc_loss);
+    }
+  }
+  for (int i = 0; i < num; ++i) {
+    map<int, vector<int> >& match_indices = (*all_match_indices)[i];
+    const map<int, vector<float> >& match_overlaps = all_match_overlaps[i];
+    // loc + conf loss.
+    const vector<float>& conf_loss = all_conf_loss[i];
+    const vector<float>& loc_loss = all_loc_loss[i];
+    vector<float> loss;
+    std::transform(conf_loss.begin(), conf_loss.end(), loc_loss.begin(),
+                   std::back_inserter(loss), std::plus<float>());
+    // Pick negatives or hard examples based on loss.
+    set<int> sel_indices;
+    vector<int> neg_indices;
+    for (map<int, vector<int> >::iterator it = match_indices.begin();
+         it != match_indices.end(); ++it) {
+      const int label = it->first;
+      int num_sel = 0;
+      // Get potential indices and loss pairs.
+      vector<pair<float, int> > loss_indices;
+      for (int m = 0; m < match_indices[label].size(); ++m) {
+        if (IsEligibleMining(mining_type, match_indices[label][m],
+            match_overlaps.find(label)->second[m], neg_overlap)) {
+          loss_indices.push_back(std::make_pair(loss[m], m));
+          ++num_sel;
+        }
+      }
+      if (mining_type == MultiBoxLossParameter_MiningType_MAX_NEGATIVE) {
+        int num_pos = 0;
+        for (int m = 0; m < match_indices[label].size(); ++m) {
+          if (match_indices[label][m] > -1) {
+            ++num_pos;
+          }
+        }
+        num_sel = std::min(static_cast<int>(num_pos * neg_pos_ratio), num_sel);
+      } else if (mining_type == MultiBoxLossParameter_MiningType_HARD_EXAMPLE) {
+        CHECK_GT(sample_size, 0);
+        num_sel = std::min(sample_size, num_sel);
+      }
+      // Select samples.
+      if (has_nms_param && nms_threshold > 0) {
+        // Do nms before selecting samples.
+        vector<float> sel_loss;
+        vector<NormalizedBBox> sel_bboxes;
+        if (use_prior_for_nms) {
+          for (int m = 0; m < match_indices[label].size(); ++m) {
+            if (IsEligibleMining(mining_type, match_indices[label][m],
+                match_overlaps.find(label)->second[m], neg_overlap)) {
+              sel_loss.push_back(loss[m]);
+              sel_bboxes.push_back(prior_bboxes[m]);
+            }
+          }
+        } else {
+          // Decode the prediction into bbox first.
+          vector<NormalizedBBox> loc_bboxes;
+          bool clip_bbox = false;
+          DecodeBBoxes(prior_bboxes, prior_variances,
+                       code_type, encode_variance_in_target, clip_bbox,
+                       all_loc_preds[i].find(label)->second, &loc_bboxes);
+          for (int m = 0; m < match_indices[label].size(); ++m) {
+            if (IsEligibleMining(mining_type, match_indices[label][m],
+                match_overlaps.find(label)->second[m], neg_overlap)) {
+              sel_loss.push_back(loss[m]);
+              sel_bboxes.push_back(loc_bboxes[m]);
+            }
+          }
+        }
+        // Do non-maximum suppression based on the loss.
+        vector<int> nms_indices;
+        ApplyNMS(sel_bboxes, sel_loss, nms_threshold, top_k, &nms_indices);
+        if (nms_indices.size() < num_sel) {
+          LOG(INFO) << "not enough sample after nms: " << nms_indices.size();
+        }
+        // Pick top example indices after nms.
+        num_sel = std::min(static_cast<int>(nms_indices.size()), num_sel);
+        for (int n = 0; n < num_sel; ++n) {
+          sel_indices.insert(loss_indices[nms_indices[n]].second);
+        }
+      } else {
+        // Pick top example indices based on loss.
+        std::sort(loss_indices.begin(), loss_indices.end(),
+                  SortScorePairDescend<int>);
+        for (int n = 0; n < num_sel; ++n) {
+          sel_indices.insert(loss_indices[n].second);
+        }
+      }
+      // Update the match_indices and select neg_indices.
+      for (int m = 0; m < match_indices[label].size(); ++m) {
+        if (match_indices[label][m] > -1) {
+          if (mining_type == MultiBoxLossParameter_MiningType_HARD_EXAMPLE &&
+              sel_indices.find(m) == sel_indices.end()) {
+            match_indices[label][m] = -1;
+            *num_matches -= 1;
+          }
+        } else if (match_indices[label][m] == -1) {
+          if (sel_indices.find(m) != sel_indices.end()) {
+            neg_indices.push_back(m);
+            *num_negs += 1;
+          }
+        }
+      }
+    }
+    all_neg_indices->push_back(neg_indices);
+  }
+}
+
+// Explicite initialization.
+template void MineHardExamples(const TBlob<float>& conf_blob,
+    const vector<LabelBBox>& all_loc_preds,
+    const map<int, vector<NormalizedBBox> >& all_gt_bboxes,
+    const vector<NormalizedBBox>& prior_bboxes,
+    const vector<vector<float> >& prior_variances,
+    const vector<map<int, vector<float> > >& all_match_overlaps,
+    const MultiBoxLossParameter& multibox_loss_param,
+    int* num_matches, int* num_negs,
+    vector<map<int, vector<int> > >* all_match_indices,
+    vector<vector<int> >* all_neg_indices);
+template void MineHardExamples(const TBlob<double>& conf_blob,
+    const vector<LabelBBox>& all_loc_preds,
+    const map<int, vector<NormalizedBBox> >& all_gt_bboxes,
+    const vector<NormalizedBBox>& prior_bboxes,
+    const vector<vector<float> >& prior_variances,
+    const vector<map<int, vector<float> > >& all_match_overlaps,
+    const MultiBoxLossParameter& multibox_loss_param,
+    int* num_matches, int* num_negs,
+    vector<map<int, vector<int> > >* all_match_indices,
+    vector<vector<int> >* all_neg_indices);
+template void MineHardExamples(const TBlob<float16>& conf_blob,
+    const vector<LabelBBox>& all_loc_preds,
+    const map<int, vector<NormalizedBBox> >& all_gt_bboxes,
+    const vector<NormalizedBBox>& prior_bboxes,
+    const vector<vector<float> >& prior_variances,
+    const vector<map<int, vector<float> > >& all_match_overlaps,
+    const MultiBoxLossParameter& multibox_loss_param,
+    int* num_matches, int* num_negs,
+    vector<map<int, vector<int> > >* all_match_indices,
+    vector<vector<int> >* all_neg_indices);
+
+template <typename Dtype>
+void GetGroundTruth(const Dtype* gt_data, const int num_gt,
+      const int background_label_id, const bool use_difficult_gt,
+      map<int, vector<NormalizedBBox> >* all_gt_bboxes) {
+  all_gt_bboxes->clear();
+  for (int i = 0; i < num_gt; ++i) {
+    int start_idx = i * 8;
+    int item_id = gt_data[start_idx];
+    if (item_id == -1) {
+      continue;
+    }
+    int label = gt_data[start_idx + 1];
+    CHECK_NE(background_label_id, label)
+        << "Found background label in the dataset.";
+    bool difficult = static_cast<bool>(gt_data[start_idx + 7]);
+    if (!use_difficult_gt && difficult) {
+      // Skip reading difficult ground truth.
+      continue;
+    }
+    NormalizedBBox bbox;
+    bbox.set_label(label);
+    bbox.set_xmin(gt_data[start_idx + 3]);
+    bbox.set_ymin(gt_data[start_idx + 4]);
+    bbox.set_xmax(gt_data[start_idx + 5]);
+    bbox.set_ymax(gt_data[start_idx + 6]);
+    bbox.set_difficult(difficult);
+    float bbox_size = BBoxSize(bbox);
+    bbox.set_size(bbox_size);
+    (*all_gt_bboxes)[item_id].push_back(bbox);
+  }
+}
+
+// Explicit initialization.
+template void GetGroundTruth(const float* gt_data, const int num_gt,
+      const int background_label_id, const bool use_difficult_gt,
+      map<int, vector<NormalizedBBox> >* all_gt_bboxes);
+template void GetGroundTruth(const double* gt_data, const int num_gt,
+      const int background_label_id, const bool use_difficult_gt,
+      map<int, vector<NormalizedBBox> >* all_gt_bboxes);
+template void GetGroundTruth(const float16* gt_data, const int num_gt,
+      const int background_label_id, const bool use_difficult_gt,
+      map<int, vector<NormalizedBBox> >* all_gt_bboxes);
+
+template <typename Dtype>
+void GetGroundTruth(const Dtype* gt_data, const int num_gt,
+      const int background_label_id, const bool use_difficult_gt,
+      map<int, LabelBBox>* all_gt_bboxes) {
+  all_gt_bboxes->clear();
+  for (int i = 0; i < num_gt; ++i) {
+    int start_idx = i * 8;
+    int item_id = gt_data[start_idx];
+    if (item_id == -1) {
+      break;
+    }
+    NormalizedBBox bbox;
+    int label = gt_data[start_idx + 1];
+    CHECK_NE(background_label_id, label)
+        << "Found background label in the dataset.";
+    bool difficult = static_cast<bool>(gt_data[start_idx + 7]);
+    if (!use_difficult_gt && difficult) {
+      // Skip reading difficult ground truth.
+      continue;
+    }
+    bbox.set_xmin(gt_data[start_idx + 3]);
+    bbox.set_ymin(gt_data[start_idx + 4]);
+    bbox.set_xmax(gt_data[start_idx + 5]);
+    bbox.set_ymax(gt_data[start_idx + 6]);
+    bbox.set_difficult(difficult);
+    float bbox_size = BBoxSize(bbox);
+    bbox.set_size(bbox_size);
+    (*all_gt_bboxes)[item_id][label].push_back(bbox);
+  }
+}
+
+// Explicit initialization.
+template void GetGroundTruth(const float* gt_data, const int num_gt,
+      const int background_label_id, const bool use_difficult_gt,
+      map<int, LabelBBox>* all_gt_bboxes);
+template void GetGroundTruth(const double* gt_data, const int num_gt,
+      const int background_label_id, const bool use_difficult_gt,
+      map<int, LabelBBox>* all_gt_bboxes);
+template void GetGroundTruth(const float16* gt_data, const int num_gt,
+      const int background_label_id, const bool use_difficult_gt,
+      map<int, LabelBBox>* all_gt_bboxes);
+
+template <typename Dtype>
+void GetLocPredictions(const Dtype* loc_data, const int num,
+      const int num_preds_per_class, const int num_loc_classes,
+      const bool share_location, vector<LabelBBox>* loc_preds) {
+  loc_preds->clear();
+  if (share_location) {
+    CHECK_EQ(num_loc_classes, 1);
+  }
+  loc_preds->resize(num);
+  for (int i = 0; i < num; ++i) {
+    LabelBBox& label_bbox = (*loc_preds)[i];
+    for (int p = 0; p < num_preds_per_class; ++p) {
+      int start_idx = p * num_loc_classes * 4;
+      for (int c = 0; c < num_loc_classes; ++c) {
+        int label = share_location ? -1 : c;
+        if (label_bbox.find(label) == label_bbox.end()) {
+          label_bbox[label].resize(num_preds_per_class);
+        }
+        label_bbox[label][p].set_xmin(loc_data[start_idx + c * 4]);
+        label_bbox[label][p].set_ymin(loc_data[start_idx + c * 4 + 1]);
+        label_bbox[label][p].set_xmax(loc_data[start_idx + c * 4 + 2]);
+        label_bbox[label][p].set_ymax(loc_data[start_idx + c * 4 + 3]);
+      }
+    }
+    loc_data += num_preds_per_class * num_loc_classes * 4;
+  }
+}
+
+// Explicit initialization.
+template void GetLocPredictions(const float* loc_data, const int num,
+      const int num_preds_per_class, const int num_loc_classes,
+      const bool share_location, vector<LabelBBox>* loc_preds);
+template void GetLocPredictions(const double* loc_data, const int num,
+      const int num_preds_per_class, const int num_loc_classes,
+      const bool share_location, vector<LabelBBox>* loc_preds);
+template void GetLocPredictions(const float16* loc_data, const int num,
+      const int num_preds_per_class, const int num_loc_classes,
+      const bool share_location, vector<LabelBBox>* loc_preds);
+
+template <typename Dtype>
+void EncodeLocPrediction(const vector<LabelBBox>& all_loc_preds,
+      const map<int, vector<NormalizedBBox> >& all_gt_bboxes,
+      const vector<map<int, vector<int> > >& all_match_indices,
+      const vector<NormalizedBBox>& prior_bboxes,
+      const vector<vector<float> >& prior_variances,
+      const MultiBoxLossParameter& multibox_loss_param,
+      Dtype* loc_pred_data, Dtype* loc_gt_data) {
+  int num = all_loc_preds.size();
+  // CHECK_EQ(num, all_match_indices.size());
+  // Get parameters.
+  const CodeType code_type = multibox_loss_param.code_type();
+  const bool encode_variance_in_target =
+      multibox_loss_param.encode_variance_in_target();
+  const bool bp_inside = multibox_loss_param.bp_inside();
+  const bool use_prior_for_matching =
+      multibox_loss_param.use_prior_for_matching();
+  int count = 0;
+  for (int i = 0; i < num; ++i) {
+    for (map<int, vector<int> >::const_iterator
+         it = all_match_indices[i].begin();
+         it != all_match_indices[i].end(); ++it) {
+      const int label = it->first;
+      const vector<int>& match_index = it->second;
+      CHECK(all_loc_preds[i].find(label) != all_loc_preds[i].end());
+      const vector<NormalizedBBox>& loc_pred =
+          all_loc_preds[i].find(label)->second;
+      for (int j = 0; j < match_index.size(); ++j) {
+        if (match_index[j] <= -1) {
+          continue;
+        }
+        // Store encoded ground truth.
+        const int gt_idx = match_index[j];
+        CHECK(all_gt_bboxes.find(i) != all_gt_bboxes.end());
+        CHECK_LT(gt_idx, all_gt_bboxes.find(i)->second.size());
+        const NormalizedBBox& gt_bbox = all_gt_bboxes.find(i)->second[gt_idx];
+        NormalizedBBox gt_encode;
+        CHECK_LT(j, prior_bboxes.size());
+        EncodeBBox(prior_bboxes[j], prior_variances[j], code_type,
+                   encode_variance_in_target, gt_bbox, &gt_encode);
+        loc_gt_data[count * 4] = gt_encode.xmin();
+        loc_gt_data[count * 4 + 1] = gt_encode.ymin();
+        loc_gt_data[count * 4 + 2] = gt_encode.xmax();
+        loc_gt_data[count * 4 + 3] = gt_encode.ymax();
+        // Store location prediction.
+        CHECK_LT(j, loc_pred.size());
+        if (bp_inside) {
+          NormalizedBBox match_bbox = prior_bboxes[j];
+          if (!use_prior_for_matching) {
+            const bool clip_bbox = false;
+            DecodeBBox(prior_bboxes[j], prior_variances[j], code_type,
+                       encode_variance_in_target, clip_bbox, loc_pred[j],
+                       &match_bbox);
+          }
+          // When a dimension of match_bbox is outside of image region, use
+          // gt_encode to simulate zero gradient.
+          loc_pred_data[count * 4] =
+              (match_bbox.xmin() < 0 || match_bbox.xmin() > 1) ?
+              gt_encode.xmin() : loc_pred[j].xmin();
+          loc_pred_data[count * 4 + 1] =
+              (match_bbox.ymin() < 0 || match_bbox.ymin() > 1) ?
+              gt_encode.ymin() : loc_pred[j].ymin();
+          loc_pred_data[count * 4 + 2] =
+              (match_bbox.xmax() < 0 || match_bbox.xmax() > 1) ?
+              gt_encode.xmax() : loc_pred[j].xmax();
+          loc_pred_data[count * 4 + 3] =
+              (match_bbox.ymax() < 0 || match_bbox.ymax() > 1) ?
+              gt_encode.ymax() : loc_pred[j].ymax();
+        } else {
+          loc_pred_data[count * 4] = loc_pred[j].xmin();
+          loc_pred_data[count * 4 + 1] = loc_pred[j].ymin();
+          loc_pred_data[count * 4 + 2] = loc_pred[j].xmax();
+          loc_pred_data[count * 4 + 3] = loc_pred[j].ymax();
+        }
+        if (encode_variance_in_target) {
+          for (int k = 0; k < 4; ++k) {
+            CHECK_GT(prior_variances[j][k], 0);
+            loc_pred_data[count * 4 + k] /= prior_variances[j][k];
+            loc_gt_data[count * 4 + k] /= prior_variances[j][k];
+          }
+        }
+        ++count;
+      }
+    }
+  }
+}
+
+// Explicit initialization.
+template void EncodeLocPrediction(const vector<LabelBBox>& all_loc_preds,
+      const map<int, vector<NormalizedBBox> >& all_gt_bboxes,
+      const vector<map<int, vector<int> > >& all_match_indices,
+      const vector<NormalizedBBox>& prior_bboxes,
+      const vector<vector<float> >& prior_variances,
+      const MultiBoxLossParameter& multibox_loss_param,
+      float* loc_pred_data, float* loc_gt_data);
+template void EncodeLocPrediction(const vector<LabelBBox>& all_loc_preds,
+      const map<int, vector<NormalizedBBox> >& all_gt_bboxes,
+      const vector<map<int, vector<int> > >& all_match_indices,
+      const vector<NormalizedBBox>& prior_bboxes,
+      const vector<vector<float> >& prior_variances,
+      const MultiBoxLossParameter& multibox_loss_param,
+      double* loc_pred_data, double* loc_gt_data);
+template void EncodeLocPrediction(const vector<LabelBBox>& all_loc_preds,
+      const map<int, vector<NormalizedBBox> >& all_gt_bboxes,
+      const vector<map<int, vector<int> > >& all_match_indices,
+      const vector<NormalizedBBox>& prior_bboxes,
+      const vector<vector<float> >& prior_variances,
+      const MultiBoxLossParameter& multibox_loss_param,
+      float16* loc_pred_data, float16* loc_gt_data);
+
+template <typename Dtype>
+void ComputeLocLoss(const TBlob<Dtype>& loc_pred, const TBlob<Dtype>& loc_gt,
+      const vector<map<int, vector<int> > >& all_match_indices,
+      const int num, const int num_priors, const LocLossType loc_loss_type,
+      vector<vector<float> >* all_loc_loss) {
+  int loc_count = loc_pred.count();
+  CHECK_EQ(loc_count, loc_gt.count());
+  TBlob<Dtype> diff;
+  const Dtype* diff_data = NULL;
+  if (loc_count != 0) {
+    diff.Reshape(loc_pred.shape());
+    caffe_sub(loc_count, loc_pred.cpu_data(), loc_gt.cpu_data(),
+              diff.mutable_cpu_data());
+    diff_data = diff.cpu_data();
+  }
+  int count = 0;
+  for (int i = 0; i < num; ++i) {
+    vector<float> loc_loss(num_priors, 0.f);
+    for (map<int, vector<int> >::const_iterator
+         it = all_match_indices[i].begin();
+         it != all_match_indices[i].end(); ++it) {
+      const vector<int>& match_index = it->second;
+      CHECK_EQ(num_priors, match_index.size());
+      for (int j = 0; j < match_index.size(); ++j) {
+        if (match_index[j] <= -1) {
+          continue;
+        }
+        Dtype loss = 0;
+        for (int k = 0; k < 4; ++k) {
+          Dtype val = diff_data[count * 4 + k];
+          if (loc_loss_type == MultiBoxLossParameter_LocLossType_SMOOTH_L1) {
+            Dtype abs_val = fabs(val);
+            if (abs_val < 1.) {
+              loss += 0.5 * val * val;
+            } else {
+              loss += abs_val - 0.5;
+            }
+          } else if (loc_loss_type == MultiBoxLossParameter_LocLossType_L2) {
+            loss += 0.5 * val * val;
+          } else {
+            LOG(FATAL) << "Unknown loc loss type.";
+          }
+        }
+        loc_loss[j] = loss;
+        ++count;
+      }
+    }
+    all_loc_loss->push_back(loc_loss);
+  }
+}
+
+// Explicit initialization.
+template void ComputeLocLoss(const TBlob<float>& loc_pred,
+      const TBlob<float>& loc_gt,
+      const vector<map<int, vector<int> > >& all_match_indices,
+      const int num, const int num_priors, const LocLossType loc_loss_type,
+      vector<vector<float> >* all_loc_loss);
+template void ComputeLocLoss(const TBlob<double>& loc_pred,
+      const TBlob<double>& loc_gt,
+      const vector<map<int, vector<int> > >& all_match_indices,
+      const int num, const int num_priors, const LocLossType loc_loss_type,
+      vector<vector<float> >* all_loc_loss);
+template void ComputeLocLoss(const TBlob<float16>& loc_pred,
+      const TBlob<float16>& loc_gt,
+      const vector<map<int, vector<int> > >& all_match_indices,
+      const int num, const int num_priors, const LocLossType loc_loss_type,
+      vector<vector<float> >* all_loc_loss);
+
+template <typename Dtype>
+void GetConfidenceScores(const Dtype* conf_data, const int num,
+      const int num_preds_per_class, const int num_classes,
+      vector<map<int, vector<float> > >* conf_preds) {
+  conf_preds->clear();
+  conf_preds->resize(num);
+  for (int i = 0; i < num; ++i) {
+    map<int, vector<float> >& label_scores = (*conf_preds)[i];
+    for (int p = 0; p < num_preds_per_class; ++p) {
+      int start_idx = p * num_classes;
+      for (int c = 0; c < num_classes; ++c) {
+        label_scores[c].push_back(conf_data[start_idx + c]);
+      }
+    }
+    conf_data += num_preds_per_class * num_classes;
+  }
+}
+
+// Explicit initialization.
+template void GetConfidenceScores(const float* conf_data, const int num,
+      const int num_preds_per_class, const int num_classes,
+      vector<map<int, vector<float> > >* conf_preds);
+template void GetConfidenceScores(const double* conf_data, const int num,
+      const int num_preds_per_class, const int num_classes,
+      vector<map<int, vector<float> > >* conf_preds);
+template void GetConfidenceScores(const float16* conf_data, const int num,
+      const int num_preds_per_class, const int num_classes,
+      vector<map<int, vector<float> > >* conf_preds);
+
+template <typename Dtype>
+void GetConfidenceScores(const Dtype* conf_data, const int num,
+      const int num_preds_per_class, const int num_classes,
+      const bool class_major, vector<map<int, vector<float> > >* conf_preds) {
+  conf_preds->clear();
+  conf_preds->resize(num);
+  for (int i = 0; i < num; ++i) {
+    map<int, vector<float> >& label_scores = (*conf_preds)[i];
+    if (class_major) {
+      for (int c = 0; c < num_classes; ++c) {
+        label_scores[c].assign(conf_data, conf_data + num_preds_per_class);
+        conf_data += num_preds_per_class;
+      }
+    } else {
+      for (int p = 0; p < num_preds_per_class; ++p) {
+        int start_idx = p * num_classes;
+        for (int c = 0; c < num_classes; ++c) {
+          label_scores[c].push_back(conf_data[start_idx + c]);
+        }
+      }
+      conf_data += num_preds_per_class * num_classes;
+    }
+  }
+}
+
+// Explicit initialization.
+template void GetConfidenceScores(const float* conf_data, const int num,
+      const int num_preds_per_class, const int num_classes,
+      const bool class_major, vector<map<int, vector<float> > >* conf_preds);
+template void GetConfidenceScores(const double* conf_data, const int num,
+      const int num_preds_per_class, const int num_classes,
+      const bool class_major, vector<map<int, vector<float> > >* conf_preds);
+template void GetConfidenceScores(const float16* conf_data, const int num,
+      const int num_preds_per_class, const int num_classes,
+      const bool class_major, vector<map<int, vector<float> > >* conf_preds);
+
+template <typename Dtype>
+void ComputeConfLoss(const Dtype* conf_data, const int num,
+      const int num_preds_per_class, const int num_classes,
+      const int background_label_id, const ConfLossType loss_type,
+      vector<vector<float> >* all_conf_loss) {
+  all_conf_loss->clear();
+  for (int i = 0; i < num; ++i) {
+    vector<float> conf_loss;
+    for (int p = 0; p < num_preds_per_class; ++p) {
+      int start_idx = p * num_classes;
+      int label = background_label_id;
+      Dtype loss = 0;
+      if (loss_type == MultiBoxLossParameter_ConfLossType_SOFTMAX) {
+        CHECK_GE(label, 0);
+        CHECK_LT(label, num_classes);
+        // Compute softmax probability.
+        // We need to subtract the max to avoid numerical issues.
+        Dtype maxval = -FLT_MAX;
+        for (int c = 0; c < num_classes; ++c) {
+          maxval = std::max<Dtype>(conf_data[start_idx + c], maxval);
+        }
+        Dtype sum = 0.;
+        for (int c = 0; c < num_classes; ++c) {
+          sum += std::exp(conf_data[start_idx + c] - maxval);
+        }
+        Dtype prob = std::exp(conf_data[start_idx + label] - maxval) / sum;
+        loss = -log(std::max(prob, Dtype(FLT_MIN)));
+      } else if (loss_type == MultiBoxLossParameter_ConfLossType_LOGISTIC) {
+        int target = 0;
+        for (int c = 0; c < num_classes; ++c) {
+          if (c == label) {
+            target = 1;
+          } else {
+            target = 0;
+          }
+          Dtype input = conf_data[start_idx + c];
+          loss -= input * (target - (input >= 0)) -
+              log(1 + exp(input - 2 * input * (input >= 0)));
+        }
+      } else {
+        LOG(FATAL) << "Unknown conf loss type.";
+      }
+      conf_loss.push_back(loss);
+    }
+    conf_data += num_preds_per_class * num_classes;
+    all_conf_loss->push_back(conf_loss);
+  }
+}
+
+// Explicit initialization.
+template void ComputeConfLoss(const float* conf_data, const int num,
+      const int num_preds_per_class, const int num_classes,
+      const int background_label_id, const ConfLossType loss_type,
+      vector<vector<float> >* all_conf_loss);
+template void ComputeConfLoss(const double* conf_data, const int num,
+      const int num_preds_per_class, const int num_classes,
+      const int background_label_id, const ConfLossType loss_type,
+      vector<vector<float> >* all_conf_loss);
+template void ComputeConfLoss(const float16* conf_data, const int num,
+      const int num_preds_per_class, const int num_classes,
+      const int background_label_id, const ConfLossType loss_type,
+      vector<vector<float> >* all_conf_loss);
+
+template <typename Dtype>
+void ComputeConfLoss(const Dtype* conf_data, const int num,
+      const int num_preds_per_class, const int num_classes,
+      const int background_label_id, const ConfLossType loss_type,
+      const vector<map<int, vector<int> > >& all_match_indices,
+      const map<int, vector<NormalizedBBox> >& all_gt_bboxes,
+      vector<vector<float> >* all_conf_loss) {
+  CHECK_LT(background_label_id, num_classes);
+  // CHECK_EQ(num, all_match_indices.size());
+  all_conf_loss->clear();
+  for (int i = 0; i < num; ++i) {
+    vector<float> conf_loss;
+    const map<int, vector<int> >& match_indices = all_match_indices[i];
+    for (int p = 0; p < num_preds_per_class; ++p) {
+      int start_idx = p * num_classes;
+      // Get the label index.
+      int label = background_label_id;
+      for (map<int, vector<int> >::const_iterator it =
+           match_indices.begin(); it != match_indices.end(); ++it) {
+        const vector<int>& match_index = it->second;
+        CHECK_EQ(match_index.size(), num_preds_per_class);
+        if (match_index[p] > -1) {
+          CHECK(all_gt_bboxes.find(i) != all_gt_bboxes.end());
+          const vector<NormalizedBBox>& gt_bboxes =
+              all_gt_bboxes.find(i)->second;
+          CHECK_LT(match_index[p], gt_bboxes.size());
+          label = gt_bboxes[match_index[p]].label();
+          CHECK_GE(label, 0);
+          CHECK_NE(label, background_label_id);
+          CHECK_LT(label, num_classes);
+          // A prior can only be matched to one gt bbox.
+          break;
+        }
+      }
+      Dtype loss = 0;
+      if (loss_type == MultiBoxLossParameter_ConfLossType_SOFTMAX) {
+        CHECK_GE(label, 0);
+        CHECK_LT(label, num_classes);
+        // Compute softmax probability.
+        // We need to subtract the max to avoid numerical issues.
+        Dtype maxval = conf_data[start_idx];
+        for (int c = 1; c < num_classes; ++c) {
+          maxval = std::max<Dtype>(conf_data[start_idx + c], maxval);
+        }
+        Dtype sum = 0.;
+        for (int c = 0; c < num_classes; ++c) {
+          sum += std::exp(conf_data[start_idx + c] - maxval);
+        }
+        Dtype prob = std::exp(conf_data[start_idx + label] - maxval) / sum;
+        loss = -log(std::max(prob, Dtype(FLT_MIN)));
+      } else if (loss_type == MultiBoxLossParameter_ConfLossType_LOGISTIC) {
+        int target = 0;
+        for (int c = 0; c < num_classes; ++c) {
+          if (c == label) {
+            target = 1;
+          } else {
+            target = 0;
+          }
+          Dtype input = conf_data[start_idx + c];
+          loss -= input * (target - (input >= 0)) -
+              log(1 + exp(input - 2 * input * (input >= 0)));
+        }
+      } else {
+        LOG(FATAL) << "Unknown conf loss type.";
+      }
+      conf_loss.push_back(loss);
+    }
+    conf_data += num_preds_per_class * num_classes;
+    all_conf_loss->push_back(conf_loss);
+  }
+}
+
+// Explicit initialization.
+template void ComputeConfLoss(const float* conf_data, const int num,
+      const int num_preds_per_class, const int num_classes,
+      const int background_label_id, const ConfLossType loss_type,
+      const vector<map<int, vector<int> > >& all_match_indices,
+      const map<int, vector<NormalizedBBox> >& all_gt_bboxes,
+      vector<vector<float> >* all_conf_loss);
+template void ComputeConfLoss(const double* conf_data, const int num,
+      const int num_preds_per_class, const int num_classes,
+      const int background_label_id, const ConfLossType loss_type,
+      const vector<map<int, vector<int> > >& all_match_indices,
+      const map<int, vector<NormalizedBBox> >& all_gt_bboxes,
+      vector<vector<float> >* all_conf_loss);
+template void ComputeConfLoss(const float16* conf_data, const int num,
+      const int num_preds_per_class, const int num_classes,
+      const int background_label_id, const ConfLossType loss_type,
+      const vector<map<int, vector<int> > >& all_match_indices,
+      const map<int, vector<NormalizedBBox> >& all_gt_bboxes,
+      vector<vector<float> >* all_conf_loss);
+
+template <typename Dtype>
+void EncodeConfPrediction(const Dtype* conf_data, const int num,
+      const int num_priors, const MultiBoxLossParameter& multibox_loss_param,
+      const vector<map<int, vector<int> > >& all_match_indices,
+      const vector<vector<int> >& all_neg_indices,
+      const map<int, vector<NormalizedBBox> >& all_gt_bboxes,
+      Dtype* conf_pred_data, Dtype* conf_gt_data) {
+  // CHECK_EQ(num, all_match_indices.size());
+  // CHECK_EQ(num, all_neg_indices.size());
+  // Retrieve parameters.
+  CHECK(multibox_loss_param.has_num_classes()) << "Must provide num_classes.";
+  const int num_classes = multibox_loss_param.num_classes();
+  CHECK_GE(num_classes, 1) << "num_classes should not be less than 1.";
+  const int background_label_id = multibox_loss_param.background_label_id();
+  const bool map_object_to_agnostic =
+      multibox_loss_param.map_object_to_agnostic();
+  if (map_object_to_agnostic) {
+    if (background_label_id >= 0) {
+      CHECK_EQ(num_classes, 2);
+    } else {
+      CHECK_EQ(num_classes, 1);
+    }
+  }
+  const MiningType mining_type = multibox_loss_param.mining_type();
+  bool do_neg_mining;
+  if (multibox_loss_param.has_do_neg_mining()) {
+    LOG(WARNING) << "do_neg_mining is deprecated, use mining_type instead.";
+    do_neg_mining = multibox_loss_param.do_neg_mining();
+    CHECK_EQ(do_neg_mining,
+             mining_type != MultiBoxLossParameter_MiningType_NONE);
+  }
+  do_neg_mining = mining_type != MultiBoxLossParameter_MiningType_NONE;
+  const ConfLossType conf_loss_type = multibox_loss_param.conf_loss_type();
+  int count = 0;
+  for (int i = 0; i < num; ++i) {
+    if (all_gt_bboxes.find(i) != all_gt_bboxes.end()) {
+      // Save matched (positive) bboxes scores and labels.
+      const map<int, vector<int> >& match_indices = all_match_indices[i];
+      for (map<int, vector<int> >::const_iterator it =
+          match_indices.begin(); it != match_indices.end(); ++it) {
+        const vector<int>& match_index = it->second;
+        CHECK_EQ(match_index.size(), num_priors);
+        for (int j = 0; j < num_priors; ++j) {
+          if (match_index[j] <= -1) {
+            continue;
+          }
+          const int gt_label = map_object_to_agnostic ?
+            background_label_id + 1 :
+            all_gt_bboxes.find(i)->second[match_index[j]].label();
+          int idx = do_neg_mining ? count : j;
+          switch (conf_loss_type) {
+            case MultiBoxLossParameter_ConfLossType_SOFTMAX:
+              conf_gt_data[idx] = gt_label;
+              break;
+            case MultiBoxLossParameter_ConfLossType_LOGISTIC:
+              conf_gt_data[idx * num_classes + gt_label] = 1;
+              break;
+            default:
+              LOG(FATAL) << "Unknown conf loss type.";
+          }
+          if (do_neg_mining) {
+            // Copy scores for matched bboxes.
+            caffe_copy<Dtype>(num_classes, conf_data + j * num_classes,
+                conf_pred_data + count * num_classes);
+            ++count;
+          }
+        }
+      }
+      // Go to next image.
+      if (do_neg_mining) {
+        // Save negative bboxes scores and labels.
+        for (int n = 0; n < all_neg_indices[i].size(); ++n) {
+          int j = all_neg_indices[i][n];
+          CHECK_LT(j, num_priors);
+          caffe_copy<Dtype>(num_classes, conf_data + j * num_classes,
+              conf_pred_data + count * num_classes);
+          switch (conf_loss_type) {
+            case MultiBoxLossParameter_ConfLossType_SOFTMAX:
+              conf_gt_data[count] = background_label_id;
+              break;
+            case MultiBoxLossParameter_ConfLossType_LOGISTIC:
+              if (background_label_id >= 0 &&
+                  background_label_id < num_classes) {
+                conf_gt_data[count * num_classes + background_label_id] = 1;
+              }
+              break;
+            default:
+              LOG(FATAL) << "Unknown conf loss type.";
+          }
+          ++count;
+        }
+      }
+    }
+    if (do_neg_mining) {
+      conf_data += num_priors * num_classes;
+    } else {
+      conf_gt_data += num_priors;
+    }
+  }
+}
+
+// Explicite initialization.
+template void EncodeConfPrediction(const float* conf_data, const int num,
+      const int num_priors, const MultiBoxLossParameter& multibox_loss_param,
+      const vector<map<int, vector<int> > >& all_match_indices,
+      const vector<vector<int> >& all_neg_indices,
+      const map<int, vector<NormalizedBBox> >& all_gt_bboxes,
+      float* conf_pred_data, float* conf_gt_data);
+template void EncodeConfPrediction(const double* conf_data, const int num,
+      const int num_priors, const MultiBoxLossParameter& multibox_loss_param,
+      const vector<map<int, vector<int> > >& all_match_indices,
+      const vector<vector<int> >& all_neg_indices,
+      const map<int, vector<NormalizedBBox> >& all_gt_bboxes,
+      double* conf_pred_data, double* conf_gt_data);
+template void EncodeConfPrediction(const float16* conf_data, const int num,
+      const int num_priors, const MultiBoxLossParameter& multibox_loss_param,
+      const vector<map<int, vector<int> > >& all_match_indices,
+      const vector<vector<int> >& all_neg_indices,
+      const map<int, vector<NormalizedBBox> >& all_gt_bboxes,
+      float16* conf_pred_data, float16* conf_gt_data);
+
+template <typename Dtype>
+void GetPriorBBoxes(const Dtype* prior_data, const int num_priors,
+      vector<NormalizedBBox>* prior_bboxes,
+      vector<vector<float> >* prior_variances) {
+  prior_bboxes->clear();
+  prior_variances->clear();
+  for (int i = 0; i < num_priors; ++i) {
+    int start_idx = i * 4;
+    NormalizedBBox bbox;
+    bbox.set_xmin(prior_data[start_idx]);
+    bbox.set_ymin(prior_data[start_idx + 1]);
+    bbox.set_xmax(prior_data[start_idx + 2]);
+    bbox.set_ymax(prior_data[start_idx + 3]);
+    float bbox_size = BBoxSize(bbox);
+    bbox.set_size(bbox_size);
+    prior_bboxes->push_back(bbox);
+  }
+
+  for (int i = 0; i < num_priors; ++i) {
+    int start_idx = (num_priors + i) * 4;
+    vector<float> var;
+    for (int j = 0; j < 4; ++j) {
+      var.push_back(prior_data[start_idx + j]);
+    }
+    prior_variances->push_back(var);
+  }
+}
+
+// Explicit initialization.
+template void GetPriorBBoxes(const float* prior_data, const int num_priors,
+      vector<NormalizedBBox>* prior_bboxes,
+      vector<vector<float> >* prior_variances);
+template void GetPriorBBoxes(const double* prior_data, const int num_priors,
+      vector<NormalizedBBox>* prior_bboxes,
+      vector<vector<float> >* prior_variances);
+template void GetPriorBBoxes(const float16* prior_data, const int num_priors,
+      vector<NormalizedBBox>* prior_bboxes,
+      vector<vector<float> >* prior_variances);
+
+template <typename Dtype>
+void GetDetectionResults(const Dtype* det_data, const int num_det,
+      const int background_label_id,
+      map<int, map<int, vector<NormalizedBBox> > >* all_detections) {
+  all_detections->clear();
+  for (int i = 0; i < num_det; ++i) {
+    int start_idx = i * 7;
+    int item_id = det_data[start_idx];
+    if (item_id == -1) {
+      continue;
+    }
+    int label = det_data[start_idx + 1];
+    CHECK_NE(background_label_id, label)
+        << "Found background label in the detection results.";
+    NormalizedBBox bbox;
+    bbox.set_score(det_data[start_idx + 2]);
+    bbox.set_xmin(det_data[start_idx + 3]);
+    bbox.set_ymin(det_data[start_idx + 4]);
+    bbox.set_xmax(det_data[start_idx + 5]);
+    bbox.set_ymax(det_data[start_idx + 6]);
+    float bbox_size = BBoxSize(bbox);
+    bbox.set_size(bbox_size);
+    (*all_detections)[item_id][label].push_back(bbox);
+  }
+}
+
+// Explicit initialization.
+template void GetDetectionResults(const float* det_data, const int num_det,
+      const int background_label_id,
+      map<int, map<int, vector<NormalizedBBox> > >* all_detections);
+template void GetDetectionResults(const double* det_data, const int num_det,
+      const int background_label_id,
+      map<int, map<int, vector<NormalizedBBox> > >* all_detections);
+template void GetDetectionResults(const float16* det_data, const int num_det,
+      const int background_label_id,
+      map<int, map<int, vector<NormalizedBBox> > >* all_detections);
+
+void GetTopKScoreIndex(const vector<float>& scores, const vector<int>& indices,
+      const int top_k, vector<pair<float, int> >* score_index_vec) {
+  CHECK_EQ(scores.size(), indices.size());
+
+  // Generate index score pairs.
+  for (int i = 0; i < scores.size(); ++i) {
+    score_index_vec->push_back(std::make_pair(scores[i], indices[i]));
+  }
+
+  // Sort the score pair according to the scores in descending order
+  std::stable_sort(score_index_vec->begin(), score_index_vec->end(),
+                   SortScorePairDescend<int>);
+
+  // Keep top_k scores if needed.
+  if (top_k > -1 && top_k < score_index_vec->size()) {
+    score_index_vec->resize(top_k);
+  }
+}
+
+void GetMaxScoreIndex(const vector<float>& scores, const float threshold,
+      const int top_k, vector<pair<float, int> >* score_index_vec) {
+  // Generate index score pairs.
+  for (int i = 0; i < scores.size(); ++i) {
+    if (scores[i] > threshold) {
+      score_index_vec->push_back(std::make_pair(scores[i], i));
+    }
+  }
+
+  // Sort the score pair according to the scores in descending order
+  std::stable_sort(score_index_vec->begin(), score_index_vec->end(),
+                   SortScorePairDescend<int>);
+
+  // Keep top_k scores if needed.
+  if (top_k > -1 && top_k < score_index_vec->size()) {
+    score_index_vec->resize(top_k);
+  }
+}
+
+template <typename Dtype>
+void GetMaxScoreIndex(const Dtype* scores, const int num, const float threshold,
+      const int top_k, vector<pair<Dtype, int> >* score_index_vec) {
+  // Generate index score pairs.
+  for (int i = 0; i < num; ++i) {
+    if (scores[i] > threshold) {
+      score_index_vec->push_back(std::make_pair(scores[i], i));
+    }
+  }
+
+  // Sort the score pair according to the scores in descending order
+  std::sort(score_index_vec->begin(), score_index_vec->end(),
+            SortScorePairDescend<int>);
+
+  // Keep top_k scores if needed.
+  if (top_k > -1 && top_k < score_index_vec->size()) {
+    score_index_vec->resize(top_k);
+  }
+}
+
+template
+void GetMaxScoreIndex(const float* scores, const int num, const float threshold,
+      const int top_k, vector<pair<float, int> >* score_index_vec);
+template
+void GetMaxScoreIndex(const double* scores, const int num,
+      const float threshold, const int top_k,
+      vector<pair<double, int> >* score_index_vec);
+template
+void GetMaxScoreIndex(const float16* scores, const int num,
+      const float threshold, const int top_k,
+      vector<pair<float16, int> >* score_index_vec);
+
+void ApplyNMS(const vector<NormalizedBBox>& bboxes, const vector<float>& scores,
+      const float threshold, const int top_k, const bool reuse_overlaps,
+      map<int, map<int, float> >* overlaps, vector<int>* indices) {
+  // Sanity check.
+  CHECK_EQ(bboxes.size(), scores.size())
+      << "bboxes and scores have different size.";
+
+  // Get top_k scores (with corresponding indices).
+  vector<int> idx(boost::counting_iterator<int>(0),
+                  boost::counting_iterator<int>(scores.size()));
+  vector<pair<float, int> > score_index_vec;
+  GetTopKScoreIndex(scores, idx, top_k, &score_index_vec);
+
+  // Do nms.
+  indices->clear();
+  while (score_index_vec.size() != 0) {
+    // Get the current highest score box.
+    int best_idx = score_index_vec.front().second;
+    const NormalizedBBox& best_bbox = bboxes[best_idx];
+    if (BBoxSize(best_bbox) < 1e-5) {
+      // Erase small box.
+      score_index_vec.erase(score_index_vec.begin());
+      continue;
+    }
+    indices->push_back(best_idx);
+    // Erase the best box.
+    score_index_vec.erase(score_index_vec.begin());
+
+    if (top_k > -1 && indices->size() >= top_k) {
+      // Stop if finding enough bboxes for nms.
+      break;
+    }
+
+    // Compute overlap between best_bbox and other remaining bboxes.
+    // Remove a bbox if the overlap with best_bbox is larger than nms_threshold.
+    for (vector<pair<float, int> >::iterator it = score_index_vec.begin();
+         it != score_index_vec.end(); ) {
+      int cur_idx = it->second;
+      const NormalizedBBox& cur_bbox = bboxes[cur_idx];
+      if (BBoxSize(cur_bbox) < 1e-5) {
+        // Erase small box.
+        it = score_index_vec.erase(it);
+        continue;
+      }
+      float cur_overlap = 0.;
+      if (reuse_overlaps) {
+        if (overlaps->find(best_idx) != overlaps->end() &&
+            overlaps->find(best_idx)->second.find(cur_idx) !=
+            (*overlaps)[best_idx].end()) {
+          // Use the computed overlap.
+          cur_overlap = (*overlaps)[best_idx][cur_idx];
+        } else if (overlaps->find(cur_idx) != overlaps->end() &&
+                   overlaps->find(cur_idx)->second.find(best_idx) !=
+                   (*overlaps)[cur_idx].end()) {
+          // Use the computed overlap.
+          cur_overlap = (*overlaps)[cur_idx][best_idx];
+        } else {
+          cur_overlap = JaccardOverlap(best_bbox, cur_bbox);
+          // Store the overlap for future use.
+          (*overlaps)[best_idx][cur_idx] = cur_overlap;
+        }
+      } else {
+        cur_overlap = JaccardOverlap(best_bbox, cur_bbox);
+      }
+
+      // Remove it if necessary
+      if (cur_overlap > threshold) {
+        it = score_index_vec.erase(it);
+      } else {
+        ++it;
+      }
+    }
+  }
+}
+
+void ApplyNMS(const vector<NormalizedBBox>& bboxes, const vector<float>& scores,
+      const float threshold, const int top_k, vector<int>* indices) {
+  bool reuse_overlap = false;
+  map<int, map<int, float> > overlaps;
+  ApplyNMS(bboxes, scores, threshold, top_k, reuse_overlap, &overlaps, indices);
+}
+
+void ApplyNMS(const bool* overlapped, const int num, vector<int>* indices) {
+  vector<int> index_vec(boost::counting_iterator<int>(0),
+                        boost::counting_iterator<int>(num));
+  // Do nms.
+  indices->clear();
+  while (index_vec.size() != 0) {
+    // Get the current highest score box.
+    int best_idx = index_vec.front();
+    indices->push_back(best_idx);
+    // Erase the best box.
+    index_vec.erase(index_vec.begin());
+
+    for (vector<int>::iterator it = index_vec.begin(); it != index_vec.end();) {
+      int cur_idx = *it;
+
+      // Remove it if necessary
+      if (overlapped[best_idx * num + cur_idx]) {
+        it = index_vec.erase(it);
+      } else {
+        ++it;
+      }
+    }
+  }
+}
+
+inline int clamp(const int v, const int a, const int b) {
+  return v < a ? a : v > b ? b : v;
+}
+
+void ApplyNMSFast(const vector<NormalizedBBox>& bboxes,
+      const vector<float>& scores, const float score_threshold,
+      const float nms_threshold, const float eta, const int top_k,
+      vector<int>* indices) {
+  // Sanity check.
+  CHECK_EQ(bboxes.size(), scores.size())
+      << "bboxes and scores have different size.";
+
+  // Get top_k scores (with corresponding indices).
+  vector<pair<float, int> > score_index_vec;
+  GetMaxScoreIndex(scores, score_threshold, top_k, &score_index_vec);
+
+  // Do nms.
+  float adaptive_threshold = nms_threshold;
+  indices->clear();
+  while (score_index_vec.size() != 0) {
+    const int idx = score_index_vec.front().second;
+    bool keep = true;
+    for (int k = 0; k < indices->size(); ++k) {
+      if (keep) {
+        const int kept_idx = (*indices)[k];
+        float overlap = JaccardOverlap(bboxes[idx], bboxes[kept_idx]);
+        keep = overlap <= adaptive_threshold;
+      } else {
+        break;
+      }
+    }
+    if (keep) {
+      indices->push_back(idx);
+    }
+    score_index_vec.erase(score_index_vec.begin());
+    if (keep && eta < 1 && adaptive_threshold > 0.5) {
+      adaptive_threshold *= eta;
+    }
+  }
+}
+
+template <typename Dtype>
+void ApplyNMSFast(const Dtype* bboxes, const Dtype* scores, const int num,
+      const float score_threshold, const float nms_threshold,
+      const float eta, const int top_k, vector<int>* indices) {
+  // Get top_k scores (with corresponding indices).
+  vector<pair<Dtype, int> > score_index_vec;
+  GetMaxScoreIndex(scores, num, score_threshold, top_k, &score_index_vec);
+
+  // Do nms.
+  float adaptive_threshold = nms_threshold;
+  indices->clear();
+  while (score_index_vec.size() != 0) {
+    const int idx = score_index_vec.front().second;
+    bool keep = true;
+    for (int k = 0; k < indices->size(); ++k) {
+      if (keep) {
+        const int kept_idx = (*indices)[k];
+        float overlap = JaccardOverlap(bboxes + idx * 4, bboxes + kept_idx * 4);
+        keep = overlap <= adaptive_threshold;
+      } else {
+        break;
+      }
+    }
+    if (keep) {
+      indices->push_back(idx);
+    }
+    score_index_vec.erase(score_index_vec.begin());
+    if (keep && eta < 1 && adaptive_threshold > 0.5) {
+      adaptive_threshold *= eta;
+    }
+  }
+}
+
+template
+void ApplyNMSFast(const float* bboxes, const float* scores, const int num,
+      const float score_threshold, const float nms_threshold,
+      const float eta, const int top_k, vector<int>* indices);
+template
+void ApplyNMSFast(const double* bboxes, const double* scores, const int num,
+      const float score_threshold, const float nms_threshold,
+      const float eta, const int top_k, vector<int>* indices);
+template
+void ApplyNMSFast(const float16* bboxes, const float16* scores, const int num,
+      const float score_threshold, const float nms_threshold,
+      const float eta, const int top_k, vector<int>* indices);
+
+void CumSum(const vector<pair<float, int> >& pairs, vector<int>* cumsum) {
+  // Sort the pairs based on first item of the pair.
+  vector<pair<float, int> > sort_pairs = pairs;
+  std::stable_sort(sort_pairs.begin(), sort_pairs.end(),
+                   SortScorePairDescend<int>);
+
+  cumsum->clear();
+  for (int i = 0; i < sort_pairs.size(); ++i) {
+    if (i == 0) {
+      cumsum->push_back(sort_pairs[i].second);
+    } else {
+      cumsum->push_back(cumsum->back() + sort_pairs[i].second);
+    }
+  }
+}
+
+void ComputeAP(const vector<pair<float, int> >& tp, const int num_pos,
+               const vector<pair<float, int> >& fp, const string ap_version,
+               vector<float>* prec, vector<float>* rec, float* ap) {
+  const float eps = 1e-6;
+  CHECK_EQ(tp.size(), fp.size()) << "tp must have same size as fp.";
+  const int num = tp.size();
+  // Make sure that tp and fp have complement value.
+  for (int i = 0; i < num; ++i) {
+    CHECK_LE(fabs(tp[i].first - fp[i].first), eps);
+    CHECK_EQ(tp[i].second, 1 - fp[i].second);
+  }
+  prec->clear();
+  rec->clear();
+  *ap = 0;
+  if (tp.size() == 0 || num_pos == 0) {
+    return;
+  }
+
+  // Compute cumsum of tp.
+  vector<int> tp_cumsum;
+  CumSum(tp, &tp_cumsum);
+  CHECK_EQ(tp_cumsum.size(), num);
+
+  // Compute cumsum of fp.
+  vector<int> fp_cumsum;
+  CumSum(fp, &fp_cumsum);
+  CHECK_EQ(fp_cumsum.size(), num);
+
+  // Compute precision.
+  for (int i = 0; i < num; ++i) {
+    prec->push_back(static_cast<float>(tp_cumsum[i]) /
+                    (tp_cumsum[i] + fp_cumsum[i]));
+  }
+
+  // Compute recall.
+  for (int i = 0; i < num; ++i) {
+    CHECK_LE(tp_cumsum[i], num_pos);
+    rec->push_back(static_cast<float>(tp_cumsum[i]) / num_pos);
+  }
+
+  if (ap_version == "11point") {
+    // VOC2007 style for computing AP.
+    vector<float> max_precs(11, 0.);
+    int start_idx = num - 1;
+    for (int j = 10; j >= 0; --j) {
+      for (int i = start_idx; i >= 0 ; --i) {
+        if ((*rec)[i] < j / 10.) {
+          start_idx = i;
+          if (j > 0) {
+            max_precs[j-1] = max_precs[j];
+          }
+          break;
+        } else {
+          if (max_precs[j] < (*prec)[i]) {
+            max_precs[j] = (*prec)[i];
+          }
+        }
+      }
+    }
+    for (int j = 10; j >= 0; --j) {
+      *ap += max_precs[j] / 11;
+    }
+  } else if (ap_version == "MaxIntegral") {
+    // VOC2012 or ILSVRC style for computing AP.
+    float cur_rec = rec->back();
+    float cur_prec = prec->back();
+    for (int i = num - 2; i >= 0; --i) {
+      cur_prec = std::max<float>((*prec)[i], cur_prec);
+      if (fabs(cur_rec - (*rec)[i]) > eps) {
+        *ap += cur_prec * fabs(cur_rec - (*rec)[i]);
+      }
+      cur_rec = (*rec)[i];
+    }
+    *ap += cur_rec * cur_prec;
+  } else if (ap_version == "Integral") {
+    // Natural integral.
+    float prev_rec = 0.;
+    for (int i = 0; i < num; ++i) {
+      if (fabs((*rec)[i] - prev_rec) > eps) {
+        *ap += (*prec)[i] * fabs((*rec)[i] - prev_rec);
+      }
+      prev_rec = (*rec)[i];
+    }
+  } else {
+    LOG(FATAL) << "Unknown ap_version: " << ap_version;
+  }
+}
+
+#ifdef USE_OPENCV
+cv::Scalar HSV2RGB(const float h, const float s, const float v) {
+  const int h_i = static_cast<int>(h * 6);
+  const float f = h * 6 - h_i;
+  const float p = v * (1 - s);
+  const float q = v * (1 - f*s);
+  const float t = v * (1 - (1 - f) * s);
+  float r, g, b;
+  switch (h_i) {
+    case 0:
+      r = v; g = t; b = p;
+      break;
+    case 1:
+      r = q; g = v; b = p;
+      break;
+    case 2:
+      r = p; g = v; b = t;
+      break;
+    case 3:
+      r = p; g = q; b = v;
+      break;
+    case 4:
+      r = t; g = p; b = v;
+      break;
+    case 5:
+      r = v; g = p; b = q;
+      break;
+    default:
+      r = 1; g = 1; b = 1;
+      break;
+  }
+  return cv::Scalar(r * 255, g * 255, b * 255);
+}
+
+// http://martin.ankerl.com/2009/12/09/how-to-create-random-colors-programmatically
+vector<cv::Scalar> GetColors(const int n) {
+  vector<cv::Scalar> colors;
+  cv::RNG rng(12345);
+  const float golden_ratio_conjugate = 0.618033988749895;
+  const float s = 0.3;
+  const float v = 0.99;
+  for (int i = 0; i < n; ++i) {
+    const float h = std::fmod(rng.uniform(0.f, 1.f) + golden_ratio_conjugate,
+                              1.f);
+    colors.push_back(HSV2RGB(h, s, v));
+  }
+  return colors;
+}
+
+static clock_t start_clock = clock();
+static cv::VideoWriter cap_out;
+
+template <typename Dtype>
+void VisualizeBBox(const vector<cv::Mat>& images, const TBlob<Dtype>* detections,
+                   const float threshold, const vector<cv::Scalar>& colors,
+                   const map<int, string>& label_to_display_name,
+                   const string& save_file) {
+  // Retrieve detections.
+  CHECK_EQ(detections->width(), 7);
+  const int num_det = detections->height();
+  const int num_img = images.size();
+  if (num_det == 0 || num_img == 0) {
+    return;
+  }
+  // Comute FPS.
+  float fps = num_img / (static_cast<double>(clock() - start_clock) /
+          CLOCKS_PER_SEC);
+
+  const Dtype* detections_data = detections->cpu_data();
+  const int width = images[0].cols;
+  const int height = images[0].rows;
+  vector<LabelBBox> all_detections(num_img);
+  for (int i = 0; i < num_det; ++i) {
+    const int img_idx = detections_data[i * 7];
+    CHECK_LT(img_idx, num_img);
+    const int label = detections_data[i * 7 + 1];
+    const float score = detections_data[i * 7 + 2];
+    if (score < threshold) {
+      continue;
+    }
+    NormalizedBBox bbox;
+    bbox.set_xmin(detections_data[i * 7 + 3] * width);
+    bbox.set_ymin(detections_data[i * 7 + 4] * height);
+    bbox.set_xmax(detections_data[i * 7 + 5] * width);
+    bbox.set_ymax(detections_data[i * 7 + 6] * height);
+    bbox.set_score(score);
+    all_detections[img_idx][label].push_back(bbox);
+  }
+
+  int fontface = cv::FONT_HERSHEY_SIMPLEX;
+  double scale = 1;
+  int thickness = 2;
+  int baseline = 0;
+  char buffer[50];
+  for (int i = 0; i < num_img; ++i) {
+    cv::Mat image = images[i];
+    // Show FPS.
+    snprintf(buffer, sizeof(buffer), "FPS: %.2f", fps);
+    cv::Size text = cv::getTextSize(buffer, fontface, scale, thickness,
+                                    &baseline);
+    cv::rectangle(image, cv::Point(0, 0),
+                  cv::Point(text.width, text.height + baseline),
+                  CV_RGB(255, 255, 255), CV_FILLED);
+    cv::putText(image, buffer, cv::Point(0, text.height + baseline / 2.),
+                fontface, scale, CV_RGB(0, 0, 0), thickness, 8);
+    // Draw bboxes.
+    for (map<int, vector<NormalizedBBox> >::iterator it =
+         all_detections[i].begin(); it != all_detections[i].end(); ++it) {
+      int label = it->first;
+      string label_name = "Unknown";
+      if (label_to_display_name.find(label) != label_to_display_name.end()) {
+        label_name = label_to_display_name.find(label)->second;
+      }
+      CHECK_LT(label, colors.size());
+      const cv::Scalar& color = colors[label];
+      const vector<NormalizedBBox>& bboxes = it->second;
+      for (int j = 0; j < bboxes.size(); ++j) {
+        cv::Point top_left_pt(bboxes[j].xmin(), bboxes[j].ymin());
+        cv::Point bottom_right_pt(bboxes[j].xmax(), bboxes[j].ymax());
+        cv::rectangle(image, top_left_pt, bottom_right_pt, color, 4);
+        cv::Point bottom_left_pt(bboxes[j].xmin(), bboxes[j].ymax());
+        snprintf(buffer, sizeof(buffer), "%s: %.2f", label_name.c_str(),
+                 bboxes[j].score());
+        cv::Size text = cv::getTextSize(buffer, fontface, scale, thickness,
+                                        &baseline);
+        cv::rectangle(
+            image, bottom_left_pt + cv::Point(0, 0),
+            bottom_left_pt + cv::Point(text.width, -text.height-baseline),
+            color, CV_FILLED);
+        cv::putText(image, buffer, bottom_left_pt - cv::Point(0, baseline),
+                    fontface, scale, CV_RGB(0, 0, 0), thickness, 8);
+      }
+    }
+    // Save result if required.
+    if (!save_file.empty()) {
+      if (!cap_out.isOpened()) {
+        cv::Size size(image.size().width, image.size().height);
+        cv::VideoWriter outputVideo(save_file, CV_FOURCC('D', 'I', 'V', 'X'),
+            30, size, true);
+        cap_out = outputVideo;
+      }
+      cap_out.write(image);
+    }
+    cv::imshow("detections", image);
+    if (cv::waitKey(1) == 27) {
+      raise(SIGINT);
+    }
+  }
+  start_clock = clock();
+}
+
+template
+void VisualizeBBox(const vector<cv::Mat>& images,
+                   const TBlob<float>* detections,
+                   const float threshold, const vector<cv::Scalar>& colors,
+                   const map<int, string>& label_to_display_name,
+                   const string& save_file);
+template
+void VisualizeBBox(const vector<cv::Mat>& images,
+                   const TBlob<double>* detections,
+                   const float threshold, const vector<cv::Scalar>& colors,
+                   const map<int, string>& label_to_display_name,
+                   const string& save_file);
+template
+void VisualizeBBox(const vector<cv::Mat>& images,
+                   const TBlob<float16>* detections,
+                   const float threshold, const vector<cv::Scalar>& colors,
+                   const map<int, string>& label_to_display_name,
+                   const string& save_file);
+
+#endif  // USE_OPENCV
+
+}  // namespace caffe

--- a/src/caffe/util/bbox_util.cu
+++ b/src/caffe/util/bbox_util.cu
@@ -1,0 +1,669 @@
+#include <algorithm>
+#include <functional>
+#include <map>
+#include <vector>
+
+#include "thrust/functional.h"
+#include "thrust/sort.h"
+
+#include "caffe/common.hpp"
+#include "caffe/util/bbox_util.hpp"
+
+namespace caffe {
+
+template <typename Dtype>
+__host__ __device__ Dtype BBoxSizeGPU(const Dtype* bbox,
+    const bool normalized) {
+  if (bbox[2] < bbox[0] || bbox[3] < bbox[1]) {
+    // If bbox is invalid (e.g. xmax < xmin or ymax < ymin), return 0.
+    return Dtype(0.);
+  } else {
+    const Dtype width = bbox[2] - bbox[0];
+    const Dtype height = bbox[3] - bbox[1];
+    if (normalized) {
+      return width * height;
+    } else {
+      // If bbox is not within range [0, 1].
+      return (width + 1) * (height + 1);
+    }
+  }
+}
+
+template __host__ __device__ float BBoxSizeGPU(const float* bbox,
+    const bool normalized);
+template __host__ __device__ double BBoxSizeGPU(const double* bbox,
+    const bool normalized);
+
+template <typename Dtype>
+__host__ __device__ Dtype JaccardOverlapGPU(const Dtype* bbox1,
+    const Dtype* bbox2) {
+  if (bbox2[0] > bbox1[2] || bbox2[2] < bbox1[0] ||
+      bbox2[1] > bbox1[3] || bbox2[3] < bbox1[1]) {
+    return Dtype(0.);
+  } else {
+    const Dtype inter_xmin = max(bbox1[0], bbox2[0]);
+    const Dtype inter_ymin = max(bbox1[1], bbox2[1]);
+    const Dtype inter_xmax = min(bbox1[2], bbox2[2]);
+    const Dtype inter_ymax = min(bbox1[3], bbox2[3]);
+
+    const Dtype inter_width = inter_xmax - inter_xmin;
+    const Dtype inter_height = inter_ymax - inter_ymin;
+    const Dtype inter_size = inter_width * inter_height;
+
+    const Dtype bbox1_size = BBoxSizeGPU(bbox1);
+    const Dtype bbox2_size = BBoxSizeGPU(bbox2);
+
+    return inter_size / (bbox1_size + bbox2_size - inter_size);
+  }
+}
+
+template __host__ __device__ float JaccardOverlapGPU(const float* bbox1,
+    const float* bbox2);
+template __host__ __device__ double JaccardOverlapGPU(const double* bbox1,
+    const double* bbox2);
+
+template <typename Dtype>
+__device__ Dtype Min(const Dtype x, const Dtype y) {
+  return x < y ? x : y;
+}
+
+template <typename Dtype>
+__device__ Dtype Max(const Dtype x, const Dtype y) {
+  return x > y ? x : y;
+}
+
+template <typename Dtype>
+__device__ void ClipBBoxGPU(const Dtype* bbox, Dtype* clip_bbox) {
+  for (int i = 0; i < 4; ++i) {
+    clip_bbox[i] = Max(Min(bbox[i], Dtype(1.)), Dtype(0.));
+  }
+}
+
+template __device__ void ClipBBoxGPU(const float* bbox, float* clip_bbox);
+template __device__ void ClipBBoxGPU(const double* bbox, double* clip_bbox);
+
+template <typename Dtype>
+__global__ void DecodeBBoxesKernel(const int nthreads,
+          const Dtype* loc_data, const Dtype* prior_data,
+          const CodeType code_type, const bool variance_encoded_in_target,
+          const int num_priors, const bool share_location,
+          const int num_loc_classes, const int background_label_id,
+          const bool clip_bbox, Dtype* bbox_data) {
+  CUDA_KERNEL_LOOP(index, nthreads) {
+    const int i = index % 4;
+    const int c = (index / 4) % num_loc_classes;
+    const int d = (index / 4 / num_loc_classes) % num_priors;
+    if (!share_location && c == background_label_id) {
+      // Ignore background class if not share_location.
+      return;
+    }
+    const int pi = d * 4;
+    const int vi = pi + num_priors * 4;
+    if (code_type == PriorBoxParameter_CodeType_CORNER) {
+      if (variance_encoded_in_target) {
+        // variance is encoded in target, we simply need to add the offset
+        // predictions.
+        bbox_data[index] = prior_data[pi + i] + loc_data[index];
+      } else {
+        // variance is encoded in bbox, we need to scale the offset accordingly.
+        bbox_data[index] =
+          prior_data[pi + i] + loc_data[index] * prior_data[vi + i];
+      }
+    } else if (code_type == PriorBoxParameter_CodeType_CENTER_SIZE) {
+      const Dtype p_xmin = prior_data[pi];
+      const Dtype p_ymin = prior_data[pi + 1];
+      const Dtype p_xmax = prior_data[pi + 2];
+      const Dtype p_ymax = prior_data[pi + 3];
+      const Dtype prior_width = p_xmax - p_xmin;
+      const Dtype prior_height = p_ymax - p_ymin;
+      const Dtype prior_center_x = (p_xmin + p_xmax) / 2.;
+      const Dtype prior_center_y = (p_ymin + p_ymax) / 2.;
+
+      const Dtype xmin = loc_data[index - i];
+      const Dtype ymin = loc_data[index - i + 1];
+      const Dtype xmax = loc_data[index - i + 2];
+      const Dtype ymax = loc_data[index - i + 3];
+
+      Dtype decode_bbox_center_x, decode_bbox_center_y;
+      Dtype decode_bbox_width, decode_bbox_height;
+      if (variance_encoded_in_target) {
+        // variance is encoded in target, we simply need to retore the offset
+        // predictions.
+        decode_bbox_center_x = xmin * prior_width + prior_center_x;
+        decode_bbox_center_y = ymin * prior_height + prior_center_y;
+        decode_bbox_width = exp(xmax) * prior_width;
+        decode_bbox_height = exp(ymax) * prior_height;
+      } else {
+        // variance is encoded in bbox, we need to scale the offset accordingly.
+        decode_bbox_center_x =
+          prior_data[vi] * xmin * prior_width + prior_center_x;
+        decode_bbox_center_y =
+          prior_data[vi + 1] * ymin * prior_height + prior_center_y;
+        decode_bbox_width =
+          exp(prior_data[vi + 2] * xmax) * prior_width;
+        decode_bbox_height =
+          exp(prior_data[vi + 3] * ymax) * prior_height;
+      }
+
+      switch (i) {
+        case 0:
+          bbox_data[index] = decode_bbox_center_x - decode_bbox_width / 2.;
+          break;
+        case 1:
+          bbox_data[index] = decode_bbox_center_y - decode_bbox_height / 2.;
+          break;
+        case 2:
+          bbox_data[index] = decode_bbox_center_x + decode_bbox_width / 2.;
+          break;
+        case 3:
+          bbox_data[index] = decode_bbox_center_y + decode_bbox_height / 2.;
+          break;
+      }
+    } else if (code_type == PriorBoxParameter_CodeType_CORNER_SIZE) {
+      const Dtype p_xmin = prior_data[pi];
+      const Dtype p_ymin = prior_data[pi + 1];
+      const Dtype p_xmax = prior_data[pi + 2];
+      const Dtype p_ymax = prior_data[pi + 3];
+      const Dtype prior_width = p_xmax - p_xmin;
+      const Dtype prior_height = p_ymax - p_ymin;
+      Dtype p_size;
+      if (i == 0 || i == 2) {
+        p_size = prior_width;
+      } else {
+        p_size = prior_height;
+      }
+      if (variance_encoded_in_target) {
+        // variance is encoded in target, we simply need to add the offset
+        // predictions.
+        bbox_data[index] = prior_data[pi + i] + loc_data[index] * p_size;
+      } else {
+        // variance is encoded in bbox, we need to scale the offset accordingly.
+        bbox_data[index] =
+          prior_data[pi + i] + loc_data[index] * prior_data[vi + i] * p_size;
+      }
+    } else {
+      // Unknown code type.
+    }
+    if (clip_bbox) {
+      bbox_data[index] = max(min(bbox_data[index], Dtype(1.)), Dtype(0.));
+    }
+  }
+}
+
+template <typename Dtype>
+void DecodeBBoxesGPU(const int nthreads,
+          const Dtype* loc_data, const Dtype* prior_data,
+          const CodeType code_type, const bool variance_encoded_in_target,
+          const int num_priors, const bool share_location,
+          const int num_loc_classes, const int background_label_id,
+          const bool clip_bbox, Dtype* bbox_data) {
+  // NOLINT_NEXT_LINE(whitespace/operators)
+  DecodeBBoxesKernel<Dtype><<<CAFFE_GET_BLOCKS(nthreads),
+      CAFFE_CUDA_NUM_THREADS>>>(nthreads, loc_data, prior_data, code_type,
+      variance_encoded_in_target, num_priors, share_location, num_loc_classes,
+      background_label_id, clip_bbox, bbox_data);
+  CUDA_POST_KERNEL_CHECK;
+}
+
+template void DecodeBBoxesGPU(const int nthreads,
+          const float* loc_data, const float* prior_data,
+          const CodeType code_type, const bool variance_encoded_in_target,
+          const int num_priors, const bool share_location,
+          const int num_loc_classes, const int background_label_id,
+          const bool clip_bbox, float* bbox_data);
+template void DecodeBBoxesGPU(const int nthreads,
+          const double* loc_data, const double* prior_data,
+          const CodeType code_type, const bool variance_encoded_in_target,
+          const int num_priors, const bool share_location,
+          const int num_loc_classes, const int background_label_id,
+          const bool clip_bbox, double* bbox_data);
+template void DecodeBBoxesGPU(const int nthreads,
+          const float16* loc_data, const float16* prior_data,
+          const CodeType code_type, const bool variance_encoded_in_target,
+          const int num_priors, const bool share_location,
+          const int num_loc_classes, const int background_label_id,
+          const bool clip_bbox, float16* bbox_data);
+
+template <typename Dtype>
+__global__ void PermuteDataKernel(const int nthreads,
+          const Dtype* data, const int num_classes, const int num_data,
+          const int num_dim, Dtype* new_data) {
+  CUDA_KERNEL_LOOP(index, nthreads) {
+    const int i = index % num_dim;
+    const int c = (index / num_dim) % num_classes;
+    const int d = (index / num_dim / num_classes) % num_data;
+    const int n = index / num_dim / num_classes / num_data;
+    const int new_index = ((n * num_classes + c) * num_data + d) * num_dim + i;
+    new_data[new_index] = data[index];
+  }
+}
+
+template <typename Dtype>
+void PermuteDataGPU(const int nthreads,
+          const Dtype* data, const int num_classes, const int num_data,
+          const int num_dim, Dtype* new_data) {
+  // NOLINT_NEXT_LINE(whitespace/operators)
+  PermuteDataKernel<Dtype><<<CAFFE_GET_BLOCKS(nthreads),
+      CAFFE_CUDA_NUM_THREADS>>>(nthreads, data, num_classes, num_data,
+      num_dim, new_data);
+  CUDA_POST_KERNEL_CHECK;
+}
+
+template void PermuteDataGPU(const int nthreads,
+          const float* data, const int num_classes, const int num_data,
+          const int num_dim, float* new_data);
+template void PermuteDataGPU(const int nthreads,
+          const double* data, const int num_classes, const int num_data,
+          const int num_dim, double* new_data);
+template void PermuteDataGPU(const int nthreads,
+          const float16* data, const int num_classes, const int num_data,
+          const int num_dim, float16* new_data);
+
+template <typename Dtype>
+__global__ void kernel_channel_max(const int num, const int channels,
+    const int spatial_dim, const Dtype* data, Dtype* out) {
+  CUDA_KERNEL_LOOP(index, num * spatial_dim) {
+    int n = index / spatial_dim;
+    int s = index % spatial_dim;
+    Dtype maxval = -FLT_MAX;
+    for (int c = 0; c < channels; ++c) {
+      maxval = max(data[(n * channels + c) * spatial_dim + s], maxval);
+    }
+    out[index] = maxval;
+  }
+}
+
+template <typename Dtype>
+__global__ void kernel_channel_subtract(const int count,
+    const int num, const int channels,
+    const int spatial_dim, const Dtype* channel_data, const Dtype* channel_max,
+    Dtype* data) {
+  CUDA_KERNEL_LOOP(index, count) {
+    int n = index / channels / spatial_dim;
+    int s = index % spatial_dim;
+    data[index] = channel_data[index] - channel_max[n * spatial_dim + s];
+  }
+}
+
+template <typename Dtype>
+__global__ void kernel_exp(const int count, const Dtype* data, Dtype* out) {
+  CUDA_KERNEL_LOOP(index, count) {
+    out[index] = exp(data[index]);
+  }
+}
+
+template <typename Dtype>
+__global__ void kernel_channel_sum(const int num, const int channels,
+    const int spatial_dim, const Dtype* data, Dtype* channel_sum) {
+  CUDA_KERNEL_LOOP(index, num * spatial_dim) {
+    int n = index / spatial_dim;
+    int s = index % spatial_dim;
+    Dtype sum = 0;
+    for (int c = 0; c < channels; ++c) {
+      sum += data[(n * channels + c) * spatial_dim + s];
+    }
+    channel_sum[index] = sum;
+  }
+}
+
+template <typename Dtype>
+__global__ void kernel_channel_div(const int count,
+    const int num, const int channels,
+    const int spatial_dim, const Dtype* channel_sum, Dtype* data) {
+  CUDA_KERNEL_LOOP(index, count) {
+    int n = index / channels / spatial_dim;
+    int s = index % spatial_dim;
+    data[index] /= channel_sum[n * spatial_dim + s];
+  }
+}
+
+template <typename Dtype>
+void SoftMaxGPU(const Dtype* data, const int outer_num,
+    const int channels, const int inner_num, Dtype* prob) {
+  vector<int> shape(4, 1);
+  shape[0] = outer_num;
+  shape[1] = channels;
+  shape[2] = inner_num;
+  TBlob<Dtype> scale(shape);
+  Dtype* scale_data = scale.mutable_gpu_data();
+  int count = outer_num * channels * inner_num;
+  // We need to subtract the max to avoid numerical issues, compute the exp,
+  // and then normalize.
+  // compute max
+  // NOLINT_NEXT_LINE(whitespace/operators)
+  kernel_channel_max<Dtype><<<CAFFE_GET_BLOCKS(outer_num * inner_num),
+      CAFFE_CUDA_NUM_THREADS>>>(outer_num, channels, inner_num, data,
+      scale_data);
+  // subtract
+  // NOLINT_NEXT_LINE(whitespace/operators)
+  kernel_channel_subtract<Dtype><<<CAFFE_GET_BLOCKS(count),
+      CAFFE_CUDA_NUM_THREADS>>>(count, outer_num, channels, inner_num,
+      data, scale_data, prob);
+  // exponentiate
+  // NOLINT_NEXT_LINE(whitespace/operators)
+  kernel_exp<Dtype><<<CAFFE_GET_BLOCKS(count), CAFFE_CUDA_NUM_THREADS>>>(
+      count, prob, prob);
+  // sum after exp
+  // NOLINT_NEXT_LINE(whitespace/operators)
+  kernel_channel_sum<Dtype><<<CAFFE_GET_BLOCKS(outer_num * inner_num),
+      CAFFE_CUDA_NUM_THREADS>>>(outer_num, channels, inner_num, prob,
+      scale_data);
+  // divide
+  // NOLINT_NEXT_LINE(whitespace/operators)
+  kernel_channel_div<Dtype><<<CAFFE_GET_BLOCKS(count),
+      CAFFE_CUDA_NUM_THREADS>>>(count, outer_num, channels, inner_num,
+      scale_data, prob);
+}
+
+template void SoftMaxGPU(const float* data, const int outer_num,
+    const int channels, const int inner_num, float* prob);
+template void SoftMaxGPU(const double* data, const int outer_num,
+    const int channels, const int inner_num, double* prob);
+
+template <typename Dtype>
+__global__ void ComputeOverlappedKernel(const int nthreads,
+          const Dtype* bbox_data, const int num_bboxes, const int num_classes,
+          const Dtype overlap_threshold, bool* overlapped_data) {
+  CUDA_KERNEL_LOOP(index, nthreads) {
+    const int j = index % num_bboxes;
+    const int i = (index / num_bboxes) % num_bboxes;
+    if (i == j) {
+      // Ignore same bbox.
+      return;
+    }
+    const int c = (index / num_bboxes / num_bboxes) % num_classes;
+    const int n = index / num_bboxes / num_bboxes / num_classes;
+    // Compute overlap between i-th bbox and j-th bbox.
+    const int start_loc_i = ((n * num_bboxes + i) * num_classes + c) * 4;
+    const int start_loc_j = ((n * num_bboxes + j) * num_classes + c) * 4;
+    const Dtype overlap = JaccardOverlapGPU<Dtype>(bbox_data + start_loc_i,
+        bbox_data + start_loc_j);
+    if (overlap > overlap_threshold) {
+      overlapped_data[index] = true;
+    }
+  }
+}
+
+template <typename Dtype>
+void ComputeOverlappedGPU(const int nthreads,
+          const Dtype* bbox_data, const int num_bboxes, const int num_classes,
+          const Dtype overlap_threshold, bool* overlapped_data) {
+  // NOLINT_NEXT_LINE(whitespace/operators)
+  ComputeOverlappedKernel<Dtype><<<CAFFE_GET_BLOCKS(nthreads),
+      CAFFE_CUDA_NUM_THREADS>>>(nthreads, bbox_data, num_bboxes, num_classes,
+      overlap_threshold, overlapped_data);
+  CUDA_POST_KERNEL_CHECK;
+}
+
+template void ComputeOverlappedGPU(const int nthreads,
+          const float* bbox_data, const int num_bboxes, const int num_classes,
+          const float overlap_threshold, bool* overlapped_data);
+template void ComputeOverlappedGPU(const int nthreads,
+          const double* bbox_data, const int num_bboxes, const int num_classes,
+          const double overlap_threshold, bool* overlapped_data);
+
+template <typename Dtype>
+__global__ void ComputeOverlappedByIdxKernel(const int nthreads,
+          const Dtype* bbox_data, const Dtype overlap_threshold,
+          const int* idx, const int num_idx, bool* overlapped_data) {
+  CUDA_KERNEL_LOOP(index, nthreads) {
+    const int j = index % num_idx;
+    const int i = (index / num_idx);
+    if (i == j) {
+      // Ignore same bbox.
+      return;
+    }
+    // Compute overlap between i-th bbox and j-th bbox.
+    const int start_loc_i = idx[i] * 4;
+    const int start_loc_j = idx[j] * 4;
+    const Dtype overlap = JaccardOverlapGPU<Dtype>(bbox_data + start_loc_i,
+        bbox_data + start_loc_j);
+    if (overlap > overlap_threshold) {
+      overlapped_data[index] = true;
+    }
+  }
+}
+
+template <typename Dtype>
+void ComputeOverlappedByIdxGPU(const int nthreads,
+          const Dtype* bbox_data, const Dtype overlap_threshold,
+          const int* idx, const int num_idx, bool* overlapped_data) {
+  // NOLINT_NEXT_LINE(whitespace/operators)
+  ComputeOverlappedByIdxKernel<Dtype><<<CAFFE_GET_BLOCKS(nthreads),
+      CAFFE_CUDA_NUM_THREADS>>>(nthreads, bbox_data, overlap_threshold,
+      idx, num_idx, overlapped_data);
+  CUDA_POST_KERNEL_CHECK;
+}
+
+template void ComputeOverlappedByIdxGPU(const int nthreads,
+          const float* bbox_data, const float overlap_threshold,
+          const int* idx, const int num_idx, bool* overlapped_data);
+template void ComputeOverlappedByIdxGPU(const int nthreads,
+          const double* bbox_data, const double overlap_threshold,
+          const int* idx, const int num_idx, bool* overlapped_data);
+
+template <typename Dtype>
+void ApplyNMSGPU(const Dtype* bbox_data, const Dtype* conf_data,
+          const int num_bboxes, const float confidence_threshold,
+          const int top_k, const float nms_threshold, vector<int>* indices) {
+  // Keep part of detections whose scores are higher than confidence threshold.
+  vector<int> idx;
+  vector<float> confidences;
+  for (int i = 0; i < num_bboxes; ++i) {
+    if (conf_data[i] > confidence_threshold) {
+      idx.push_back(i);
+      confidences.push_back(conf_data[i]);
+    }
+  }
+  int num_remain = confidences.size();
+  if (num_remain == 0) {
+    return;
+  }
+  // Sort detections based on score.
+  thrust::sort_by_key(&confidences[0], &confidences[0] + num_remain, &idx[0],
+      thrust::greater<float>());
+  if (top_k > -1 && top_k < num_remain) {
+    num_remain = top_k;
+  }
+
+  // Compute overlap between remaining detections.
+  TBlob<int> idx_blob(1, 1, 1, num_remain);
+  int* idx_data = idx_blob.mutable_cpu_data();
+  std::copy(idx.begin(), idx.begin() + num_remain, idx_data);
+
+  TBlob<bool> overlapped(1, 1, num_remain, num_remain);
+  const int total_bboxes = overlapped.count();
+  bool* overlapped_data = overlapped.mutable_gpu_data();
+  ComputeOverlappedByIdxGPU<Dtype>(total_bboxes, bbox_data, nms_threshold,
+      idx_blob.gpu_data(), num_remain, overlapped_data);
+
+  // Do non-maximum suppression based on overlapped results.
+  const bool* overlapped_results = overlapped.cpu_data();
+  vector<int> selected_indices;
+  ApplyNMS(overlapped_results, num_remain, &selected_indices);
+
+  // Put back the selected information.
+  for (int i = 0; i < selected_indices.size(); ++i) {
+    indices->push_back(idx[selected_indices[i]]);
+  }
+}
+
+template
+void ApplyNMSGPU(const float* bbox_data, const float* conf_data,
+          const int num_bboxes, const float confidence_threshold,
+          const int top_k, const float nms_threshold, vector<int>* indices);
+template
+void ApplyNMSGPU(const double* bbox_data, const double* conf_data,
+          const int num_bboxes, const float confidence_threshold,
+          const int top_k, const float nms_threshold, vector<int>* indices);
+
+template
+void ApplyNMSGPU(const float16* bbox_data, const float16* conf_data,
+          const int num_bboxes, const float confidence_threshold,
+          const int top_k, const float nms_threshold, vector<int>* indices);
+
+template <typename Dtype>
+__global__ void GetDetectionsKernel(const int nthreads,
+          const Dtype* bbox_data, const Dtype* conf_data, const int image_id,
+          const int label, const int* indices, const bool clip_bbox,
+          Dtype* detection_data) {
+  CUDA_KERNEL_LOOP(index, nthreads) {
+    const int det_idx = indices[index];
+    detection_data[index * 7] = image_id;
+    detection_data[index * 7 + 1] = label;
+    detection_data[index * 7 + 2] = conf_data[det_idx];
+    if (clip_bbox) {
+      ClipBBoxGPU(&(bbox_data[det_idx * 4]), &(detection_data[index * 7 + 3]));
+    } else {
+      for (int i = 0; i < 4; ++i) {
+        detection_data[index * 7 + 3 + i] = bbox_data[det_idx * 4 + i];
+      }
+    }
+  }
+}
+
+template <typename Dtype>
+void GetDetectionsGPU(const Dtype* bbox_data, const Dtype* conf_data,
+          const int image_id, const int label, const vector<int>& indices,
+          const bool clip_bbox, TBlob<Dtype>* detection_blob) {
+  // Store selected indices in array.
+  int num_det = indices.size();
+  if (num_det == 0) {
+    return;
+  }
+  TBlob<int> idx_blob(1, 1, 1, num_det);
+  int* idx_data = idx_blob.mutable_cpu_data();
+  std::copy(indices.begin(), indices.end(), idx_data);
+  // Prepare detection_blob.
+  detection_blob->Reshape(1, 1, num_det, 7);
+  Dtype* detection_data = detection_blob->mutable_gpu_data();
+  // NOLINT_NEXT_LINE(whitespace/operators)
+  GetDetectionsKernel<Dtype><<<CAFFE_GET_BLOCKS(num_det),
+      CAFFE_CUDA_NUM_THREADS>>>(num_det, bbox_data, conf_data, image_id, label,
+      idx_blob.gpu_data(), clip_bbox, detection_data);
+  CUDA_POST_KERNEL_CHECK;
+}
+
+template void GetDetectionsGPU(const float* bbox_data, const float* conf_data,
+          const int image_id, const int label, const vector<int>& indices,
+          const bool clip_bbox, TBlob<float>* detection_blob);
+template void GetDetectionsGPU(const double* bbox_data, const double* conf_data,
+          const int image_id, const int label, const vector<int>& indices,
+          const bool clip_bbox, TBlob<double>* detection_blob);
+
+template <typename Dtype>
+__global__ void ComputeConfLossKernel(const int nthreads,
+    const Dtype* conf_data, const int num_preds_per_class,
+    const int num_classes, const ConfLossType loss_type,
+    const Dtype* match_data, Dtype* conf_loss_data) {
+  CUDA_KERNEL_LOOP(index, nthreads) {
+    int label = match_data[index];
+    int num = index / num_preds_per_class;
+    int p = index % num_preds_per_class;
+    int start_idx = (num * num_preds_per_class + p) * num_classes;
+    Dtype loss = 0;
+    if (loss_type == MultiBoxLossParameter_ConfLossType_SOFTMAX) {
+      // Compute softmax probability.
+      Dtype prob = conf_data[start_idx + label];
+      loss = -log(Max(prob, Dtype(FLT_MIN)));
+    } else if (loss_type == MultiBoxLossParameter_ConfLossType_LOGISTIC) {
+      int target = 0;
+      for (int c = 0; c < num_classes; ++c) {
+        if (c == label) {
+          target = 1;
+        } else {
+          target = 0;
+        }
+        Dtype input = conf_data[start_idx + c];
+        loss -= input * (target - (input >= 0)) -
+          log(1 + exp(input - 2 * input * (input >= 0)));
+      }
+    }
+    conf_loss_data[index] = loss;
+  }
+}
+
+template <typename Dtype>
+void ComputeConfLossGPU(const TBlob<Dtype>& conf_blob, const int num,
+      const int num_preds_per_class, const int num_classes,
+      const int background_label_id, const ConfLossType loss_type,
+      const vector<map<int, vector<int> > >& all_match_indices,
+      const map<int, vector<NormalizedBBox> >& all_gt_bboxes,
+      vector<vector<float> >* all_conf_loss) {
+  CHECK_LT(background_label_id, num_classes);
+  TBlob<Dtype> match_blob(num, num_preds_per_class, 1, 1);
+  Dtype* match_data = match_blob.mutable_cpu_data();
+  for (int i = 0; i < num; ++i) {
+    const map<int, vector<int> >& match_indices = all_match_indices[i];
+    for (int p = 0; p < num_preds_per_class; ++p) {
+      // Get the label index.
+      int label = background_label_id;
+      for (map<int, vector<int> >::const_iterator it =
+           match_indices.begin(); it != match_indices.end(); ++it) {
+        const vector<int>& match_index = it->second;
+        CHECK_EQ(match_index.size(), num_preds_per_class);
+        if (match_index[p] > -1) {
+          CHECK(all_gt_bboxes.find(i) != all_gt_bboxes.end());
+          const vector<NormalizedBBox>& gt_bboxes =
+              all_gt_bboxes.find(i)->second;
+          CHECK_LT(match_index[p], gt_bboxes.size());
+          label = gt_bboxes[match_index[p]].label();
+          CHECK_GE(label, 0);
+          CHECK_NE(label, background_label_id);
+          CHECK_LT(label, num_classes);
+          // A prior can only be matched to one gt bbox.
+          break;
+        }
+      }
+      match_data[i * num_preds_per_class + p] = label;
+    }
+  }
+  // Get probability data.
+  const Dtype* conf_gpu_data = conf_blob.gpu_data();
+  TBlob<Dtype> prob_blob;
+  prob_blob.ReshapeLike(conf_blob);
+  if (loss_type == MultiBoxLossParameter_ConfLossType_SOFTMAX) {
+    Dtype* prob_gpu_data = prob_blob.mutable_gpu_data();
+    SoftMaxGPU(conf_blob.gpu_data(), num * num_preds_per_class, num_classes, 1,
+        prob_gpu_data);
+    conf_gpu_data = prob_blob.gpu_data();
+  }
+  // Compute the loss.
+  TBlob<Dtype> conf_loss_blob(num, num_preds_per_class, 1, 1);
+  Dtype* conf_loss_gpu_data = conf_loss_blob.mutable_gpu_data();
+  const int num_threads = num * num_preds_per_class;
+  // NOLINT_NEXT_LINE(whitespace/operators)
+  ComputeConfLossKernel<Dtype><<<CAFFE_GET_BLOCKS(num_threads),
+    CAFFE_CUDA_NUM_THREADS>>>(num_threads, conf_gpu_data, num_preds_per_class,
+        num_classes, loss_type, match_blob.gpu_data(), conf_loss_gpu_data);
+  // Save the loss.
+  all_conf_loss->clear();
+  const Dtype* loss_data = conf_loss_blob.cpu_data();
+  for (int i = 0; i < num; ++i) {
+    vector<float> conf_loss(loss_data, loss_data + num_preds_per_class);
+    all_conf_loss->push_back(conf_loss);
+    loss_data += num_preds_per_class;
+  }
+}
+
+// Explicit initialization.
+template void ComputeConfLossGPU(const TBlob<float>& conf_data, const int num,
+      const int num_preds_per_class, const int num_classes,
+      const int background_label_id, const ConfLossType loss_type,
+      const vector<map<int, vector<int> > >& all_match_indices,
+      const map<int, vector<NormalizedBBox> >& all_gt_bboxes,
+      vector<vector<float> >* all_conf_loss);
+template void ComputeConfLossGPU(const TBlob<double>& conf_data, const int num,
+      const int num_preds_per_class, const int num_classes,
+      const int background_label_id, const ConfLossType loss_type,
+      const vector<map<int, vector<int> > >& all_match_indices,
+      const map<int, vector<NormalizedBBox> >& all_gt_bboxes,
+      vector<vector<float> >* all_conf_loss);
+template void ComputeConfLossGPU(const TBlob<float16>& conf_data, const int num,
+      const int num_preds_per_class, const int num_classes,
+      const int background_label_id, const ConfLossType loss_type,
+      const vector<map<int, vector<int> > >& all_match_indices,
+      const map<int, vector<NormalizedBBox> >& all_gt_bboxes,
+      vector<vector<float> >* all_conf_loss);
+
+}  // namespace caffe

--- a/src/caffe/util/blocking_queue.cpp
+++ b/src/caffe/util/blocking_queue.cpp
@@ -98,6 +98,7 @@ template class BlockingQueue<shared_ptr<Batch<double>>>;
 template class BlockingQueue<shared_ptr<Batch<float16>>>;
 #endif
 template class BlockingQueue<shared_ptr<Datum>>;
+template class BlockingQueue<shared_ptr<AnnotatedDatum>>;
 template class BlockingQueue<P2PSync*>;
 
 }  // namespace caffe

--- a/src/caffe/util/im_transforms.cpp
+++ b/src/caffe/util/im_transforms.cpp
@@ -1,0 +1,733 @@
+#ifdef USE_OPENCV
+#include <opencv2/highgui/highgui.hpp>
+
+#if CV_VERSION_MAJOR == 3
+#include <opencv2/imgcodecs/imgcodecs.hpp>
+#define CV_GRAY2BGR cv::COLOR_GRAY2BGR
+#define CV_BGR2GRAY cv::COLOR_BGR2GRAY
+#define CV_BGR2YCrCb cv::COLOR_BGR2YCrCb
+#define CV_YCrCb2BGR cv::COLOR_YCrCb2BGR
+#define CV_IMWRITE_JPEG_QUALITY cv::IMWRITE_JPEG_QUALITY
+#define CV_LOAD_IMAGE_COLOR cv::IMREAD_COLOR
+#define CV_THRESH_BINARY_INV cv::THRESH_BINARY_INV
+#define CV_THRESH_OTSU cv::THRESH_OTSU
+#endif
+#endif  // USE_OPENCV
+
+#include <algorithm>
+#include <numeric>
+#include <vector>
+
+#include "caffe/util/im_transforms.hpp"
+#include "caffe/util/math_functions.hpp"
+
+namespace caffe {
+
+const float prob_eps = 0.01;
+
+int roll_weighted_die(const vector<float>& probabilities) {
+  vector<float> cumulative;
+  std::partial_sum(&probabilities[0], &probabilities[0] + probabilities.size(),
+                   std::back_inserter(cumulative));
+  float val;
+  caffe_rng_uniform(1, static_cast<float>(0), cumulative.back(), &val);
+
+  // Find the position within the sequence and add 1
+  return (std::lower_bound(cumulative.begin(), cumulative.end(), val)
+          - cumulative.begin());
+}
+
+void UpdateBBoxByResizePolicy(const ResizeParameter& param,
+                              const int old_width, const int old_height,
+                              NormalizedBBox* bbox) {
+  float new_height = param.height();
+  float new_width = param.width();
+  float orig_aspect = static_cast<float>(old_width) / old_height;
+  float new_aspect = new_width / new_height;
+
+  float x_min = bbox->xmin() * old_width;
+  float y_min = bbox->ymin() * old_height;
+  float x_max = bbox->xmax() * old_width;
+  float y_max = bbox->ymax() * old_height;
+  float padding;
+  switch (param.resize_mode()) {
+    case ResizeParameter_Resize_mode_WARP:
+      x_min = std::max(0.f, x_min * new_width / old_width);
+      x_max = std::min(new_width, x_max * new_width / old_width);
+      y_min = std::max(0.f, y_min * new_height / old_height);
+      y_max = std::min(new_height, y_max * new_height / old_height);
+      break;
+    case ResizeParameter_Resize_mode_FIT_LARGE_SIZE_AND_PAD:
+      if (orig_aspect > new_aspect) {
+        padding = (new_height - new_width / orig_aspect) / 2;
+        x_min = std::max(0.f, x_min * new_width / old_width);
+        x_max = std::min(new_width, x_max * new_width / old_width);
+        y_min = y_min * (new_height - 2 * padding) / old_height;
+        y_min = padding + std::max(0.f, y_min);
+        y_max = y_max * (new_height - 2 * padding) / old_height;
+        y_max = padding + std::min(new_height, y_max);
+      } else {
+        padding = (new_width - orig_aspect * new_height) / 2;
+        x_min = x_min * (new_width - 2 * padding) / old_width;
+        x_min = padding + std::max(0.f, x_min);
+        x_max = x_max * (new_width - 2 * padding) / old_width;
+        x_max = padding + std::min(new_width, x_max);
+        y_min = std::max(0.f, y_min * new_height / old_height);
+        y_max = std::min(new_height, y_max * new_height / old_height);
+      }
+      break;
+    case ResizeParameter_Resize_mode_FIT_SMALL_SIZE:
+      if (orig_aspect < new_aspect) {
+        new_height = new_width / orig_aspect;
+      } else {
+        new_width = orig_aspect * new_height;
+      }
+      x_min = std::max(0.f, x_min * new_width / old_width);
+      x_max = std::min(new_width, x_max * new_width / old_width);
+      y_min = std::max(0.f, y_min * new_height / old_height);
+      y_max = std::min(new_height, y_max * new_height / old_height);
+      break;
+    default:
+      LOG(FATAL) << "Unknown resize mode.";
+  }
+  bbox->set_xmin(x_min / new_width);
+  bbox->set_ymin(y_min / new_height);
+  bbox->set_xmax(x_max / new_width);
+  bbox->set_ymax(y_max / new_height);
+}
+
+void InferNewSize(const ResizeParameter& resize_param,
+                  const int old_width, const int old_height,
+                  int* new_width, int* new_height) {
+  int height = resize_param.height();
+  int width = resize_param.width();
+  float orig_aspect = static_cast<float>(old_width) / old_height;
+  float aspect = static_cast<float>(width) / height;
+
+  switch (resize_param.resize_mode()) {
+    case ResizeParameter_Resize_mode_WARP:
+      break;
+    case ResizeParameter_Resize_mode_FIT_LARGE_SIZE_AND_PAD:
+      break;
+    case ResizeParameter_Resize_mode_FIT_SMALL_SIZE:
+      if (orig_aspect < aspect) {
+        height = static_cast<int>(width / orig_aspect);
+      } else {
+        width = static_cast<int>(orig_aspect * height);
+      }
+      break;
+    default:
+      LOG(FATAL) << "Unknown resize mode.";
+  }
+  *new_height = height;
+  *new_width = width;
+}
+
+#ifdef USE_OPENCV
+template <typename T>
+bool is_border(const cv::Mat& edge, T color) {
+  cv::Mat im = edge.clone().reshape(0, 1);
+  bool res = true;
+  for (int i = 0; i < im.cols; ++i) {
+    res &= (color == im.at<T>(0, i));
+  }
+  return res;
+}
+
+template
+bool is_border(const cv::Mat& edge, uchar color);
+
+template <typename T>
+cv::Rect CropMask(const cv::Mat& src, T point, int padding) {
+  cv::Rect win(0, 0, src.cols, src.rows);
+
+  vector<cv::Rect> edges;
+  edges.push_back(cv::Rect(0, 0, src.cols, 1));
+  edges.push_back(cv::Rect(src.cols-2, 0, 1, src.rows));
+  edges.push_back(cv::Rect(0, src.rows-2, src.cols, 1));
+  edges.push_back(cv::Rect(0, 0, 1, src.rows));
+
+  cv::Mat edge;
+  int nborder = 0;
+  T color = src.at<T>(0, 0);
+  for (int i = 0; i < edges.size(); ++i) {
+    edge = src(edges[i]);
+    nborder += is_border(edge, color);
+  }
+
+  if (nborder < 4) {
+    return win;
+  }
+
+  bool next;
+  do {
+    edge = src(cv::Rect(win.x, win.height - 2, win.width, 1));
+    next = is_border(edge, color);
+    if (next) {
+      win.height--;
+    }
+  } while (next && (win.height > 0));
+
+  do {
+    edge = src(cv::Rect(win.width - 2, win.y, 1, win.height));
+    next = is_border(edge, color);
+    if (next) {
+      win.width--;
+    }
+  } while (next && (win.width > 0));
+
+  do {
+    edge = src(cv::Rect(win.x, win.y, win.width, 1));
+    next = is_border(edge, color);
+    if (next) {
+      win.y++;
+      win.height--;
+    }
+  } while (next && (win.y <= src.rows));
+
+  do {
+    edge = src(cv::Rect(win.x, win.y, 1, win.height));
+    next = is_border(edge, color);
+    if (next) {
+      win.x++;
+      win.width--;
+    }
+  } while (next && (win.x <= src.cols));
+
+  // add padding
+  if (win.x > padding) {
+    win.x -= padding;
+  }
+  if (win.y > padding) {
+    win.y -= padding;
+  }
+  if ((win.width + win.x + padding) < src.cols) {
+    win.width += padding;
+  }
+  if ((win.height + win.y + padding) < src.rows) {
+    win.height += padding;
+  }
+
+  return win;
+}
+
+template
+cv::Rect CropMask(const cv::Mat& src, uchar point, int padding);
+
+cv::Mat colorReduce(const cv::Mat& image, int div) {
+  cv::Mat out_img;
+  cv::Mat lookUpTable(1, 256, CV_8U);
+  uchar* p = lookUpTable.data;
+  const int div_2 = div / 2;
+  for ( int i = 0; i < 256; ++i ) {
+    p[i] = i / div * div + div_2;
+  }
+  cv::LUT(image, lookUpTable, out_img);
+  return out_img;
+}
+
+void fillEdgeImage(const cv::Mat& edgesIn, cv::Mat* filledEdgesOut) {
+  cv::Mat edgesNeg = edgesIn.clone();
+  cv::Scalar val(255, 255, 255);
+  cv::floodFill(edgesNeg, cv::Point(0, 0), val);
+  cv::floodFill(edgesNeg, cv::Point(edgesIn.cols - 1, edgesIn.rows - 1), val);
+  cv::floodFill(edgesNeg, cv::Point(0, edgesIn.rows - 1), val);
+  cv::floodFill(edgesNeg, cv::Point(edgesIn.cols - 1, 0), val);
+  cv::bitwise_not(edgesNeg, edgesNeg);
+  *filledEdgesOut = (edgesNeg | edgesIn);
+  return;
+}
+
+void CenterObjectAndFillBg(const cv::Mat& in_img, const bool fill_bg,
+                           cv::Mat* out_img) {
+  cv::Mat mask, crop_mask;
+  if (in_img.channels() > 1) {
+    cv::Mat in_img_gray;
+    cv::cvtColor(in_img, in_img_gray, CV_BGR2GRAY);
+    cv::threshold(in_img_gray, mask, 0, 255,
+                  CV_THRESH_BINARY_INV | CV_THRESH_OTSU);
+  } else {
+    cv::threshold(in_img, mask, 0, 255,
+                  CV_THRESH_BINARY_INV | CV_THRESH_OTSU);
+  }
+  cv::Rect crop_rect = CropMask(mask, mask.at<uchar>(0, 0), 2);
+
+  if (fill_bg) {
+    cv::Mat temp_img = in_img(crop_rect);
+    fillEdgeImage(mask, &mask);
+    crop_mask = mask(crop_rect).clone();
+    *out_img = cv::Mat::zeros(crop_rect.size(), in_img.type());
+    temp_img.copyTo(*out_img, crop_mask);
+  } else {
+    *out_img = in_img(crop_rect).clone();
+  }
+}
+
+cv::Mat AspectKeepingResizeAndPad(const cv::Mat& in_img,
+                                  const int new_width, const int new_height,
+                                  const int pad_type,  const cv::Scalar pad_val,
+                                  const int interp_mode) {
+  cv::Mat img_resized;
+  float orig_aspect = static_cast<float>(in_img.cols) / in_img.rows;
+  float new_aspect = static_cast<float>(new_width) / new_height;
+
+  if (orig_aspect > new_aspect) {
+    int height = floor(static_cast<float>(new_width) / orig_aspect);
+    cv::resize(in_img, img_resized, cv::Size(new_width, height), 0, 0,
+               interp_mode);
+    cv::Size resSize = img_resized.size();
+    int padding = floor((new_height - resSize.height) / 2.0);
+    cv::copyMakeBorder(img_resized, img_resized, padding,
+                       new_height - resSize.height - padding, 0, 0,
+                       pad_type, pad_val);
+  } else {
+    int width = floor(orig_aspect * new_height);
+    cv::resize(in_img, img_resized, cv::Size(width, new_height), 0, 0,
+               interp_mode);
+    cv::Size resSize = img_resized.size();
+    int padding = floor((new_width - resSize.width) / 2.0);
+    cv::copyMakeBorder(img_resized, img_resized, 0, 0, padding,
+                       new_width - resSize.width - padding,
+                       pad_type, pad_val);
+  }
+  return img_resized;
+}
+
+cv::Mat AspectKeepingResizeBySmall(const cv::Mat& in_img,
+                                   const int new_width,
+                                   const int new_height,
+                                   const int interp_mode) {
+  cv::Mat img_resized;
+  float orig_aspect = static_cast<float>(in_img.cols) / in_img.rows;
+  float new_aspect = static_cast<float> (new_width) / new_height;
+
+  if (orig_aspect < new_aspect) {
+    int height = floor(static_cast<float>(new_width) / orig_aspect);
+    cv::resize(in_img, img_resized, cv::Size(new_width, height), 0, 0,
+               interp_mode);
+  } else {
+    int width = floor(orig_aspect * new_height);
+    cv::resize(in_img, img_resized, cv::Size(width, new_height), 0, 0,
+               interp_mode);
+  }
+  return img_resized;
+}
+
+void constantNoise(const int n, const vector<uchar>& val, cv::Mat* image) {
+  const int cols = image->cols;
+  const int rows = image->rows;
+
+  if (image->channels() == 1) {
+    for (int k = 0; k < n; ++k) {
+      const int i = caffe_rng_rand() % cols;
+      const int j = caffe_rng_rand() % rows;
+      uchar* ptr = image->ptr<uchar>(j);
+      ptr[i]= val[0];
+    }
+  } else if (image->channels() == 3) {  // color image
+    for (int k = 0; k < n; ++k) {
+      const int i = caffe_rng_rand() % cols;
+      const int j = caffe_rng_rand() % rows;
+      cv::Vec3b* ptr = image->ptr<cv::Vec3b>(j);
+      (ptr[i])[0] = val[0];
+      (ptr[i])[1] = val[1];
+      (ptr[i])[2] = val[2];
+    }
+  }
+}
+
+cv::Mat ApplyResize(const cv::Mat& in_img, const ResizeParameter& param) {
+  cv::Mat out_img;
+
+  // Reading parameters
+  const int new_height = param.height();
+  const int new_width = param.width();
+
+  int pad_mode = cv::BORDER_CONSTANT;
+  switch (param.pad_mode()) {
+    case ResizeParameter_Pad_mode_CONSTANT:
+      break;
+    case ResizeParameter_Pad_mode_MIRRORED:
+      pad_mode = cv::BORDER_REFLECT101;
+      break;
+    case ResizeParameter_Pad_mode_REPEAT_NEAREST:
+      pad_mode = cv::BORDER_REPLICATE;
+      break;
+    default:
+      LOG(FATAL) << "Unknown pad mode.";
+  }
+
+  int interp_mode = cv::INTER_LINEAR;
+  int num_interp_mode = param.interp_mode_size();
+  if (num_interp_mode > 0) {
+    vector<float> probs(num_interp_mode, 1.f / num_interp_mode);
+    int prob_num = roll_weighted_die(probs);
+    switch (param.interp_mode(prob_num)) {
+      case ResizeParameter_Interp_mode_AREA:
+        interp_mode = cv::INTER_AREA;
+        break;
+      case ResizeParameter_Interp_mode_CUBIC:
+        interp_mode = cv::INTER_CUBIC;
+        break;
+      case ResizeParameter_Interp_mode_LINEAR:
+        interp_mode = cv::INTER_LINEAR;
+        break;
+      case ResizeParameter_Interp_mode_NEAREST:
+        interp_mode = cv::INTER_NEAREST;
+        break;
+      case ResizeParameter_Interp_mode_LANCZOS4:
+        interp_mode = cv::INTER_LANCZOS4;
+        break;
+      default:
+        LOG(FATAL) << "Unknown interp mode.";
+    }
+  }
+
+  cv::Scalar pad_val = cv::Scalar(0, 0, 0);
+  const int img_channels = in_img.channels();
+  if (param.pad_value_size() > 0) {
+    CHECK(param.pad_value_size() == 1 ||
+          param.pad_value_size() == img_channels) <<
+        "Specify either 1 pad_value or as many as channels: " << img_channels;
+    vector<float> pad_values;
+    for (int i = 0; i < param.pad_value_size(); ++i) {
+      pad_values.push_back(param.pad_value(i));
+    }
+    if (img_channels > 1 && param.pad_value_size() == 1) {
+      // Replicate the pad_value for simplicity
+      for (int c = 1; c < img_channels; ++c) {
+        pad_values.push_back(pad_values[0]);
+      }
+    }
+    pad_val = cv::Scalar(pad_values[0], pad_values[1], pad_values[2]);
+  }
+
+  switch (param.resize_mode()) {
+    case ResizeParameter_Resize_mode_WARP:
+      cv::resize(in_img, out_img, cv::Size(new_width, new_height), 0, 0,
+                 interp_mode);
+      break;
+    case ResizeParameter_Resize_mode_FIT_LARGE_SIZE_AND_PAD:
+      out_img = AspectKeepingResizeAndPad(in_img, new_width, new_height,
+                                          pad_mode, pad_val, interp_mode);
+      break;
+    case ResizeParameter_Resize_mode_FIT_SMALL_SIZE:
+      out_img = AspectKeepingResizeBySmall(in_img, new_width, new_height,
+                                           interp_mode);
+      break;
+    default:
+      LOG(INFO) << "Unknown resize mode.";
+  }
+  return  out_img;
+}
+
+cv::Mat ApplyNoise(const cv::Mat& in_img, const NoiseParameter& param) {
+  cv::Mat out_img;
+
+  if (param.decolorize()) {
+    cv::Mat grayscale_img;
+    cv::cvtColor(in_img, grayscale_img, CV_BGR2GRAY);
+    cv::cvtColor(grayscale_img, out_img,  CV_GRAY2BGR);
+  } else {
+    out_img = in_img;
+  }
+
+  if (param.gauss_blur()) {
+    cv::GaussianBlur(out_img, out_img, cv::Size(7, 7), 1.5);
+  }
+
+  if (param.hist_eq()) {
+    if (out_img.channels() > 1) {
+      cv::Mat ycrcb_image;
+      cv::cvtColor(out_img, ycrcb_image, CV_BGR2YCrCb);
+      // Extract the L channel
+      vector<cv::Mat> ycrcb_planes(3);
+      cv::split(ycrcb_image, ycrcb_planes);
+      // now we have the L image in ycrcb_planes[0]
+      cv::Mat dst;
+      cv::equalizeHist(ycrcb_planes[0], dst);
+      ycrcb_planes[0] = dst;
+      cv::merge(ycrcb_planes, ycrcb_image);
+      // convert back to RGB
+      cv::cvtColor(ycrcb_image, out_img, CV_YCrCb2BGR);
+    } else {
+      cv::Mat temp_img;
+      cv::equalizeHist(out_img, temp_img);
+      out_img = temp_img;
+    }
+  }
+
+  if (param.clahe()) {
+    cv::Ptr<cv::CLAHE> clahe = cv::createCLAHE();
+    clahe->setClipLimit(4);
+    if (out_img.channels() > 1) {
+      cv::Mat ycrcb_image;
+      cv::cvtColor(out_img, ycrcb_image, CV_BGR2YCrCb);
+      // Extract the L channel
+      vector<cv::Mat> ycrcb_planes(3);
+      cv::split(ycrcb_image, ycrcb_planes);
+      // now we have the L image in ycrcb_planes[0]
+      cv::Mat dst;
+      clahe->apply(ycrcb_planes[0], dst);
+      ycrcb_planes[0] = dst;
+      cv::merge(ycrcb_planes, ycrcb_image);
+      // convert back to RGB
+      cv::cvtColor(ycrcb_image, out_img, CV_YCrCb2BGR);
+    } else {
+      cv::Ptr<cv::CLAHE> clahe = cv::createCLAHE();
+      clahe->setClipLimit(4);
+      cv::Mat temp_img;
+      clahe->apply(out_img, temp_img);
+      out_img = temp_img;
+    }
+  }
+
+  if (param.jpeg() > 0) {
+    vector<uchar> buf;
+    vector<int> params;
+    params.push_back(CV_IMWRITE_JPEG_QUALITY);
+    params.push_back(param.jpeg());
+    cv::imencode(".jpg", out_img, buf, params);
+    out_img = cv::imdecode(buf, CV_LOAD_IMAGE_COLOR);
+  }
+
+  if (param.erode()) {
+    cv::Mat element = cv::getStructuringElement(
+        2, cv::Size(3, 3), cv::Point(1, 1));
+    cv::erode(out_img, out_img, element);
+  }
+
+  if (param.posterize()) {
+    cv::Mat tmp_img;
+    tmp_img = colorReduce(out_img);
+    out_img = tmp_img;
+  }
+
+  if (param.inverse()) {
+    cv::Mat tmp_img;
+    cv::bitwise_not(out_img, tmp_img);
+    out_img = tmp_img;
+  }
+
+  vector<uchar> noise_values;
+  if (param.saltpepper_param().value_size() > 0) {
+    CHECK(param.saltpepper_param().value_size() == 1
+          || param.saltpepper_param().value_size() == out_img.channels())
+        << "Specify either 1 pad_value or as many as channels: "
+        << out_img.channels();
+
+    for (int i = 0; i < param.saltpepper_param().value_size(); i++) {
+      noise_values.push_back(uchar(param.saltpepper_param().value(i)));
+    }
+    if (out_img.channels()  > 1
+        && param.saltpepper_param().value_size() == 1) {
+      // Replicate the pad_value for simplicity
+      for (int c = 1; c < out_img.channels(); ++c) {
+        noise_values.push_back(uchar(noise_values[0]));
+      }
+    }
+  }
+  if (param.saltpepper()) {
+    const int noise_pixels_num =
+        floor(param.saltpepper_param().fraction()
+              * out_img.cols * out_img.rows);
+    constantNoise(noise_pixels_num, noise_values, &out_img);
+  }
+
+  if (param.convert_to_hsv()) {
+    cv::Mat hsv_image;
+    cv::cvtColor(out_img, hsv_image, CV_BGR2HSV);
+    out_img = hsv_image;
+  }
+  if (param.convert_to_lab()) {
+    cv::Mat lab_image;
+    out_img.convertTo(lab_image, CV_32F);
+    lab_image *= 1.0 / 255;
+    cv::cvtColor(lab_image, out_img, CV_BGR2Lab);
+  }
+  return  out_img;
+}
+
+void RandomBrightness(const cv::Mat& in_img, cv::Mat* out_img,
+    const float brightness_prob, const float brightness_delta) {
+  float prob;
+  caffe_rng_uniform(1, 0.f, 1.f, &prob);
+  if (prob < brightness_prob) {
+    CHECK_GE(brightness_delta, 0) << "brightness_delta must be non-negative.";
+    float delta;
+    caffe_rng_uniform(1, -brightness_delta, brightness_delta, &delta);
+    AdjustBrightness(in_img, delta, out_img);
+  } else {
+    *out_img = in_img;
+  }
+}
+
+void AdjustBrightness(const cv::Mat& in_img, const float delta,
+                      cv::Mat* out_img) {
+  if (fabs(delta) > 0) {
+    in_img.convertTo(*out_img, -1, 1, delta);
+  } else {
+    *out_img = in_img;
+  }
+}
+
+void RandomContrast(const cv::Mat& in_img, cv::Mat* out_img,
+    const float contrast_prob, const float lower, const float upper) {
+  float prob;
+  caffe_rng_uniform(1, 0.f, 1.f, &prob);
+  if (prob < contrast_prob) {
+    CHECK_GE(upper, lower) << "contrast upper must be >= lower.";
+    CHECK_GE(lower, 0) << "contrast lower must be non-negative.";
+    float delta;
+    caffe_rng_uniform(1, lower, upper, &delta);
+    AdjustContrast(in_img, delta, out_img);
+  } else {
+    *out_img = in_img;
+  }
+}
+
+void AdjustContrast(const cv::Mat& in_img, const float delta,
+                    cv::Mat* out_img) {
+  if (fabs(delta - 1.f) > 1e-3) {
+    in_img.convertTo(*out_img, -1, delta, 0);
+  } else {
+    *out_img = in_img;
+  }
+}
+
+void RandomSaturation(const cv::Mat& in_img, cv::Mat* out_img,
+    const float saturation_prob, const float lower, const float upper) {
+  float prob;
+  caffe_rng_uniform(1, 0.f, 1.f, &prob);
+  if (prob < saturation_prob) {
+    CHECK_GE(upper, lower) << "saturation upper must be >= lower.";
+    CHECK_GE(lower, 0) << "saturation lower must be non-negative.";
+    float delta;
+    caffe_rng_uniform(1, lower, upper, &delta);
+    AdjustSaturation(in_img, delta, out_img);
+  } else {
+    *out_img = in_img;
+  }
+}
+
+void AdjustSaturation(const cv::Mat& in_img, const float delta,
+                      cv::Mat* out_img) {
+  if (fabs(delta - 1.f) != 1e-3) {
+    // Convert to HSV colorspae.
+    cv::cvtColor(in_img, *out_img, CV_BGR2HSV);
+
+    // Split the image to 3 channels.
+    vector<cv::Mat> channels;
+    cv::split(*out_img, channels);
+
+    // Adjust the saturation.
+    channels[1].convertTo(channels[1], -1, delta, 0);
+    cv::merge(channels, *out_img);
+
+    // Back to BGR colorspace.
+    cvtColor(*out_img, *out_img, CV_HSV2BGR);
+  } else {
+    *out_img = in_img;
+  }
+}
+
+void RandomHue(const cv::Mat& in_img, cv::Mat* out_img,
+               const float hue_prob, const float hue_delta) {
+  float prob;
+  caffe_rng_uniform(1, 0.f, 1.f, &prob);
+  if (prob < hue_prob) {
+    CHECK_GE(hue_delta, 0) << "hue_delta must be non-negative.";
+    float delta;
+    caffe_rng_uniform(1, -hue_delta, hue_delta, &delta);
+    AdjustHue(in_img, delta, out_img);
+  } else {
+    *out_img = in_img;
+  }
+}
+
+void AdjustHue(const cv::Mat& in_img, const float delta, cv::Mat* out_img) {
+  if (fabs(delta) > 0) {
+    // Convert to HSV colorspae.
+    cv::cvtColor(in_img, *out_img, CV_BGR2HSV);
+
+    // Split the image to 3 channels.
+    vector<cv::Mat> channels;
+    cv::split(*out_img, channels);
+
+    // Adjust the hue.
+    channels[0].convertTo(channels[0], -1, 1, delta);
+    cv::merge(channels, *out_img);
+
+    // Back to BGR colorspace.
+    cvtColor(*out_img, *out_img, CV_HSV2BGR);
+  } else {
+    *out_img = in_img;
+  }
+}
+
+void RandomOrderChannels(const cv::Mat& in_img, cv::Mat* out_img,
+                         const float random_order_prob) {
+  float prob;
+  caffe_rng_uniform(1, 0.f, 1.f, &prob);
+  if (prob < random_order_prob) {
+    // Split the image to 3 channels.
+    vector<cv::Mat> channels;
+    cv::split(*out_img, channels);
+    CHECK_EQ(channels.size(), 3);
+
+    // Shuffle the channels.
+    std::random_shuffle(channels.begin(), channels.end());
+    cv::merge(channels, *out_img);
+  } else {
+    *out_img = in_img;
+  }
+}
+
+cv::Mat ApplyDistort(const cv::Mat& in_img, const DistortionParameter& param) {
+  cv::Mat out_img = in_img;
+  float prob;
+  caffe_rng_uniform(1, 0.f, 1.f, &prob);
+
+  if (prob > 0.5) {
+    // Do random brightness distortion.
+    RandomBrightness(out_img, &out_img, param.brightness_prob(),
+                     param.brightness_delta());
+
+    // Do random contrast distortion.
+    RandomContrast(out_img, &out_img, param.contrast_prob(),
+                   param.contrast_lower(), param.contrast_upper());
+
+    // Do random saturation distortion.
+    RandomSaturation(out_img, &out_img, param.saturation_prob(),
+                     param.saturation_lower(), param.saturation_upper());
+
+    // Do random hue distortion.
+    RandomHue(out_img, &out_img, param.hue_prob(), param.hue_delta());
+
+    // Do random reordering of the channels.
+    RandomOrderChannels(out_img, &out_img, param.random_order_prob());
+  } else {
+    // Do random brightness distortion.
+    RandomBrightness(out_img, &out_img, param.brightness_prob(),
+                     param.brightness_delta());
+
+    // Do random saturation distortion.
+    RandomSaturation(out_img, &out_img, param.saturation_prob(),
+                     param.saturation_lower(), param.saturation_upper());
+
+    // Do random hue distortion.
+    RandomHue(out_img, &out_img, param.hue_prob(), param.hue_delta());
+
+    // Do random contrast distortion.
+    RandomContrast(out_img, &out_img, param.contrast_prob(),
+                   param.contrast_lower(), param.contrast_upper());
+
+    // Do random reordering of the channels.
+    RandomOrderChannels(out_img, &out_img, param.random_order_prob());
+  }
+
+  return out_img;
+}
+#endif  // USE_OPENCV
+
+}  // namespace caffe

--- a/src/caffe/util/io.cpp
+++ b/src/caffe/util/io.cpp
@@ -97,21 +97,48 @@ cv::Mat ReadImageToCVMat(const string& filename,
   }
   return cv_img;
 }
-/*
+
+cv::Mat ReadImageToCVMat(const string& filename, const int height,
+    const int width, const int min_dim, const int max_dim,
+    const bool is_color) {
+  cv::Mat cv_img;
+  int cv_read_flag = (is_color ? CV_LOAD_IMAGE_COLOR :
+    CV_LOAD_IMAGE_GRAYSCALE);
+  cv::Mat cv_img_origin = cv::imread(filename, cv_read_flag);
+  if (!cv_img_origin.data) {
+    LOG(ERROR) << "Could not open or find file " << filename;
+    return cv_img_origin;
+  }
+  if (min_dim > 0 || max_dim > 0) {
+    int num_rows = cv_img_origin.rows;
+    int num_cols = cv_img_origin.cols;
+    int min_num = std::min(num_rows, num_cols);
+    int max_num = std::max(num_rows, num_cols);
+    float scale_factor = 1;
+    if (min_dim > 0 && min_num < min_dim) {
+      scale_factor = static_cast<float>(min_dim) / min_num;
+    }
+    if (max_dim > 0 && static_cast<int>(scale_factor * max_num) > max_dim) {
+      // Make sure the maximum dimension is less than max_dim.
+      scale_factor = static_cast<float>(max_dim) / max_num;
+    }
+    if (scale_factor == 1) {
+      cv_img = cv_img_origin;
+    } else {
+      cv::resize(cv_img_origin, cv_img, cv::Size(0, 0),
+                 scale_factor, scale_factor);
+    }
+  } else if (height > 0 && width > 0) {
+    cv::resize(cv_img_origin, cv_img, cv::Size(width, height));
+  } else {
+    cv_img = cv_img_origin;
+  }
+  return cv_img;
+}
+
 cv::Mat ReadImageToCVMat(const string& filename, const int height,
     const int width, const int min_dim, const int max_dim) {
   return ReadImageToCVMat(filename, height, width, min_dim, max_dim, true);
-}
-
-cv::Mat ReadImageToCVMat(const string& filename,
-    const int height, const int width, const bool is_color) {
-  return ReadImageToCVMat(filename, height, width, 0, 0, is_color);
-}
-*/
-
-cv::Mat ReadImageToCVMat(const string& filename, const int height,
-    const int width, const int min_dim, const int max_dim, bool is_color) {
-  return ReadImageToCVMat(filename, height, width, min_dim, max_dim, is_color);
 }
 
 cv::Mat ReadImageToCVMat(const string& filename,

--- a/src/caffe/util/io.cpp
+++ b/src/caffe/util/io.cpp
@@ -1,3 +1,10 @@
+#include <boost/algorithm/string/classification.hpp>
+#include <boost/algorithm/string/split.hpp>
+#include <boost/filesystem.hpp>
+#include <boost/foreach.hpp>
+#include <boost/property_tree/json_parser.hpp>
+#include <boost/property_tree/ptree.hpp>
+#include <boost/property_tree/xml_parser.hpp>
 #include <fcntl.h>
 #include <google/protobuf/io/coded_stream.h>
 #include <google/protobuf/io/zero_copy_stream_impl.h>
@@ -12,6 +19,7 @@
 
 #include <algorithm>
 #include <fstream>  // NOLINT(readability/streams)
+#include <map>
 #include <string>
 #include <vector>
 
@@ -23,6 +31,7 @@ const int kProtoReadBytesLimit = INT_MAX;  // Max size of 2 GB minus 1 byte.
 
 namespace caffe {
 
+using namespace boost::property_tree;  // NOLINT(build/namespaces)
 using google::protobuf::io::FileInputStream;
 using google::protobuf::io::FileOutputStream;
 using google::protobuf::io::ZeroCopyInputStream;
@@ -88,6 +97,22 @@ cv::Mat ReadImageToCVMat(const string& filename,
   }
   return cv_img;
 }
+/*
+cv::Mat ReadImageToCVMat(const string& filename, const int height,
+    const int width, const int min_dim, const int max_dim) {
+  return ReadImageToCVMat(filename, height, width, min_dim, max_dim, true);
+}
+
+cv::Mat ReadImageToCVMat(const string& filename,
+    const int height, const int width, const bool is_color) {
+  return ReadImageToCVMat(filename, height, width, 0, 0, is_color);
+}
+*/
+
+cv::Mat ReadImageToCVMat(const string& filename, const int height,
+    const int width, const int min_dim, const int max_dim, bool is_color) {
+  return ReadImageToCVMat(filename, height, width, min_dim, max_dim, is_color);
+}
 
 cv::Mat ReadImageToCVMat(const string& filename,
     const int height, const int width) {
@@ -142,6 +167,83 @@ bool ReadImageToDatum(const string& filename, const int label,
     return false;
   }
 }
+
+bool ReadImageToDatum(const string& filename, const int label,
+    const int height, const int width, const int min_dim, const int max_dim,
+    const bool is_color, const std::string & encoding, Datum* datum) {
+  cv::Mat cv_img = ReadImageToCVMat(filename, height, width, min_dim, max_dim,
+                                    is_color);
+  if (cv_img.data) {
+    if (encoding.size()) {
+      if ( (cv_img.channels() == 3) == is_color && !height && !width &&
+          !min_dim && !max_dim && matchExt(filename, encoding) ) {
+        datum->set_channels(cv_img.channels());
+        datum->set_height(cv_img.rows);
+        datum->set_width(cv_img.cols);
+        return ReadFileToDatum(filename, label, datum);
+      }
+      EncodeCVMatToDatum(cv_img, encoding, datum);
+      datum->set_label(label);
+      return true;
+    }
+    CVMatToDatum(cv_img, *datum);
+    datum->set_label(label);
+    return true;
+  } else {
+    return false;
+  }
+}
+
+void GetImageSize(const string& filename, int* height, int* width) {
+  cv::Mat cv_img = cv::imread(filename);
+  if (!cv_img.data) {
+    LOG(ERROR) << "Could not open or find file " << filename;
+    return;
+  }
+  *height = cv_img.rows;
+  *width = cv_img.cols;
+}
+
+bool ReadRichImageToAnnotatedDatum(const string& filename,
+    const string& labelfile, const int height, const int width,
+    const int min_dim, const int max_dim, const bool is_color,
+    const string& encoding, const AnnotatedDatum_AnnotationType type,
+    const string& labeltype, const std::map<string, int>& name_to_label,
+    AnnotatedDatum* anno_datum) {
+  // Read image to datum.
+  bool status = ReadImageToDatum(filename, -1, height, width,
+                                 min_dim, max_dim, is_color, encoding,
+                                 anno_datum->mutable_datum());
+  if (status == false) {
+    return status;
+  }
+  anno_datum->clear_annotation_group();
+  if (!boost::filesystem::exists(labelfile)) {
+    return true;
+  }
+  switch (type) {
+    case AnnotatedDatum_AnnotationType_BBOX:
+      int ori_height, ori_width;
+      GetImageSize(filename, &ori_height, &ori_width);
+      if (labeltype == "xml") {
+        return ReadXMLToAnnotatedDatum(labelfile, ori_height, ori_width,
+                                       name_to_label, anno_datum);
+      } else if (labeltype == "json") {
+        return ReadJSONToAnnotatedDatum(labelfile, ori_height, ori_width,
+                                        name_to_label, anno_datum);
+      } else if (labeltype == "txt") {
+        return ReadTxtToAnnotatedDatum(labelfile, ori_height, ori_width,
+                                       anno_datum);
+      } else {
+        LOG(FATAL) << "Unknown label file type.";
+        return false;
+      }
+      break;
+    default:
+      LOG(FATAL) << "Unknown annotation type.";
+      return false;
+  }
+}
 #endif  // USE_OPENCV
 
 bool ReadFileToDatum(const string& filename, const int label,
@@ -164,6 +266,397 @@ bool ReadFileToDatum(const string& filename, const int label,
   }
 }
 
+// Parse VOC/ILSVRC detection annotation.
+bool ReadXMLToAnnotatedDatum(const string& labelfile, const int img_height,
+    const int img_width, const std::map<string, int>& name_to_label,
+    AnnotatedDatum* anno_datum) {
+  ptree pt;
+  read_xml(labelfile, pt);
+
+  // Parse annotation.
+  int width = 0, height = 0;
+  try {
+    height = pt.get<int>("annotation.size.height");
+    width = pt.get<int>("annotation.size.width");
+  } catch (const ptree_error &e) {
+    LOG(WARNING) << "When parsing " << labelfile << ": " << e.what();
+    height = img_height;
+    width = img_width;
+  }
+  LOG_IF(WARNING, height != img_height) << labelfile <<
+      " inconsistent image height.";
+  LOG_IF(WARNING, width != img_width) << labelfile <<
+      " inconsistent image width.";
+  CHECK(width != 0 && height != 0) << labelfile <<
+      " no valid image width/height.";
+  int instance_id = 0;
+  BOOST_FOREACH(ptree::value_type &v1, pt.get_child("annotation")) {
+    ptree pt1 = v1.second;
+    if (v1.first == "object") {
+      Annotation* anno = NULL;
+      bool difficult = false;
+      ptree object = v1.second;
+      BOOST_FOREACH(ptree::value_type &v2, object.get_child("")) {
+        ptree pt2 = v2.second;
+        if (v2.first == "name") {
+          string name = pt2.data();
+          if (name_to_label.find(name) == name_to_label.end()) {
+            LOG(FATAL) << "Unknown name: " << name;
+          }
+          int label = name_to_label.find(name)->second;
+          bool found_group = false;
+          for (int g = 0; g < anno_datum->annotation_group_size(); ++g) {
+            AnnotationGroup* anno_group =
+                anno_datum->mutable_annotation_group(g);
+            if (label == anno_group->group_label()) {
+              if (anno_group->annotation_size() == 0) {
+                instance_id = 0;
+              } else {
+                instance_id = anno_group->annotation(
+                    anno_group->annotation_size() - 1).instance_id() + 1;
+              }
+              anno = anno_group->add_annotation();
+              found_group = true;
+            }
+          }
+          if (!found_group) {
+            // If there is no such annotation_group, create a new one.
+            AnnotationGroup* anno_group = anno_datum->add_annotation_group();
+            anno_group->set_group_label(label);
+            anno = anno_group->add_annotation();
+            instance_id = 0;
+          }
+          anno->set_instance_id(instance_id++);
+        } else if (v2.first == "difficult") {
+          difficult = pt2.data() == "1";
+        } else if (v2.first == "bndbox") {
+          int xmin = pt2.get("xmin", 0);
+          int ymin = pt2.get("ymin", 0);
+          int xmax = pt2.get("xmax", 0);
+          int ymax = pt2.get("ymax", 0);
+          CHECK_NOTNULL(anno);
+          LOG_IF(WARNING, xmin > width) << labelfile <<
+              " bounding box exceeds image boundary.";
+          LOG_IF(WARNING, ymin > height) << labelfile <<
+              " bounding box exceeds image boundary.";
+          LOG_IF(WARNING, xmax > width) << labelfile <<
+              " bounding box exceeds image boundary.";
+          LOG_IF(WARNING, ymax > height) << labelfile <<
+              " bounding box exceeds image boundary.";
+          LOG_IF(WARNING, xmin < 0) << labelfile <<
+              " bounding box exceeds image boundary.";
+          LOG_IF(WARNING, ymin < 0) << labelfile <<
+              " bounding box exceeds image boundary.";
+          LOG_IF(WARNING, xmax < 0) << labelfile <<
+              " bounding box exceeds image boundary.";
+          LOG_IF(WARNING, ymax < 0) << labelfile <<
+              " bounding box exceeds image boundary.";
+          LOG_IF(WARNING, xmin > xmax) << labelfile <<
+              " bounding box irregular.";
+          LOG_IF(WARNING, ymin > ymax) << labelfile <<
+              " bounding box irregular.";
+          // Store the normalized bounding box.
+          NormalizedBBox* bbox = anno->mutable_bbox();
+          bbox->set_xmin(static_cast<float>(xmin) / width);
+          bbox->set_ymin(static_cast<float>(ymin) / height);
+          bbox->set_xmax(static_cast<float>(xmax) / width);
+          bbox->set_ymax(static_cast<float>(ymax) / height);
+          bbox->set_difficult(difficult);
+        }
+      }
+    }
+  }
+  return true;
+}
+
+// Parse MSCOCO detection annotation.
+bool ReadJSONToAnnotatedDatum(const string& labelfile, const int img_height,
+    const int img_width, const std::map<string, int>& name_to_label,
+    AnnotatedDatum* anno_datum) {
+  ptree pt;
+  read_json(labelfile, pt);
+
+  // Get image info.
+  int width = 0, height = 0;
+  try {
+    height = pt.get<int>("image.height");
+    width = pt.get<int>("image.width");
+  } catch (const ptree_error &e) {
+    LOG(WARNING) << "When parsing " << labelfile << ": " << e.what();
+    height = img_height;
+    width = img_width;
+  }
+  LOG_IF(WARNING, height != img_height) << labelfile <<
+      " inconsistent image height.";
+  LOG_IF(WARNING, width != img_width) << labelfile <<
+      " inconsistent image width.";
+  CHECK(width != 0 && height != 0) << labelfile <<
+      " no valid image width/height.";
+
+  // Get annotation info.
+  int instance_id = 0;
+  BOOST_FOREACH(ptree::value_type& v1, pt.get_child("annotation")) {
+    Annotation* anno = NULL;
+    bool iscrowd = false;
+    ptree object = v1.second;
+    // Get category_id.
+    string name = object.get<string>("category_id");
+    if (name_to_label.find(name) == name_to_label.end()) {
+      LOG(FATAL) << "Unknown name: " << name;
+    }
+    int label = name_to_label.find(name)->second;
+    bool found_group = false;
+    for (int g = 0; g < anno_datum->annotation_group_size(); ++g) {
+      AnnotationGroup* anno_group =
+          anno_datum->mutable_annotation_group(g);
+      if (label == anno_group->group_label()) {
+        if (anno_group->annotation_size() == 0) {
+          instance_id = 0;
+        } else {
+          instance_id = anno_group->annotation(
+              anno_group->annotation_size() - 1).instance_id() + 1;
+        }
+        anno = anno_group->add_annotation();
+        found_group = true;
+      }
+    }
+    if (!found_group) {
+      // If there is no such annotation_group, create a new one.
+      AnnotationGroup* anno_group = anno_datum->add_annotation_group();
+      anno_group->set_group_label(label);
+      anno = anno_group->add_annotation();
+      instance_id = 0;
+    }
+    anno->set_instance_id(instance_id++);
+
+    // Get iscrowd.
+    iscrowd = object.get<int>("iscrowd", 0);
+
+    // Get bbox.
+    vector<float> bbox_items;
+    BOOST_FOREACH(ptree::value_type& v2, object.get_child("bbox")) {
+      bbox_items.push_back(v2.second.get_value<float>());
+    }
+    CHECK_EQ(bbox_items.size(), 4);
+    float xmin = bbox_items[0];
+    float ymin = bbox_items[1];
+    float xmax = bbox_items[0] + bbox_items[2];
+    float ymax = bbox_items[1] + bbox_items[3];
+    CHECK_NOTNULL(anno);
+    LOG_IF(WARNING, xmin > width) << labelfile <<
+        " bounding box exceeds image boundary.";
+    LOG_IF(WARNING, ymin > height) << labelfile <<
+        " bounding box exceeds image boundary.";
+    LOG_IF(WARNING, xmax > width) << labelfile <<
+        " bounding box exceeds image boundary.";
+    LOG_IF(WARNING, ymax > height) << labelfile <<
+        " bounding box exceeds image boundary.";
+    LOG_IF(WARNING, xmin < 0) << labelfile <<
+        " bounding box exceeds image boundary.";
+    LOG_IF(WARNING, ymin < 0) << labelfile <<
+        " bounding box exceeds image boundary.";
+    LOG_IF(WARNING, xmax < 0) << labelfile <<
+        " bounding box exceeds image boundary.";
+    LOG_IF(WARNING, ymax < 0) << labelfile <<
+        " bounding box exceeds image boundary.";
+    LOG_IF(WARNING, xmin > xmax) << labelfile <<
+        " bounding box irregular.";
+    LOG_IF(WARNING, ymin > ymax) << labelfile <<
+        " bounding box irregular.";
+    // Store the normalized bounding box.
+    NormalizedBBox* bbox = anno->mutable_bbox();
+    bbox->set_xmin(xmin / width);
+    bbox->set_ymin(ymin / height);
+    bbox->set_xmax(xmax / width);
+    bbox->set_ymax(ymax / height);
+    bbox->set_difficult(iscrowd);
+  }
+  return true;
+}
+
+// Parse plain txt detection annotation: label_id, xmin, ymin, xmax, ymax.
+bool ReadTxtToAnnotatedDatum(const string& labelfile, const int height,
+    const int width, AnnotatedDatum* anno_datum) {
+  std::ifstream infile(labelfile.c_str());
+  if (!infile.good()) {
+    LOG(INFO) << "Cannot open " << labelfile;
+    return false;
+  }
+  int label;
+  float xmin, ymin, xmax, ymax;
+  while (infile >> label >> xmin >> ymin >> xmax >> ymax) {
+    Annotation* anno = NULL;
+    int instance_id = 0;
+    bool found_group = false;
+    for (int g = 0; g < anno_datum->annotation_group_size(); ++g) {
+      AnnotationGroup* anno_group = anno_datum->mutable_annotation_group(g);
+      if (label == anno_group->group_label()) {
+        if (anno_group->annotation_size() == 0) {
+          instance_id = 0;
+        } else {
+          instance_id = anno_group->annotation(
+              anno_group->annotation_size() - 1).instance_id() + 1;
+        }
+        anno = anno_group->add_annotation();
+        found_group = true;
+      }
+    }
+    if (!found_group) {
+      // If there is no such annotation_group, create a new one.
+      AnnotationGroup* anno_group = anno_datum->add_annotation_group();
+      anno_group->set_group_label(label);
+      anno = anno_group->add_annotation();
+      instance_id = 0;
+    }
+    anno->set_instance_id(instance_id++);
+    LOG_IF(WARNING, xmin > width) << labelfile <<
+      " bounding box exceeds image boundary.";
+    LOG_IF(WARNING, ymin > height) << labelfile <<
+      " bounding box exceeds image boundary.";
+    LOG_IF(WARNING, xmax > width) << labelfile <<
+      " bounding box exceeds image boundary.";
+    LOG_IF(WARNING, ymax > height) << labelfile <<
+      " bounding box exceeds image boundary.";
+    LOG_IF(WARNING, xmin < 0) << labelfile <<
+      " bounding box exceeds image boundary.";
+    LOG_IF(WARNING, ymin < 0) << labelfile <<
+      " bounding box exceeds image boundary.";
+    LOG_IF(WARNING, xmax < 0) << labelfile <<
+      " bounding box exceeds image boundary.";
+    LOG_IF(WARNING, ymax < 0) << labelfile <<
+      " bounding box exceeds image boundary.";
+    LOG_IF(WARNING, xmin > xmax) << labelfile <<
+      " bounding box irregular.";
+    LOG_IF(WARNING, ymin > ymax) << labelfile <<
+      " bounding box irregular.";
+    // Store the normalized bounding box.
+    NormalizedBBox* bbox = anno->mutable_bbox();
+    bbox->set_xmin(xmin / width);
+    bbox->set_ymin(ymin / height);
+    bbox->set_xmax(xmax / width);
+    bbox->set_ymax(ymax / height);
+    bbox->set_difficult(false);
+  }
+  return true;
+}
+
+bool ReadLabelFileToLabelMap(const string& filename, bool include_background,
+    const string& delimiter, LabelMap* map) {
+  // cleanup
+  map->Clear();
+
+  std::ifstream file(filename.c_str());
+  string line;
+  // Every line can have [1, 3] number of fields.
+  // The delimiter between fields can be one of " :;".
+  // The order of the fields are:
+  //  name [label] [display_name]
+  //  ...
+  int field_size = -1;
+  int label = 0;
+  LabelMapItem* map_item;
+  // Add background (none_of_the_above) class.
+  if (include_background) {
+    map_item = map->add_item();
+    map_item->set_name("none_of_the_above");
+    map_item->set_label(label++);
+    map_item->set_display_name("background");
+  }
+  while (std::getline(file, line)) {
+    vector<string> fields;
+    fields.clear();
+    boost::split(fields, line, boost::is_any_of(delimiter));
+    if (field_size == -1) {
+      field_size = fields.size();
+    } else {
+      CHECK_EQ(field_size, fields.size())
+          << "Inconsistent number of fields per line.";
+    }
+    map_item = map->add_item();
+    map_item->set_name(fields[0]);
+    switch (field_size) {
+      case 1:
+        map_item->set_label(label++);
+        map_item->set_display_name(fields[0]);
+        break;
+      case 2:
+        label = std::atoi(fields[1].c_str());
+        map_item->set_label(label);
+        map_item->set_display_name(fields[0]);
+        break;
+      case 3:
+        label = std::atoi(fields[1].c_str());
+        map_item->set_label(label);
+        map_item->set_display_name(fields[2]);
+        break;
+      default:
+        LOG(FATAL) << "The number of fields should be [1, 3].";
+        break;
+    }
+  }
+  return true;
+}
+
+bool MapNameToLabel(const LabelMap& map, const bool strict_check,
+    std::map<string, int>* name_to_label) {
+  // cleanup
+  name_to_label->clear();
+
+  for (int i = 0; i < map.item_size(); ++i) {
+    const string& name = map.item(i).name();
+    const int label = map.item(i).label();
+    if (strict_check) {
+      if (!name_to_label->insert(std::make_pair(name, label)).second) {
+        LOG(FATAL) << "There are many duplicates of name: " << name;
+        return false;
+      }
+    } else {
+      (*name_to_label)[name] = label;
+    }
+  }
+  return true;
+}
+
+bool MapLabelToName(const LabelMap& map, const bool strict_check,
+    std::map<int, string>* label_to_name) {
+  // cleanup
+  label_to_name->clear();
+
+  for (int i = 0; i < map.item_size(); ++i) {
+    const string& name = map.item(i).name();
+    const int label = map.item(i).label();
+    if (strict_check) {
+      if (!label_to_name->insert(std::make_pair(label, name)).second) {
+        LOG(FATAL) << "There are many duplicates of label: " << label;
+        return false;
+      }
+    } else {
+      (*label_to_name)[label] = name;
+    }
+  }
+  return true;
+}
+
+bool MapLabelToDisplayName(const LabelMap& map, const bool strict_check,
+    std::map<int, string>* label_to_display_name) {
+  // cleanup
+  label_to_display_name->clear();
+
+  for (int i = 0; i < map.item_size(); ++i) {
+    const string& display_name = map.item(i).display_name();
+    const int label = map.item(i).label();
+    if (strict_check) {
+      if (!label_to_display_name->insert(
+              std::make_pair(label, display_name)).second) {
+        LOG(FATAL) << "There are many duplicates of label: " << label;
+        return false;
+      }
+    } else {
+      (*label_to_display_name)[label] = display_name;
+    }
+  }
+  return true;
+}
 #ifdef USE_OPENCV
 cv::Mat DecodeDatumToCVMatNative(const Datum& datum) {
   cv::Mat cv_img;
@@ -218,6 +711,18 @@ bool DecodeDatum(Datum* datum, bool is_color) {
   } else {
     return false;
   }
+}
+
+void EncodeCVMatToDatum(const cv::Mat& cv_img, const string& encoding,
+                        Datum* datum) {
+  std::vector<uchar> buf;
+  cv::imencode("."+encoding, cv_img, buf);
+  datum->set_data(std::string(reinterpret_cast<char*>(&buf[0]),
+                              buf.size()));
+  datum->set_channels(cv_img.channels());
+  datum->set_height(cv_img.rows);
+  datum->set_width(cv_img.cols);
+  datum->set_encoded(true);
 }
 
 void DatumToCVMat(const Datum& datum, cv::Mat& img) {

--- a/src/caffe/util/sampler.cpp
+++ b/src/caffe/util/sampler.cpp
@@ -1,0 +1,163 @@
+#include <algorithm>
+#include <vector>
+
+#include "caffe/util/bbox_util.hpp"
+#include "caffe/util/sampler.hpp"
+
+namespace caffe {
+
+void GroupObjectBBoxes(const AnnotatedDatum& anno_datum,
+                       vector<NormalizedBBox>* object_bboxes) {
+  object_bboxes->clear();
+  for (int i = 0; i < anno_datum.annotation_group_size(); ++i) {
+    const AnnotationGroup& anno_group = anno_datum.annotation_group(i);
+    for (int j = 0; j < anno_group.annotation_size(); ++j) {
+      const Annotation& anno = anno_group.annotation(j);
+      object_bboxes->push_back(anno.bbox());
+    }
+  }
+}
+
+bool SatisfySampleConstraint(const NormalizedBBox& sampled_bbox,
+                             const vector<NormalizedBBox>& object_bboxes,
+                             const SampleConstraint& sample_constraint) {
+  bool has_jaccard_overlap = sample_constraint.has_min_jaccard_overlap() ||
+      sample_constraint.has_max_jaccard_overlap();
+  bool has_sample_coverage = sample_constraint.has_min_sample_coverage() ||
+      sample_constraint.has_max_sample_coverage();
+  bool has_object_coverage = sample_constraint.has_min_object_coverage() ||
+      sample_constraint.has_max_object_coverage();
+  bool satisfy = !has_jaccard_overlap && !has_sample_coverage &&
+      !has_object_coverage;
+  if (satisfy) {
+    // By default, the sampled_bbox is "positive" if no constraints are defined.
+    return true;
+  }
+  // Check constraints.
+  bool found = false;
+  for (int i = 0; i < object_bboxes.size(); ++i) {
+    const NormalizedBBox& object_bbox = object_bboxes[i];
+    // Test jaccard overlap.
+    if (has_jaccard_overlap) {
+      const float jaccard_overlap = JaccardOverlap(sampled_bbox, object_bbox);
+      if (sample_constraint.has_min_jaccard_overlap() &&
+          jaccard_overlap < sample_constraint.min_jaccard_overlap()) {
+        continue;
+      }
+      if (sample_constraint.has_max_jaccard_overlap() &&
+          jaccard_overlap > sample_constraint.max_jaccard_overlap()) {
+        continue;
+      }
+      found = true;
+    }
+    // Test sample coverage.
+    if (has_sample_coverage) {
+      const float sample_coverage = BBoxCoverage(sampled_bbox, object_bbox);
+      if (sample_constraint.has_min_sample_coverage() &&
+          sample_coverage < sample_constraint.min_sample_coverage()) {
+        continue;
+      }
+      if (sample_constraint.has_max_sample_coverage() &&
+          sample_coverage > sample_constraint.max_sample_coverage()) {
+        continue;
+      }
+      found = true;
+    }
+    // Test object coverage.
+    if (has_object_coverage) {
+      const float object_coverage = BBoxCoverage(object_bbox, sampled_bbox);
+      if (sample_constraint.has_min_object_coverage() &&
+          object_coverage < sample_constraint.min_object_coverage()) {
+        continue;
+      }
+      if (sample_constraint.has_max_object_coverage() &&
+          object_coverage > sample_constraint.max_object_coverage()) {
+        continue;
+      }
+      found = true;
+    }
+    if (found) {
+      return true;
+    }
+  }
+  return found;
+}
+
+void SampleBBox(const Sampler& sampler, NormalizedBBox* sampled_bbox) {
+  // Get random scale.
+  CHECK_GE(sampler.max_scale(), sampler.min_scale());
+  CHECK_GT(sampler.min_scale(), 0.);
+  CHECK_LE(sampler.max_scale(), 1.);
+  float scale;
+  caffe_rng_uniform(1, sampler.min_scale(), sampler.max_scale(), &scale);
+
+  // Get random aspect ratio.
+  CHECK_GE(sampler.max_aspect_ratio(), sampler.min_aspect_ratio());
+  CHECK_GT(sampler.min_aspect_ratio(), 0.);
+  CHECK_LT(sampler.max_aspect_ratio(), FLT_MAX);
+  float aspect_ratio;
+  caffe_rng_uniform(1, sampler.min_aspect_ratio(), sampler.max_aspect_ratio(),
+      &aspect_ratio);
+
+  aspect_ratio = std::max<float>(aspect_ratio, std::pow(scale, 2.));
+  aspect_ratio = std::min<float>(aspect_ratio, 1 / std::pow(scale, 2.));
+
+  // Figure out bbox dimension.
+  float bbox_width = scale * sqrt(aspect_ratio);
+  float bbox_height = scale / sqrt(aspect_ratio);
+
+  // Figure out top left coordinates.
+  float w_off, h_off;
+  caffe_rng_uniform(1, 0.f, 1 - bbox_width, &w_off);
+  caffe_rng_uniform(1, 0.f, 1 - bbox_height, &h_off);
+
+  sampled_bbox->set_xmin(w_off);
+  sampled_bbox->set_ymin(h_off);
+  sampled_bbox->set_xmax(w_off + bbox_width);
+  sampled_bbox->set_ymax(h_off + bbox_height);
+}
+
+void GenerateSamples(const NormalizedBBox& source_bbox,
+                     const vector<NormalizedBBox>& object_bboxes,
+                     const BatchSampler& batch_sampler,
+                     vector<NormalizedBBox>* sampled_bboxes) {
+  int found = 0;
+  for (int i = 0; i < batch_sampler.max_trials(); ++i) {
+    if (batch_sampler.has_max_sample() &&
+        found >= batch_sampler.max_sample()) {
+      break;
+    }
+    // Generate sampled_bbox in the normalized space [0, 1].
+    NormalizedBBox sampled_bbox;
+    SampleBBox(batch_sampler.sampler(), &sampled_bbox);
+    // Transform the sampled_bbox w.r.t. source_bbox.
+    LocateBBox(source_bbox, sampled_bbox, &sampled_bbox);
+    // Determine if the sampled bbox is positive or negative by the constraint.
+    if (SatisfySampleConstraint(sampled_bbox, object_bboxes,
+                                batch_sampler.sample_constraint())) {
+      ++found;
+      sampled_bboxes->push_back(sampled_bbox);
+    }
+  }
+}
+
+void GenerateBatchSamples(const AnnotatedDatum& anno_datum,
+                          const vector<BatchSampler>& batch_samplers,
+                          vector<NormalizedBBox>* sampled_bboxes) {
+  sampled_bboxes->clear();
+  vector<NormalizedBBox> object_bboxes;
+  GroupObjectBBoxes(anno_datum, &object_bboxes);
+  for (int i = 0; i < batch_samplers.size(); ++i) {
+    if (batch_samplers[i].use_original_image()) {
+      NormalizedBBox unit_bbox;
+      unit_bbox.set_xmin(0);
+      unit_bbox.set_ymin(0);
+      unit_bbox.set_xmax(1);
+      unit_bbox.set_ymax(1);
+      GenerateSamples(unit_bbox, object_bboxes, batch_samplers[i],
+                      sampled_bboxes);
+    }
+  }
+}
+
+}  // namespace caffe

--- a/tools/caffe.cpp
+++ b/tools/caffe.cpp
@@ -10,6 +10,7 @@ namespace bp = boost::python;
 
 #include "caffe/caffe.hpp"
 #include "caffe/util/signal_handler.h"
+#include "caffe/util/bbox_util.hpp"
 
 
 using caffe::TBlob;
@@ -45,6 +46,10 @@ DEFINE_string(sigint_effect, "stop",
 DEFINE_string(sighup_effect, "snapshot",
              "Optional; action to take when a SIGHUP signal is received: "
              "snapshot, stop or none.");
+DEFINE_string(ap_version, "11point",
+    "Average Precision type for object detection");
+DEFINE_bool(show_per_class_result, true,
+    "Show per class result for object detection");
 
 // A simple registry for caffe commands.
 typedef int (*BrewFunction)();
@@ -322,6 +327,186 @@ int test() {
   return 0;
 }
 RegisterBrewFunction(test);
+
+
+// Test: score a detection model.
+int test_detection() {
+  typedef float Dtype;
+  CHECK_GT(FLAGS_model.size(), 0) << "Need a model definition to score.";
+  CHECK_GT(FLAGS_weights.size(), 0) << "Need model weights to score.";
+
+  // Read flags for list of GPUs
+  vector<int> gpus;
+  get_gpus(&gpus);
+  while (gpus.size() > 1) {
+    // Only use one GPU
+    LOG(INFO) << "Not using GPU #" << gpus.back() << " for single-GPU function";
+    gpus.pop_back();
+  }
+#ifndef CPU_ONLY
+  if (gpus.size() > 0) {
+    Caffe::SetDevice(gpus[0]);
+  }
+  caffe::GPUMemory::Scope gpu_memory_scope(gpus);
+#endif
+
+  // Set mode and device id
+  if (gpus.size() != 0) {
+    LOG(INFO) << "Use GPU with device ID " << gpus[0];
+#ifndef CPU_ONLY
+    cudaDeviceProp device_prop;
+    cudaGetDeviceProperties(&device_prop, gpus[0]);
+    LOG(INFO) << "GPU device name: " << device_prop.name;
+#endif
+    Caffe::set_mode(Caffe::GPU);
+  } else {
+    LOG(INFO) << "Use CPU.";
+    Caffe::set_mode(Caffe::CPU);
+  }
+
+  // Instantiate the caffe net.
+  Net caffe_net(FLAGS_model, caffe::TEST, 0U);
+  caffe_net.CopyTrainedLayersFrom(FLAGS_weights);
+  LOG(INFO) << "Running for " << FLAGS_iterations << " iterations.";
+
+  std::map<int, std::map<int, vector<std::pair<float, int> > > > all_true_pos;
+  std::map<int, std::map<int, vector<std::pair<float, int> > > > all_false_pos;
+  std::map<int, std::map<int, int> > all_num_pos;
+  
+  vector<int> test_score_output_id;
+  vector<float> test_score;
+  float loss = 0;
+  for (int i = 0; i < FLAGS_iterations; ++i) {
+    float iter_loss;
+    const vector<Blob*>& result =
+        caffe_net.Forward(&iter_loss);
+    loss += iter_loss;
+    int idx = 0;
+    for (int j = 0; j < result.size(); ++j) {
+      const float* result_vec = result[j]->cpu_data<float>();
+      for (int k = 0; k < result[j]->count(); ++k, ++idx) {
+        const float score = result_vec[k];
+        if (i == 0) {
+          test_score.push_back(score);
+          test_score_output_id.push_back(j);
+        } else {
+          test_score[idx] += score;
+        }
+        const std::string& output_name = caffe_net.blob_names()[
+            caffe_net.output_blob_indices()[j]];
+        LOG(INFO) << "Batch " << i << ", " << output_name << " = " << score;
+      }
+    }
+	
+    //To compute mAP
+    for (int j = 0; j < result.size(); ++j) {	
+      CHECK_EQ(result[j]->width(), 5);
+      const Dtype* result_vec = result[j]->cpu_data<Dtype>();
+      int num_det = result[j]->height();
+      for (int k = 0; k < num_det; ++k) {
+        int item_id = static_cast<int>(result_vec[k * 5]);
+        int label = static_cast<int>(result_vec[k * 5 + 1]);
+        if (item_id == -1) {
+          // Special row of storing number of positives for a label.
+          if (all_num_pos[j].find(label) == all_num_pos[j].end()) {
+            all_num_pos[j][label] = static_cast<int>(result_vec[k * 5 + 2]);
+          } else {
+            all_num_pos[j][label] += static_cast<int>(result_vec[k * 5 + 2]);
+          }
+        } else {
+          // Normal row storing detection status.
+          float score = result_vec[k * 5 + 2];
+          int tp = static_cast<int>(result_vec[k * 5 + 3]);
+          int fp = static_cast<int>(result_vec[k * 5 + 4]);
+          if (tp == 0 && fp == 0) {
+            // Ignore such case. It happens when a detection bbox is matched to
+            // a difficult gt bbox and we don't evaluate on difficult gt bbox.
+            continue;
+          }
+          all_true_pos[j][label].push_back(std::make_pair(score, tp));
+          all_false_pos[j][label].push_back(std::make_pair(score, fp));
+        }
+      }
+    }	
+  }
+  loss /= FLAGS_iterations;
+  LOG(INFO) << "Loss: " << loss;
+
+  for (int i = 0; i < test_score.size(); ++i) {
+    int test_score_output_id_value = test_score_output_id[i];
+    const vector<int>& output_blob_indices = caffe_net.output_blob_indices();
+    const vector<string>& blob_names = caffe_net.blob_names();
+    const vector<float>& blob_loss_weights = caffe_net.blob_loss_weights();
+    if(test_score_output_id_value < output_blob_indices.size()) {
+      int blob_index = output_blob_indices[test_score_output_id_value];
+      if(blob_index < blob_names.size() && blob_index < blob_loss_weights.size()) {
+        const std::string& output_name = blob_names[blob_index];
+        const float loss_weight = blob_loss_weights[blob_index];
+        std::ostringstream loss_msg_stream;
+        const float mean_score = test_score[i] / FLAGS_iterations;
+        if (loss_weight) {
+          loss_msg_stream << " (* " << loss_weight
+                          << " = " << (loss_weight * mean_score) << " loss)";
+        }
+        LOG(INFO) << output_name << " = " << mean_score << loss_msg_stream.str();
+      }
+    }
+  }
+
+  //To compute mAP
+  for (int i = 0; i < all_true_pos.size(); ++i) {
+    if (all_true_pos.find(i) == all_true_pos.end()) {
+      LOG(FATAL) << "Missing output_blob true_pos: " << i;
+    }
+    const std::map<int, vector<std::pair<float, int> > >& true_pos =
+        all_true_pos.find(i)->second;
+    if (all_false_pos.find(i) == all_false_pos.end()) {
+      LOG(FATAL) << "Missing output_blob false_pos: " << i;
+    }
+    const std::map<int, vector<std::pair<float, int> > >& false_pos =
+        all_false_pos.find(i)->second;
+    if (all_num_pos.find(i) == all_num_pos.end()) {
+      LOG(FATAL) << "Missing output_blob num_pos: " << i;
+    }
+    const std::map<int, int>& num_pos = all_num_pos.find(i)->second;
+    std::map<int, float> APs;
+    float mAP = 0.;
+    // Sort true_pos and false_pos with descend scores.
+    for (std::map<int, int>::const_iterator it = num_pos.begin();
+         it != num_pos.end(); ++it) {
+      int label = it->first;
+      int label_num_pos = it->second;
+      if (true_pos.find(label) == true_pos.end()) {
+        LOG(WARNING) << "Missing true_pos for label: " << label;
+        continue;
+      }
+      const vector<std::pair<float, int> >& label_true_pos =
+          true_pos.find(label)->second;
+      if (false_pos.find(label) == false_pos.end()) {
+        LOG(WARNING) << "Missing false_pos for label: " << label;
+        continue;
+      }
+      const vector<std::pair<float, int> >& label_false_pos =
+          false_pos.find(label)->second;
+      vector<float> prec, rec;
+      caffe::ComputeAP(label_true_pos, label_num_pos, label_false_pos,
+                FLAGS_ap_version, &prec, &rec, &(APs[label]));
+      mAP += APs[label];
+      if (FLAGS_show_per_class_result) {
+        LOG(INFO) << "class AP " << label << ": " << APs[label];
+      }
+    }
+    mAP /= num_pos.size();
+    const int output_blob_index = caffe_net.output_blob_indices()[i];
+    const string& output_name = caffe_net.blob_names()[output_blob_index];
+    LOG(INFO) << "Test net output mAP #" << i << ": " << output_name << " = "
+              << mAP;	
+  }  
+  
+  return 0;
+}
+RegisterBrewFunction(test_detection);
+
 
 // Time: benchmark the execution time of a model.
 int time() {

--- a/tools/compute_image_mean.cpp
+++ b/tools/compute_image_mean.cpp
@@ -49,7 +49,7 @@ int main(int argc, char** argv) {
   int count = 0;
   // load first datum
   Datum datum;
-  cursor->parse(&datum);
+  cursor->parse(&datum, DatumTypeInfo_DATUM);
 
   if (DecodeDatumNative(&datum)) {
     LOG(INFO) << "Decoding Datum";
@@ -68,7 +68,7 @@ int main(int argc, char** argv) {
   LOG(INFO) << "Starting Iteration";
   while (cursor->valid()) {
     Datum datum;
-    cursor->parse(&datum);
+    cursor->parse(&datum, DatumTypeInfo_DATUM);
     DecodeDatumNative(&datum);
 
     const std::string& data = datum.data();

--- a/tools/convert_annoset.cpp
+++ b/tools/convert_annoset.cpp
@@ -1,0 +1,207 @@
+// This program converts a set of images and annotations to a lmdb/leveldb by
+// storing them as AnnotatedDatum proto buffers.
+// Usage:
+//   convert_annoset [FLAGS] ROOTFOLDER/ LISTFILE DB_NAME
+//
+// where ROOTFOLDER is the root folder that holds all the images and
+// annotations, and LISTFILE should be a list of files as well as their labels
+// or label files.
+// For classification task, the file should be in the format as
+//   imgfolder1/img1.JPEG 7
+//   ....
+// For detection task, the file should be in the format as
+//   imgfolder1/img1.JPEG annofolder1/anno1.xml
+//   ....
+
+#include <algorithm>
+#include <fstream>  // NOLINT(readability/streams)
+#include <map>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "boost/scoped_ptr.hpp"
+#include "boost/variant.hpp"
+#include "gflags/gflags.h"
+#include "glog/logging.h"
+
+#include "caffe/proto/caffe.pb.h"
+#include "caffe/util/db.hpp"
+#include "caffe/util/format.hpp"
+#include "caffe/util/io.hpp"
+#include "caffe/util/rng.hpp"
+
+using namespace caffe;  // NOLINT(build/namespaces)
+using std::pair;
+using boost::scoped_ptr;
+
+DEFINE_bool(gray, false,
+    "When this option is on, treat images as grayscale ones");
+DEFINE_bool(shuffle, false,
+    "Randomly shuffle the order of images and their labels");
+DEFINE_string(backend, "lmdb",
+    "The backend {lmdb, leveldb} for storing the result");
+DEFINE_string(anno_type, "classification",
+    "The type of annotation {classification, detection}.");
+DEFINE_string(label_type, "xml",
+    "The type of annotation file format.");
+DEFINE_string(label_map_file, "",
+    "A file with LabelMap protobuf message.");
+DEFINE_bool(check_label, false,
+    "When this option is on, check that there is no duplicated name/label.");
+DEFINE_int32(min_dim, 0,
+    "Minimum dimension images are resized to (keep same aspect ratio)");
+DEFINE_int32(max_dim, 0,
+    "Maximum dimension images are resized to (keep same aspect ratio)");
+DEFINE_int32(resize_width, 0, "Width images are resized to");
+DEFINE_int32(resize_height, 0, "Height images are resized to");
+DEFINE_bool(check_size, false,
+    "When this option is on, check that all the datum have the same size");
+DEFINE_bool(encoded, false,
+    "When this option is on, the encoded image will be save in datum");
+DEFINE_string(encode_type, "",
+    "Optional: What type should we encode the image as ('png','jpg',...).");
+
+int main(int argc, char** argv) {
+#ifdef USE_OPENCV
+  ::google::InitGoogleLogging(argv[0]);
+  // Print output to stderr (while still logging)
+  FLAGS_alsologtostderr = 1;
+
+#ifndef GFLAGS_GFLAGS_H_
+  namespace gflags = google;
+#endif
+
+  gflags::SetUsageMessage("Convert a set of images and annotations to the "
+        "leveldb/lmdb format used as input for Caffe.\n"
+        "Usage:\n"
+        "    convert_annoset [FLAGS] ROOTFOLDER/ LISTFILE DB_NAME\n");
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+
+  if (argc < 4) {
+    gflags::ShowUsageWithFlagsRestrict(argv[0], "tools/convert_annoset");
+    return 1;
+  }
+
+  const bool is_color = !FLAGS_gray;
+  const bool check_size = FLAGS_check_size;
+  const bool encoded = FLAGS_encoded;
+  const string encode_type = FLAGS_encode_type;
+  const string anno_type = FLAGS_anno_type;
+  AnnotatedDatum_AnnotationType type;
+  const string label_type = FLAGS_label_type;
+  const string label_map_file = FLAGS_label_map_file;
+  const bool check_label = FLAGS_check_label;
+  std::map<std::string, int> name_to_label;
+
+  std::ifstream infile(argv[2]);
+  std::vector<std::pair<std::string, boost::variant<int, std::string> > > lines;
+  std::string filename;
+  int label;
+  std::string labelname;
+  if (anno_type == "classification") {
+    while (infile >> filename >> label) {
+      lines.push_back(std::make_pair(filename, label));
+    }
+  } else if (anno_type == "detection") {
+    type = AnnotatedDatum_AnnotationType_BBOX;
+    LabelMap label_map;
+    CHECK(ReadProtoFromTextFile(label_map_file, &label_map))
+        << "Failed to read label map file.";
+    CHECK(MapNameToLabel(label_map, check_label, &name_to_label))
+        << "Failed to convert name to label.";
+    while (infile >> filename >> labelname) {
+      lines.push_back(std::make_pair(filename, labelname));
+    }
+  }
+  if (FLAGS_shuffle) {
+    // randomly shuffle data
+    LOG(INFO) << "Shuffling data";
+    shuffle(lines.begin(), lines.end());
+  }
+  LOG(INFO) << "A total of " << lines.size() << " images.";
+
+  if (encode_type.size() && !encoded)
+    LOG(INFO) << "encode_type specified, assuming encoded=true.";
+
+  int min_dim = std::max<int>(0, FLAGS_min_dim);
+  int max_dim = std::max<int>(0, FLAGS_max_dim);
+  int resize_height = std::max<int>(0, FLAGS_resize_height);
+  int resize_width = std::max<int>(0, FLAGS_resize_width);
+
+  // Create new DB
+  scoped_ptr<db::DB> db(db::GetDB(FLAGS_backend));
+  db->Open(argv[3], db::NEW);
+  scoped_ptr<db::Transaction> txn(db->NewTransaction());
+
+  // Storing to db
+  std::string root_folder(argv[1]);
+  AnnotatedDatum anno_datum;
+  Datum* datum = anno_datum.mutable_datum();
+  int count = 0;
+  int data_size = 0;
+  bool data_size_initialized = false;
+
+  for (int line_id = 0; line_id < lines.size(); ++line_id) {
+    bool status = true;
+    std::string enc = encode_type;
+    if (encoded && !enc.size()) {
+      // Guess the encoding type from the file name
+      string fn = lines[line_id].first;
+      size_t p = fn.rfind('.');
+      if ( p == fn.npos )
+        LOG(WARNING) << "Failed to guess the encoding of '" << fn << "'";
+      enc = fn.substr(p);
+      std::transform(enc.begin(), enc.end(), enc.begin(), ::tolower);
+    }
+    filename = root_folder + lines[line_id].first;
+    if (anno_type == "classification") {
+      label = boost::get<int>(lines[line_id].second);
+      status = ReadImageToDatum(filename, label, resize_height, resize_width,
+          min_dim, max_dim, is_color, enc, datum);
+    } else if (anno_type == "detection") {
+      labelname = root_folder + boost::get<std::string>(lines[line_id].second);
+      status = ReadRichImageToAnnotatedDatum(filename, labelname, resize_height,
+          resize_width, min_dim, max_dim, is_color, enc, type, label_type,
+          name_to_label, &anno_datum);
+      anno_datum.set_type(AnnotatedDatum_AnnotationType_BBOX);
+    }
+    if (status == false) {
+      LOG(WARNING) << "Failed to read " << lines[line_id].first;
+      continue;
+    }
+    if (check_size) {
+      if (!data_size_initialized) {
+        data_size = datum->channels() * datum->height() * datum->width();
+        data_size_initialized = true;
+      } else {
+        const std::string& data = datum->data();
+        CHECK_EQ(data.size(), data_size) << "Incorrect data field size "
+            << data.size();
+      }
+    }
+    // sequential
+    string key_str = caffe::format_int(line_id, 8) + "_" + lines[line_id].first;
+
+    // Put in db
+    string out;
+    CHECK(anno_datum.SerializeToString(&out));
+    txn->Put(key_str, out);
+
+    if (++count % 1000 == 0) {
+      // Commit db
+      txn->Commit();
+      txn.reset(db->NewTransaction());
+      LOG(INFO) << "Processed " << count << " files.";
+    }
+  }
+  // write the last batch
+  if (count % 1000 != 0) {
+    txn->Commit();
+    LOG(INFO) << "Processed " << count << " files.";
+  }
+#else
+  LOG(FATAL) << "This tool requires OpenCV; compile with USE_OPENCV.";
+#endif  // USE_OPENCV
+  return 0;
+}

--- a/tools/create_label_map.cpp
+++ b/tools/create_label_map.cpp
@@ -1,0 +1,65 @@
+// This program reads in pairs label names and optionally ids and display names
+// and store them in LabelMap proto buffer.
+// Usage:
+//   create_label_map [FLAGS] MAPFILE OUTFILE
+// where MAPFILE is a list of label names and optionally label ids and
+// displaynames, and OUTFILE stores the information in LabelMap proto.
+// Example:
+//   ./build/tools/create_label_map --delimiter=" " --include_background=true
+//   data/VOC2007/map.txt data/VOC2007/labelmap_voc.prototxt
+// The format of MAPFILE is like following:
+//   class1 [1] [someclass1]
+//   ...
+// The format of OUTFILE is like following:
+//   item {
+//     name: "class1"
+//     label: 1
+//     display_name: "someclass1"
+//   }
+//   ...
+
+#include <fstream>  // NOLINT(readability/streams)
+#include <string>
+
+#include "gflags/gflags.h"
+#include "glog/logging.h"
+
+#include "caffe/proto/caffe.pb.h"
+#include "caffe/util/io.hpp"
+
+using namespace caffe;  // NOLINT(build/namespaces)
+
+DEFINE_bool(include_background, false,
+    "When this option is on, include none_of_the_above as class 0.");
+DEFINE_string(delimiter, " ",
+    "The delimiter used to separate fields in label_map_file.");
+
+int main(int argc, char** argv) {
+  ::google::InitGoogleLogging(argv[0]);
+  // Print output to stderr (while still logging)
+  FLAGS_alsologtostderr = 1;
+
+#ifndef GFLAGS_GFLAGS_H_
+  namespace gflags = google;
+#endif
+
+  gflags::SetUsageMessage("Read in pairs label names and optionally ids and "
+        "display names and store them in LabelMap proto buffer.\n"
+        "Usage:\n"
+        "    create_label_map [FLAGS] MAPFILE OUTFILE\n");
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+
+  if (argc < 3) {
+    gflags::ShowUsageWithFlagsRestrict(argv[0], "tools/create_label_map");
+    return 1;
+  }
+
+  const bool include_background = FLAGS_include_background;
+  const string delimiter = FLAGS_delimiter;
+
+  const string& map_file = argv[1];
+  LabelMap label_map;
+  ReadLabelFileToLabelMap(map_file, include_background, delimiter, &label_map);
+
+  WriteProtoToTextFile(label_map, argv[2]);
+}

--- a/tools/get_image_size.cpp
+++ b/tools/get_image_size.cpp
@@ -1,0 +1,113 @@
+// This program retrieves the sizes of a set of images.
+// Usage:
+//   get_image_size [FLAGS] ROOTFOLDER/ LISTFILE OUTFILE
+//
+// where ROOTFOLDER is the root folder that holds all the images and
+// annotations, and LISTFILE should be a list of files as well as their labels
+// or label files.
+// For classification task, the file should be in the format as
+//   imgfolder1/img1.JPEG 7
+//   ....
+// For detection task, the file should be in the format as
+//   imgfolder1/img1.JPEG annofolder1/anno1.xml
+//   ....
+
+#include <fstream>  // NOLINT(readability/streams)
+#include <map>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "gflags/gflags.h"
+#include "glog/logging.h"
+
+#include "caffe/util/io.hpp"
+
+using namespace caffe;  // NOLINT(build/namespaces)
+
+DEFINE_string(name_id_file, "",
+              "A file which maps image_name to image_id.");
+
+int main(int argc, char** argv) {
+#ifdef USE_OPENCV
+  ::google::InitGoogleLogging(argv[0]);
+  // Print output to stderr (while still logging)
+  FLAGS_alsologtostderr = 1;
+
+#ifndef GFLAGS_GFLAGS_H_
+  namespace gflags = google;
+#endif
+
+  gflags::SetUsageMessage("Get sizes of a set of images.\n"
+        "Usage:\n"
+        "    get_image_size ROOTFOLDER/ LISTFILE OUTFILE\n");
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+
+  if (argc < 4) {
+    gflags::ShowUsageWithFlagsRestrict(argv[0], "tools/get_image_size");
+    return 1;
+  }
+
+  std::ifstream infile(argv[2]);
+  if (!infile.good()) {
+    LOG(FATAL) << "Failed to open file: " << argv[2];
+  }
+  std::vector<std::pair<std::string, std::string> > lines;
+  std::string filename, label;
+  while (infile >> filename >> label) {
+    lines.push_back(std::make_pair(filename, label));
+  }
+  infile.close();
+  LOG(INFO) << "A total of " << lines.size() << " images.";
+
+  const string name_id_file = FLAGS_name_id_file;
+  std::map<string, int> map_name_id;
+  if (!name_id_file.empty()) {
+    std::ifstream nameidfile(name_id_file.c_str());
+    if (!nameidfile.good()) {
+      LOG(FATAL) << "Failed to open name_id_file: " << name_id_file;
+    }
+    std::string name;
+    int id;
+    while (nameidfile >> name >> id) {
+      CHECK(map_name_id.find(name) == map_name_id.end());
+      map_name_id[name] = id;
+    }
+    CHECK_EQ(map_name_id.size(), lines.size());
+  }
+
+  // Storing to outfile
+  boost::filesystem::path root_folder(argv[1]);
+  std::ofstream outfile(argv[3]);
+  if (!outfile.good()) {
+    LOG(FATAL) << "Failed to open file: " << argv[3];
+  }
+  int height, width;
+  int count = 0;
+  for (int line_id = 0; line_id < lines.size(); ++line_id) {
+    boost::filesystem::path img_file = root_folder / lines[line_id].first;
+    GetImageSize(img_file.string(), &height, &width);
+    std::string img_name = img_file.stem().string();
+    if (map_name_id.size() == 0) {
+      outfile << img_name << " " << height << " " << width << std::endl;
+    } else {
+      CHECK(map_name_id.find(img_name) != map_name_id.end());
+      int img_id = map_name_id.find(img_name)->second;
+      outfile << img_id << " " << height << " " << width << std::endl;
+    }
+
+    if (++count % 1000 == 0) {
+      LOG(INFO) << "Processed " << count << " files.";
+    }
+  }
+  // write the last batch
+  if (count % 1000 != 0) {
+    LOG(INFO) << "Processed " << count << " files.";
+  }
+  outfile.flush();
+  outfile.close();
+#else
+  LOG(FATAL) << "This tool requires OpenCV; compile with USE_OPENCV.";
+#endif  // USE_OPENCV
+  return 0;
+}


### PR DESCRIPTION
Single Shot Multibox detector (https://arxiv.org/abs/1512.02325, https://github.com/weiliu89/caffe/tree/ssd) is an important algorithm for machine learning and computer vision. 

SSD is currently not integrated into caffe. It exists in one form of BVLC/caffe. Significant effort was needed to port it into NVIDIA/caffe (due to the changes that happened in NVIDIA/caffe recently).

This pull rquest will enable SSD object detection in NVIDIA/caffe.