### PR TITLE
DetectNetTransformLayer support in OpenCV 3+

### DIFF
--- a/src/caffe/layers/detectnet_transform_layer.cpp
+++ b/src/caffe/layers/detectnet_transform_layer.cpp
@@ -467,7 +467,7 @@ DetectNetTransformationLayer<Dtype>::transform_hsv_cpu(
   // Use CV_32F since cvtColor doesn't support CV_64F
   cv::Mat_<cv::Vec<float, 3> > result = orig;
   cvtColor(result, result, COLOR_BGR2HSV);
-  vector<Mat1v> channels(3);
+  vector<Mat> channels(3);
   cv::split(result, channels);
   // Perform transformations
   if (as.doHueRotation()) {


### PR DESCRIPTION
When doing `make runtest` with NVCaffe 0.15.0 (or any future version) using OpenCV 3+ (rather than 2.4, as is installed from apt), tests fail with 3 errors:

```
[  PASSED  ] 1091 tests.
[  FAILED  ] 3 tests, listed below:
[  FAILED  ] DetectNetTransformationLayerTest/1.TestDesaturation, where TypeParam = caffe::CPUDevice<double>
[  FAILED  ] DetectNetTransformationLayerTest/1.TestAllAugmentation, where TypeParam = caffe::CPUDevice<double>
[  FAILED  ] DetectNetTransformationLayerTest/1.TestHueRotation, where TypeParam = caffe::CPUDevice<double>
```


This error stems from the deprecation of the `cv::split()` syntax when passed a `Mat_` and a `vector<Mat_<_Tp>>`: https://docs.opencv.org/ref/2.4/d2/d75/namespacecv.html#a0ecb520e917cc9f41a8d5b9bfc4b991f.

However, the syntax to `cv::split()` when passed a `Mat_` and a `vector<Mat>` (https://docs.opencv.org/3.4.2/d2/de8/group__core__array.html#ga8027f9deee1e42716be8039e5863fbd9) is supported in both OpenCV 3+ and 2.4. This single file change means NVCaffe has all tests passing with OpenCV 3+.