### PR TITLE
fix batchnorm with bottom dims less than 4

### DIFF
--- a/src/caffe/layers/batch_norm_layer.cpp
+++ b/src/caffe/layers/batch_norm_layer.cpp
@@ -110,7 +110,7 @@ BatchNormLayer<Ftype, Btype>::LayerSetUp(const vector<Blob*>& bottom, const vect
 
   // =====================================
   int N = bottom[0]->shape(0);
-  int C = (bottom[0]->num_axes() > 1) ? bottom[0]->shape(1) : 1;
+  int C = channels_;
   int H = (bottom[0]->num_axes() > 2) ? bottom[0]->shape(2) : 1;
   int W = (bottom[0]->num_axes() > 3) ? bottom[0]->shape(3) : 1;
 
@@ -140,7 +140,7 @@ void BatchNormLayer<Ftype, Btype>::Reshape(const vector<Blob*>& bottom, const ve
   top[0]->ReshapeLike(*bottom[0]);
 
   int N = bottom[0]->shape(0);
-  int C = (bottom[0]->num_axes() > 1) ? bottom[0]->shape(1) : 1;
+  int C = channels_;
   int H = (bottom[0]->num_axes() > 2) ? bottom[0]->shape(2) : 1;
   int W = (bottom[0]->num_axes() > 3) ? bottom[0]->shape(3) : 1;
 

--- a/src/caffe/layers/batch_norm_layer.cpp
+++ b/src/caffe/layers/batch_norm_layer.cpp
@@ -110,9 +110,9 @@ BatchNormLayer<Ftype, Btype>::LayerSetUp(const vector<Blob*>& bottom, const vect
 
   // =====================================
   int N = bottom[0]->shape(0);
-  int C = bottom[0]->shape(1);
-  int H = bottom[0]->shape(2);
-  int W = bottom[0]->shape(3);
+  int C = channels_;
+  int H = (bottom[0]->num_axes() > 2) ? bottom[0]->shape(2) : 1;
+  int W = (bottom[0]->num_axes() > 3) ? bottom[0]->shape(3) : 1;
 
   mean_ = Blob::create<Ftype>(C);
   var_ = Blob::create<Ftype>(C);
@@ -140,9 +140,9 @@ void BatchNormLayer<Ftype, Btype>::Reshape(const vector<Blob*>& bottom, const ve
   top[0]->ReshapeLike(*bottom[0]);
 
   int N = bottom[0]->shape(0);
-  int C = bottom[0]->shape(1);
-  int H = bottom[0]->shape(2);
-  int W = bottom[0]->shape(3);
+  int C = channels_;
+  int H = (bottom[0]->num_axes() > 2) ? bottom[0]->shape(2) : 1;
+  int W = (bottom[0]->num_axes() > 3) ? bottom[0]->shape(3) : 1;
 
   mean_->Reshape(C);
   var_->Reshape(C);

--- a/src/caffe/layers/batch_norm_layer.cpp
+++ b/src/caffe/layers/batch_norm_layer.cpp
@@ -110,7 +110,7 @@ BatchNormLayer<Ftype, Btype>::LayerSetUp(const vector<Blob*>& bottom, const vect
 
   // =====================================
   int N = bottom[0]->shape(0);
-  int C = channels_;
+  int C = (bottom[0]->num_axes() > 1) ? bottom[0]->shape(1) : 1;
   int H = (bottom[0]->num_axes() > 2) ? bottom[0]->shape(2) : 1;
   int W = (bottom[0]->num_axes() > 3) ? bottom[0]->shape(3) : 1;
 
@@ -140,7 +140,7 @@ void BatchNormLayer<Ftype, Btype>::Reshape(const vector<Blob*>& bottom, const ve
   top[0]->ReshapeLike(*bottom[0]);
 
   int N = bottom[0]->shape(0);
-  int C = channels_;
+  int C = (bottom[0]->num_axes() > 1) ? bottom[0]->shape(1) : 1;
   int H = (bottom[0]->num_axes() > 2) ? bottom[0]->shape(2) : 1;
   int W = (bottom[0]->num_axes() > 3) ? bottom[0]->shape(3) : 1;
 


### PR DESCRIPTION
NVcaffe will crash while put a batchnorm layer after an inner product layer. However, the BVLC/caffe runs well on such situations.  The following model is an example which can hit this bug. This commit tries to fix this bug.
```
name: "LeNet"
layer {
  name: "mnist"
  type: "Data"
  top: "data"
  top: "label"
  include {
    phase: TRAIN
  }
  transform_param {
    scale: 0.00390625
  }
  data_param {
    source: "mnist_train_lmdb"
    batch_size: 50
    backend: LMDB
  }
}
layer {
  name: "mnist"
  type: "Data"
  top: "data"
  top: "label"
  include {
    phase: TEST
  }
  transform_param {
    scale: 0.00390625
  }
  data_param {
    source: "mnist_test_lmdb"
    batch_size: 100
    backend: LMDB
  }
}


layer {
  name: "conv1"
  type: "Convolution"
  bottom: "data"
  top: "conv1"
  param {
    lr_mult: 1
  }
  param {
    lr_mult: 2
  }
  convolution_param {
    num_output: 32
    kernel_size: 5
    stride: 1
    weight_filler {
      type: "xavier"
    }
    bias_filler {
      type: "constant"
    }
  }
}

layer {
	bottom: "conv1"
	top: "conv1"
	name: "conv1_bn"
	type: "BatchNorm"
	batch_norm_param {
		use_global_stats: false
	}
}

layer {
	bottom: "conv1"
	top: "conv1"
	name: "conv1_scale"
	type: "Scale"
	scale_param {
		bias_term: true
	}
}

layer {
	bottom: "conv1"
	top: "conv1"
	name: "conv1_relu"
	type: "ReLU"
}

layer {
  name: "pool1"
  type: "Pooling"
  bottom: "conv1"
  top: "pool1"
  pooling_param {
    pool: MAX
    kernel_size: 2
    stride: 2
  }
}


layer {
  name: "conv2"
  type: "Convolution"
  bottom: "pool1"
  top: "conv2"
  param {
    lr_mult: 1
  }
  param {
    lr_mult: 2
  }
  convolution_param {
    num_output: 64
    kernel_size: 5
    stride: 1
    weight_filler {
      type: "xavier"
    }
    bias_filler {
      type: "constant"
    }
  }
}

layer {
	bottom: "conv2"
	top: "conv2"
	name: "conv2_bn"
	type: "BatchNorm"
	batch_norm_param {
		use_global_stats: false
	}
}

layer {
	bottom: "conv2"
	top: "conv2"
	name: "conv2_scale"
	type: "Scale"
	scale_param {
		bias_term: true
	}
}

layer {
	bottom: "conv2"
	top: "conv2"
	name: "conv2_relu"
	type: "ReLU"
}




layer {
  name: "pool2"
  type: "Pooling"
  bottom: "conv2"
  top: "pool2"
  pooling_param {
    pool: MAX
    kernel_size: 2
    stride: 2
  }
}
layer {
  name: "ip1"
  type: "InnerProduct"
  bottom: "pool2"
  top: "ip1"
  param {
    lr_mult: 1
  }
  param {
    lr_mult: 2
  }
  inner_product_param {
    num_output: 512
    weight_filler {
      type: "xavier"
    }
    bias_filler {
      type: "constant"
    }
  }
}
layer {
	bottom: "ip1"
	top: "ip1"
	name: "ip1_bn"
	type: "BatchNorm"
	batch_norm_param {
		use_global_stats: false
	}
}

layer {
	bottom: "ip1"
	top: "ip1"
	name: "ip1_scale"
	type: "Scale"
	scale_param {
		bias_term: true
	}
}

layer {
	bottom: "ip1"
	top: "ip1"
	name: "ip1_relu"
	type: "ReLU"
}

layer {
  name: "ip2"
  type: "InnerProduct"
  bottom: "ip1"
  top: "ip2"
  param {
    lr_mult: 1
  }
  param {
    lr_mult: 2
  }
  inner_product_param {
    num_output: 10
    weight_filler {
      type: "xavier"
    }
    bias_filler {
      type: "constant"
    }
  }
}
layer {
  name: "accuracy"
  type: "Accuracy"
  bottom: "ip2"
  bottom: "label"
  top: "accuracy"
  include {
    phase: TEST
  }
}
layer {
  name: "loss"
  type: "SoftmaxWithLoss"
  bottom: "ip2"
  bottom: "label"
  top: "loss"
}
```