### PR TITLE
Improve Vector Performance - Save Reallocation Cost

### DIFF
--- a/src/caffe/layers/batch_reindex_layer.cpp
+++ b/src/caffe/layers/batch_reindex_layer.cpp
@@ -10,6 +10,7 @@ void BatchReindexLayer<Ftype, Btype>::Reshape(const vector<Blob*>& bottom,
                                        const vector<Blob*>& top) {
   CHECK_EQ(1, bottom[1]->num_axes());
   vector<int> newshape;
+  newshape.reserve(bottom[0]->shape().size() + 1);
   newshape.push_back(bottom[1]->shape(0));
   for (int i = 1; i < bottom[0]->shape().size(); ++i) {
     newshape.push_back(bottom[0]->shape()[i]);

--- a/src/caffe/layers/batch_reindex_layer.cpp
+++ b/src/caffe/layers/batch_reindex_layer.cpp
@@ -11,15 +11,12 @@ void BatchReindexLayer<Ftype, Btype>::Reshape(const vector<Blob*>& bottom,
   CHECK_EQ(1, bottom[1]->num_axes());
 
   const auto& shape0 = bottom[0]->shape();
-  
   vector<int> newshape;
   newshape.reserve(shape0.size());
-  
   newshape.push_back(bottom[1]->shape(0));
   for (int i = 1; i < shape0.size(); ++i) {
     newshape.push_back(shape0[i]);
   }
-  
   top[0]->Reshape(newshape);
 }
 

--- a/src/caffe/layers/batch_reindex_layer.cpp
+++ b/src/caffe/layers/batch_reindex_layer.cpp
@@ -9,12 +9,17 @@ template <typename Ftype, typename Btype>
 void BatchReindexLayer<Ftype, Btype>::Reshape(const vector<Blob*>& bottom,
                                        const vector<Blob*>& top) {
   CHECK_EQ(1, bottom[1]->num_axes());
+
+  const auto& shape0 = bottom[0]->shape();
+  
   vector<int> newshape;
-  newshape.reserve(bottom[0]->shape().size() + 1);
+  newshape.reserve(shape0.size());
+  
   newshape.push_back(bottom[1]->shape(0));
-  for (int i = 1; i < bottom[0]->shape().size(); ++i) {
-    newshape.push_back(bottom[0]->shape()[i]);
+  for (int i = 1; i < shape0.size(); ++i) {
+    newshape.push_back(shape0[i]);
   }
+  
   top[0]->Reshape(newshape);
 }
 


### PR DESCRIPTION
We know the number of elements pushed into the vector will be (1 + bottom[0]->shape().size()). 
So reserve it, to save on reallocation costs.