### PR TITLE
Remove redundant call to GPUMemory::Finalize.

### DIFF
--- a/src/caffe/layers/cudnn_conv_layer.cpp
+++ b/src/caffe/layers/cudnn_conv_layer.cpp
@@ -995,7 +995,6 @@ bool CuDNNConvolutionLayer<Ftype, Btype>::IsConvDescChanged(
 
 template <typename Ftype, typename Btype>
 CuDNNConvolutionLayer<Ftype, Btype>::~CuDNNConvolutionLayer() {
-  GPUMemory::Finalize();  // clean workspaces before everything dies
   const int dev = Caffe::current_device();
   ws_released_[dev] = false;  // For next unit test
   // Check that handles have been setup before destroying.


### PR DESCRIPTION
This was missed in previous cleanups, and can potentially causes crashes if nets are destroyed.

Fixes https://github.com/NVIDIA/caffe/issues/466.