### PR TITLE
io.py updated

### DIFF
--- a/python/caffe/io.py
+++ b/python/caffe/io.py
@@ -256,7 +256,14 @@ class Transformer:
             if len(ms) != 3:
                 raise ValueError('Mean shape invalid')
             if ms != self.inputs[in_][1:]:
-                raise ValueError('Mean shape incompatible with input shape.')
+                print(self.inputs[in_])
+                in_shape = self.inputs[in_][1:]
+                m_min, m_max = mean.min(), mean.max()
+                normal_mean = (mean - m_min) / (m_max - m_min)
+                mean = resize_image(normal_mean.transpose((1,2,0)),
+                                    in_shape[1:]).transpose((2,0,1)) * \
+                                    (m_max - m_min) + m_min
+                # raise ValueError('Mean shape incompatible with input shape.')
         self.mean[in_] = mean
 
     def set_input_scale(self, in_, scale):


### PR DESCRIPTION
This error is solved in BVLC repo so please update
reference: https://github.com/BVLC/caffe/pull/3555
https://github.com/BVLC/caffe/issues/5718

![meanvalueer](https://user-images.githubusercontent.com/2122671/34719678-a91ba366-f561-11e7-9f30-7f3cc0e5c7e7.png)

**Steps to reproduce:**
It is a procedure to train & test imagenet data set with ImageNet model

** Train **
We have to run below command to get model and label data. (It tooks long time. Approximately, 10m, 232MB, 405KB/s ). We can download the data files that was used at 2012 ILSVRC (ImageNet Large-Scale Visual Recognition Challenge) with the below commands.

$ time python scripts/download_model_binary.py models/bvlc_reference_caffenet
$ sh data/ilsvrc12/get_ilsvrc_aux.sh

** Test **
$ python python/classify.py examples/images/cat.jpg foo