### PR TITLE
caffe_rng_gaussian - remove unnecessary check

### DIFF
--- a/src/caffe/util/math_functions.cpp
+++ b/src/caffe/util/math_functions.cpp
@@ -418,7 +418,7 @@ void caffe_rng_uniform<float16>(int n, float16 a, float16 b, float16* r) {
 template <typename Ftype>
 void caffe_rng_gaussian(int n, Ftype mu, Ftype sigma, Blob* blob) {
   CHECK_GE(n, 0);
-  CHECK_LE(mu, sigma);
+  CHECK_GT(sigma, 0);
   boost::normal_distribution<float> random_distribution(mu, sigma);
   boost::variate_generator<caffe::rng_t*, boost::normal_distribution<float> >
       variate_generator(caffe_rng(), random_distribution);
@@ -447,7 +447,7 @@ void caffe_rng_gaussian(int n, Ftype mu, Ftype sigma, Blob* blob) {
 template <typename Ftype>
 void caffe_rng_gaussian(int n, Ftype mu, Ftype sigma, Ftype* r) {
   CHECK_GE(n, 0);
-  CHECK_LE(mu, sigma);
+  CHECK_GT(sigma, 0);
   boost::normal_distribution<float> random_distribution(mu, sigma);
   boost::variate_generator<caffe::rng_t*, boost::normal_distribution<float> >
       variate_generator(caffe_rng(), random_distribution);

--- a/src/caffe/util/math_functions.cpp
+++ b/src/caffe/util/math_functions.cpp
@@ -471,7 +471,7 @@ void caffe_rng_gaussian<double>(int n, double mu, double sigma, double* r);
 template<>
 void caffe_rng_gaussian<float16>(int n, float16 mu, float16 sigma, float16* r) {
   CHECK_GE(n, 0);
-  CHECK_LE(mu, sigma);
+  CHECK_GT(sigma, 0);
   boost::normal_distribution<float> random_distribution(static_cast<float>(mu),
       static_cast<float>(sigma));
   boost::variate_generator<caffe::rng_t*, boost::normal_distribution<float>>


### PR DESCRIPTION
mu does not need to be less than sigma.

Example case where this causes problem.

  44 layer {
  45   name: "fake_data"
  46   type: "DummyData"
  47   top: "fake_data"
  48   include {
  49     phase: TRAIN
  50   }
  51   dummy_data_param {
  52     data_filler {
  53        type: "gaussian"
  54        mean: 1.0
  55        std:  0.01
  56       }
  57     shape {
  58        dim: 16
  59        dim: 2
  60        dim: 100
  61        dim: 80
  62       }
  63    }
  64 }
