### PR TITLE
Update requirements.txt to use Django1.11 

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -17,4 +17,4 @@ pyyaml>=3.10
 Pillow>=2.3.0
 six>=1.1.0
 image>=1.5.16
-django>=1.11.5
+django==1.11.*


### PR DESCRIPTION
Change `requirements.txt` in order to install Django1.11 and not Django2 (who doesn't work with python2)
I was having this kind of issue during the install
```
    AttributeError: 'module' object has no attribute 'lru_cache'
```
  